### PR TITLE
test(wtr): use async/await instead of promise chains @W-19098252

### DIFF
--- a/packages/@lwc/integration-not-karma/configs/base.js
+++ b/packages/@lwc/integration-not-karma/configs/base.js
@@ -29,6 +29,7 @@ export default {
     // time out before they receive focus. But it also makes the full suite take 3x longer to run...
     // Potential workaround: https://github.com/modernweb-dev/web/issues/2588
     concurrency: 1,
+    browserLogs: false,
     nodeResolve: true,
     rootDir: join(import.meta.dirname, '..'),
     plugins: [

--- a/packages/@lwc/integration-not-karma/configs/base.js
+++ b/packages/@lwc/integration-not-karma/configs/base.js
@@ -29,7 +29,6 @@ export default {
     // time out before they receive focus. But it also makes the full suite take 3x longer to run...
     // Potential workaround: https://github.com/modernweb-dev/web/issues/2588
     concurrency: 1,
-    browserLogs: false,
     nodeResolve: true,
     rootDir: join(import.meta.dirname, '..'),
     plugins: [

--- a/packages/@lwc/integration-not-karma/test-hydration/component-lifecycle/disconnected-callback/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/component-lifecycle/disconnected-callback/index.spec.js
@@ -14,15 +14,14 @@ export default {
             xFoo: target.shadowRoot.querySelector('x-foo'),
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const xFoo = target.shadowRoot.querySelector('x-foo');
         expect(xFoo).not.toBe(null);
         expect(xFoo).toBe(snapshots.xFoo);
 
         target.showFoo = false;
 
-        return Promise.resolve().then(() => {
-            expect(disconnectedCalled).toBe(true);
-        });
+        await Promise.resolve();
+        expect(disconnectedCalled).toBe(true);
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/component-lifecycle/render-method/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/component-lifecycle/render-method/index.spec.js
@@ -9,7 +9,7 @@ export default {
             text: p.firstChild,
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const p = target.shadowRoot.querySelector('p');
         expect(p).toBe(snapshots.p);
         expect(p.firstChild).toBe(snapshots.text);
@@ -17,8 +17,7 @@ export default {
 
         target.useTplA = false;
 
-        return Promise.resolve().then(() => {
-            expect(target.shadowRoot.querySelector('p').textContent).toBe('template B');
-        });
+        await Promise.resolve();
+        expect(target.shadowRoot.querySelector('p').textContent).toBe('template B');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/component-lifecycle/rendered-callback/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/component-lifecycle/rendered-callback/index.spec.js
@@ -6,14 +6,13 @@ export default {
             text: p.firstChild,
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const p = target.shadowRoot.querySelector('p');
         expect(p).toBe(snapshots.p);
         expect(p.firstChild).toBe(snapshots.text);
         expect(p.textContent).toBe('renderedCallback:false');
 
-        return Promise.resolve().then(() => {
-            expect(p.textContent).toBe('renderedCallback:true');
-        });
+        await Promise.resolve();
+        expect(p.textContent).toBe('renderedCallback:true');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/directives/for-each/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/directives/for-each/index.spec.js
@@ -8,7 +8,7 @@ export default {
             colors: target.shadowRoot.querySelectorAll('li'),
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const ul = target.shadowRoot.querySelector('ul');
         let colors = ul.querySelectorAll('li');
         expect(ul).toBe(snapshots.ul);
@@ -21,11 +21,10 @@ export default {
 
         target.colors = ['orange', 'green', 'violet'];
 
-        return Promise.resolve().then(() => {
-            colors = ul.querySelectorAll('li');
-            expect(colors[0].textContent).toBe('orange');
-            expect(colors[1].textContent).toBe('green');
-            expect(colors[2].textContent).toBe('violet');
-        });
+        await Promise.resolve();
+        colors = ul.querySelectorAll('li');
+        expect(colors[0].textContent).toBe('orange');
+        expect(colors[1].textContent).toBe('green');
+        expect(colors[2].textContent).toBe('violet');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/directives/if-false/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/directives/if-false/index.spec.js
@@ -7,13 +7,12 @@ export default {
             p: target.shadowRoot.querySelector('p'),
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         expect(target.shadowRoot.querySelector('p')).toBe(snapshots.p);
 
         target.control = true;
 
-        return Promise.resolve().then(() => {
-            expect(target.shadowRoot.querySelector('p')).toBeNull();
-        });
+        await Promise.resolve();
+        expect(target.shadowRoot.querySelector('p')).toBeNull();
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/directives/if-true/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/directives/if-true/index.spec.js
@@ -7,13 +7,12 @@ export default {
             p: target.shadowRoot.querySelector('p'),
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         expect(target.shadowRoot.querySelector('p')).toBe(snapshots.p);
 
         target.control = false;
 
-        return Promise.resolve().then(() => {
-            expect(target.shadowRoot.querySelector('p')).toBeNull();
-        });
+        await Promise.resolve();
+        expect(target.shadowRoot.querySelector('p')).toBeNull();
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/directives/iterator/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/directives/iterator/index.spec.js
@@ -8,7 +8,7 @@ export default {
             colors: target.shadowRoot.querySelectorAll('li'),
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const ul = target.shadowRoot.querySelector('ul');
         let colors = ul.querySelectorAll('li');
         expect(ul).toBe(snapshots.ul);
@@ -21,11 +21,10 @@ export default {
 
         target.colors = ['orange', 'green', 'violet'];
 
-        return Promise.resolve().then(() => {
-            colors = ul.querySelectorAll('li');
-            expect(colors[0].textContent).toBe('orange');
-            expect(colors[1].textContent).toBe('green');
-            expect(colors[2].textContent).toBe('violet');
-        });
+        await Promise.resolve();
+        colors = ul.querySelectorAll('li');
+        expect(colors[0].textContent).toBe('orange');
+        expect(colors[1].textContent).toBe('green');
+        expect(colors[2].textContent).toBe('violet');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/light-dom/component-lifecycle/disconnected-callback/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/light-dom/component-lifecycle/disconnected-callback/index.spec.js
@@ -14,15 +14,14 @@ export default {
             xFoo: target.querySelector('x-foo'),
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const xFoo = target.querySelector('x-foo');
         expect(xFoo).not.toBe(null);
         expect(xFoo).toBe(snapshots.xFoo);
 
         target.showFoo = false;
 
-        return Promise.resolve().then(() => {
-            expect(disconnectedCalled).toBe(true);
-        });
+        await Promise.resolve();
+        expect(disconnectedCalled).toBe(true);
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/light-dom/component-lifecycle/render-method/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/light-dom/component-lifecycle/render-method/index.spec.js
@@ -9,7 +9,7 @@ export default {
             text: p.firstChild,
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const p = target.querySelector('p');
         expect(p).toBe(snapshots.p);
         expect(p.firstChild).toBe(snapshots.text);
@@ -17,8 +17,7 @@ export default {
 
         target.useTplA = false;
 
-        return Promise.resolve().then(() => {
-            expect(target.querySelector('p').textContent).toBe('template B');
-        });
+        await Promise.resolve();
+        expect(target.querySelector('p').textContent).toBe('template B');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/light-dom/component-lifecycle/rendered-callback/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/light-dom/component-lifecycle/rendered-callback/index.spec.js
@@ -6,14 +6,13 @@ export default {
             text: p.firstChild,
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const p = target.querySelector('p');
         expect(p).toBe(snapshots.p);
         expect(p.firstChild).toBe(snapshots.text);
         expect(p.textContent).toBe('renderedCallback:false');
 
-        return Promise.resolve().then(() => {
-            expect(p.textContent).toBe('renderedCallback:true');
-        });
+        await Promise.resolve();
+        expect(p.textContent).toBe('renderedCallback:true');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/light-dom/directives/for-each/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/light-dom/directives/for-each/index.spec.js
@@ -8,7 +8,7 @@ export default {
             colors: target.querySelectorAll('li'),
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const ul = target.querySelector('ul');
         let colors = ul.querySelectorAll('li');
         expect(ul).toBe(snapshots.ul);
@@ -21,11 +21,10 @@ export default {
 
         target.colors = ['orange', 'green', 'violet'];
 
-        return Promise.resolve().then(() => {
-            colors = ul.querySelectorAll('li');
-            expect(colors[0].textContent).toBe('orange');
-            expect(colors[1].textContent).toBe('green');
-            expect(colors[2].textContent).toBe('violet');
-        });
+        await Promise.resolve();
+        colors = ul.querySelectorAll('li');
+        expect(colors[0].textContent).toBe('orange');
+        expect(colors[1].textContent).toBe('green');
+        expect(colors[2].textContent).toBe('violet');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/light-dom/directives/if-false/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/light-dom/directives/if-false/index.spec.js
@@ -7,13 +7,12 @@ export default {
             p: target.querySelector('p'),
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         expect(target.querySelector('p')).toBe(snapshots.p);
 
         target.control = true;
 
-        return Promise.resolve().then(() => {
-            expect(target.querySelector('p')).toBeNull();
-        });
+        await Promise.resolve();
+        expect(target.querySelector('p')).toBeNull();
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/light-dom/directives/if-true/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/light-dom/directives/if-true/index.spec.js
@@ -7,13 +7,12 @@ export default {
             p: target.querySelector('p'),
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         expect(target.querySelector('p')).toBe(snapshots.p);
 
         target.control = false;
 
-        return Promise.resolve().then(() => {
-            expect(target.querySelector('p')).toBeNull();
-        });
+        await Promise.resolve();
+        expect(target.querySelector('p')).toBeNull();
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/light-dom/directives/iterator/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/light-dom/directives/iterator/index.spec.js
@@ -8,7 +8,7 @@ export default {
             colors: target.querySelectorAll('li'),
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const ul = target.querySelector('ul');
         let colors = ul.querySelectorAll('li');
         expect(ul).toBe(snapshots.ul);
@@ -21,11 +21,10 @@ export default {
 
         target.colors = ['orange', 'green', 'violet'];
 
-        return Promise.resolve().then(() => {
-            colors = ul.querySelectorAll('li');
-            expect(colors[0].textContent).toBe('orange');
-            expect(colors[1].textContent).toBe('green');
-            expect(colors[2].textContent).toBe('violet');
-        });
+        await Promise.resolve();
+        colors = ul.querySelectorAll('li');
+        expect(colors[0].textContent).toBe('orange');
+        expect(colors[1].textContent).toBe('green');
+        expect(colors[2].textContent).toBe('violet');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/light-dom/scoped-styles/can-scope-shadow-dom-styles/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/light-dom/scoped-styles/can-scope-shadow-dom-styles/index.spec.js
@@ -1,14 +1,13 @@
 export default {
-    test(target) {
+    async test(target) {
         expect(getComputedStyle(target).backgroundColor).toEqual('rgb(0, 0, 255)');
         expect(getComputedStyle(target.shadowRoot.querySelector('div')).color).toEqual(
             'rgb(255, 0, 0)'
         );
 
-        return Promise.resolve().then(() => {
-            expect(
-                getComputedStyle(target.shadowRoot.querySelector('x-light-child div')).color
-            ).not.toEqual('rgb(255, 0, 0)');
-        });
+        await Promise.resolve();
+        expect(
+            getComputedStyle(target.shadowRoot.querySelector('x-light-child div')).color
+        ).not.toEqual('rgb(255, 0, 0)');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/light-dom/scoped-styles/replace-scoped-styles-with-dynamic-templates/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/light-dom/scoped-styles/replace-scoped-styles-with-dynamic-templates/index.spec.js
@@ -1,31 +1,21 @@
 export default {
-    test(target) {
+    async test(target) {
         const rafPromise = () => new Promise((resolve) => requestAnimationFrame(() => resolve()));
 
         // A (no styles) -> B (styles) -> C (no styles) -> D (styles)
         expect(getComputedStyle(target).marginLeft).toEqual('0px');
         expect(getComputedStyle(target.querySelector('div')).color).toEqual('rgb(0, 0, 0)');
         target.next();
-        return rafPromise()
-            .then(() => {
-                expect(getComputedStyle(target).marginLeft).toEqual('20px');
-                expect(getComputedStyle(target.querySelector('div')).color).toEqual(
-                    'rgb(255, 0, 0)'
-                );
-                target.next();
-                return rafPromise();
-            })
-            .then(() => {
-                expect(getComputedStyle(target).marginLeft).toEqual('0px');
-                expect(getComputedStyle(target.querySelector('div')).color).toEqual('rgb(0, 0, 0)');
-                target.next();
-                return rafPromise();
-            })
-            .then(() => {
-                expect(getComputedStyle(target).marginLeft).toEqual('30px');
-                expect(getComputedStyle(target.querySelector('div')).color).toEqual(
-                    'rgb(0, 0, 255)'
-                );
-            });
+        await rafPromise();
+        expect(getComputedStyle(target).marginLeft).toEqual('20px');
+        expect(getComputedStyle(target.querySelector('div')).color).toEqual('rgb(255, 0, 0)');
+        target.next();
+        await rafPromise();
+        expect(getComputedStyle(target).marginLeft).toEqual('0px');
+        expect(getComputedStyle(target.querySelector('div')).color).toEqual('rgb(0, 0, 0)');
+        target.next();
+        await rafPromise();
+        expect(getComputedStyle(target).marginLeft).toEqual('30px');
+        expect(getComputedStyle(target.querySelector('div')).color).toEqual('rgb(0, 0, 255)');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/light-dom/slots/default/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/light-dom/slots/default/index.spec.js
@@ -16,7 +16,7 @@ export default {
             cmpWithSlotParagraphs,
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const snapshotAfterHydration = this.snapshot(target);
 
         expect(snapshotAfterHydration.withSlot).toBe(snapshots.withSlot);
@@ -37,10 +37,8 @@ export default {
 
         target.slotText = 'changed';
 
-        return Promise.resolve().then(() => {
-            const lateSnapshot = this.snapshot(target);
-
-            expect(lateSnapshot.mainText.textContent).toBe('changed');
-        });
+        await Promise.resolve();
+        const lateSnapshot = this.snapshot(target);
+        expect(lateSnapshot.mainText.textContent).toBe('changed');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/light-dom/slots/named/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/light-dom/slots/named/index.spec.js
@@ -16,7 +16,7 @@ export default {
             cmpWithSlotParagraphs,
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const snapshotAfterHydration = this.snapshot(target);
 
         expect(snapshotAfterHydration.withSlot).toBe(snapshots.withSlot);
@@ -37,10 +37,8 @@ export default {
 
         target.slotText = 'changed';
 
-        return Promise.resolve().then(() => {
-            const lateSnapshot = this.snapshot(target);
-
-            expect(lateSnapshot.mainText.textContent).toBe('changed');
-        });
+        await Promise.resolve();
+        const lateSnapshot = this.snapshot(target);
+        expect(lateSnapshot.mainText.textContent).toBe('changed');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/light-dom/slots/nested/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/light-dom/slots/nested/index.spec.js
@@ -21,7 +21,7 @@ export default {
             childParagraphs,
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const snapshotAfterHydration = this.snapshot(target);
 
         expect(snapshotAfterHydration.withSlot).toBe(snapshots.withSlot);
@@ -45,10 +45,8 @@ export default {
 
         target.slotText = 'changed';
 
-        return Promise.resolve().then(() => {
-            const lateSnapshot = this.snapshot(target);
-
-            expect(lateSnapshot.mainText.textContent).toBe('changed');
-        });
+        await Promise.resolve();
+        const lateSnapshot = this.snapshot(target);
+        expect(lateSnapshot.mainText.textContent).toBe('changed');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/mismatches/different-lwc-inner-html/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/mismatches/different-lwc-inner-html/index.spec.js
@@ -15,7 +15,7 @@ export default {
             p,
         };
     },
-    test(target, snapshot, consoleCalls) {
+    async test(target, snapshot, consoleCalls) {
         const div = target.shadowRoot.querySelector('div');
         const p = div.querySelector('p');
 
@@ -32,8 +32,7 @@ export default {
 
         target.content = '<p>another-content</p>';
 
-        return Promise.resolve().then(() => {
-            expect(div.textContent).toBe('another-content');
-        });
+        await Promise.resolve();
+        expect(div.textContent).toBe('another-content');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/simple/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/simple/index.spec.js
@@ -9,7 +9,7 @@ export default {
             text: p.firstChild,
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const p = target.shadowRoot.querySelector('p');
         expect(p).toBe(snapshots.p);
         expect(p.firstChild).toBe(snapshots.text);
@@ -19,8 +19,7 @@ export default {
 
         target.greeting = 'bye!';
 
-        return Promise.resolve().then(() => {
-            expect(p.textContent).toBe('bye!');
-        });
+        await Promise.resolve();
+        expect(p.textContent).toBe('bye!');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/slots/default/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/slots/default/index.spec.js
@@ -16,7 +16,7 @@ export default {
             cmpWithSlotParagraphs,
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const snapshotAfterHydration = this.snapshot(target);
 
         expect(snapshotAfterHydration.withSlot).toBe(snapshots.withSlot);
@@ -37,10 +37,8 @@ export default {
 
         target.slotText = 'changed';
 
-        return Promise.resolve().then(() => {
-            const lateSnapshot = this.snapshot(target);
-
-            expect(lateSnapshot.mainText.textContent).toBe('changed');
-        });
+        await Promise.resolve();
+        const lateSnapshot = this.snapshot(target);
+        expect(lateSnapshot.mainText.textContent).toBe('changed');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/slots/named/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/slots/named/index.spec.js
@@ -16,7 +16,7 @@ export default {
             cmpWithSlotParagraphs,
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const snapshotAfterHydration = this.snapshot(target);
 
         expect(snapshotAfterHydration.withSlot).toBe(snapshots.withSlot);
@@ -37,10 +37,8 @@ export default {
 
         target.slotText = 'changed';
 
-        return Promise.resolve().then(() => {
-            const lateSnapshot = this.snapshot(target);
-
-            expect(lateSnapshot.mainText.textContent).toBe('changed');
-        });
+        await Promise.resolve();
+        const lateSnapshot = this.snapshot(target);
+        expect(lateSnapshot.mainText.textContent).toBe('changed');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/slots/nested/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/slots/nested/index.spec.js
@@ -21,7 +21,7 @@ export default {
             childParagraphs,
         };
     },
-    test(target, snapshots) {
+    async test(target, snapshots) {
         const snapshotAfterHydration = this.snapshot(target);
 
         expect(snapshotAfterHydration.withSlot).toBe(snapshots.withSlot);
@@ -45,10 +45,8 @@ export default {
 
         target.slotText = 'changed';
 
-        return Promise.resolve().then(() => {
-            const lateSnapshot = this.snapshot(target);
-
-            expect(lateSnapshot.mainText.textContent).toBe('changed');
-        });
+        await Promise.resolve();
+        const lateSnapshot = this.snapshot(target);
+        expect(lateSnapshot.mainText.textContent).toBe('changed');
     },
 };

--- a/packages/@lwc/integration-not-karma/test-hydration/stylesheet/works-with-multiple-templates/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test-hydration/stylesheet/works-with-multiple-templates/index.spec.js
@@ -1,14 +1,13 @@
 export default {
-    test(elm) {
-        const div = elm.shadowRoot.querySelector('div');
+    async test(elm) {
+        let div = elm.shadowRoot.querySelector('div');
         expect(window.getComputedStyle(div).marginLeft).toBe('10px');
         expect(window.getComputedStyle(div).marginRight).toBe('0px');
 
         elm.toggleTemplate();
-        return Promise.resolve().then(() => {
-            const div = elm.shadowRoot.querySelector('div');
-            expect(window.getComputedStyle(div).marginLeft).toBe('0px');
-            expect(window.getComputedStyle(div).marginRight).toBe('10px');
-        });
+        await Promise.resolve();
+        div = elm.shadowRoot.querySelector('div');
+        expect(window.getComputedStyle(div).marginLeft).toBe('0px');
+        expect(window.getComputedStyle(div).marginRight).toBe('10px');
     },
 };

--- a/packages/@lwc/integration-not-karma/test/act/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/act/index.spec.js
@@ -315,7 +315,7 @@ describe('ACTCompiler', () => {
         );
     });
 
-    it('property reference and events', () => {
+    it('property reference and events', async () => {
         let callCount = 0;
         const component = createAndInsertActComponent(testPropertyReference, {
             props: {
@@ -350,16 +350,13 @@ describe('ACTCompiler', () => {
 
         const outputPercent = component.shadowRoot.querySelector('ui-outputpercent');
         outputPercent.fireToggleSectionCollapsedEvent();
-        return Promise.resolve()
-            .then(() => {
-                expect(callCount).toEqual(1);
-                expect(nodes.notWhitelisted.textContent).toEqual('foobar1');
-                outputPercent.fireToggleSectionCollapsedEvent();
-            })
-            .then(() => {
-                expect(callCount).toEqual(2);
-                expect(nodes.notWhitelisted.textContent).toEqual('foobar2');
-            });
+        await Promise.resolve();
+        expect(callCount).toEqual(1);
+        expect(nodes.notWhitelisted.textContent).toEqual('foobar1');
+        outputPercent.fireToggleSectionCollapsedEvent();
+        await Promise.resolve();
+        expect(callCount).toEqual(2);
+        expect(nodes.notWhitelisted.textContent).toEqual('foobar2');
     });
 
     it('slot adjacent to named slot', () => {

--- a/packages/@lwc/integration-not-karma/test/api/isNodeFromTemplate/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/api/isNodeFromTemplate/index.spec.js
@@ -39,7 +39,7 @@ it('should return true on elements rendered from the template', () => {
     expect(isNodeFromTemplate(div)).toBe(true);
 });
 
-it('should return true on elements manually inserted in the DOM inside an element with lwc:dom="manual"', () => {
+it('should return true on elements manually inserted in the DOM inside an element with lwc:dom="manual"', async () => {
     const elm = createElement('x-test', { is: Test });
     document.body.appendChild(elm);
 
@@ -52,18 +52,17 @@ it('should return true on elements manually inserted in the DOM inside an elemen
     if (!process.env.NATIVE_SHADOW) {
         expect(isNodeFromTemplate(div)).toBe(false); // it is false sync because MO hasn't pick up the element yet
     }
-    return new Promise((resolve) => {
+    await new Promise((resolve) => {
         setTimeout(resolve);
-    }).then(() => {
-        expect(isNodeFromTemplate(div)).toBe(true); // it is true async because MO has already pick up the element
     });
+    expect(isNodeFromTemplate(div)).toBe(true); // it is true async because MO has already pick up the element
 });
 
 // TODO [#1252]: old behavior that is still used by some pieces of the platform
 // if isNodeFromTemplate() returns true, locker will prevent traversing to such elements from document
 it.skipIf(process.env.NATIVE_SHADOW)(
     'should return false on elements manually inserted in the DOM inside an element NOT marked with lwc:dom="manual"',
-    () => {
+    async () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
         spyOn(console, 'warn'); // ignore warning about manipulating node without lwc:dom="manual"
@@ -71,10 +70,9 @@ it.skipIf(process.env.NATIVE_SHADOW)(
         const span = document.createElement('span');
         elm.shadowRoot.querySelector('h2').appendChild(span);
 
-        return new Promise((resolve) => {
+        await new Promise((resolve) => {
             setTimeout(resolve);
-        }).then(() => {
-            expect(isNodeFromTemplate(span)).toBe(false);
         });
+        expect(isNodeFromTemplate(span)).toBe(false);
     }
 );

--- a/packages/@lwc/integration-not-karma/test/api/sanitizeHtmlContent/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/api/sanitizeHtmlContent/index.spec.js
@@ -38,7 +38,7 @@ it('receives the right parameters', () => {
     setSanitizeHtmlContentHookForTest(original);
 });
 
-it('does not call sanitizeHtmlContent when raw value does not change', () => {
+it('does not call sanitizeHtmlContent when raw value does not change', async () => {
     const spy = jasmine.createSpy('sanitizeHook', override);
     const original = setSanitizeHtmlContentHookForTest(spy);
 
@@ -50,11 +50,10 @@ it('does not call sanitizeHtmlContent when raw value does not change', () => {
 
     elm.message = 'modified';
 
-    return Promise.resolve().then(() => {
-        expect(spy).toHaveBeenCalledTimes(1);
-        expect(elm.shadowRoot.querySelector('p').innerText).toBe('modified');
-        setSanitizeHtmlContentHookForTest(original);
-    });
+    await Promise.resolve();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(elm.shadowRoot.querySelector('p').innerText).toBe('modified');
+    setSanitizeHtmlContentHookForTest(original);
 });
 
 it('replace the original attribute value with the returned value', () => {

--- a/packages/@lwc/integration-not-karma/test/bundle/css_only/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/bundle/css_only/index.spec.js
@@ -4,34 +4,29 @@ import Container from 'x/cssContainer';
 import ContainerComposition from 'x/cssContainerComposition';
 
 describe('CSS only modules', () => {
-    it('CSS should be applied', function () {
+    it('CSS should be applied', async function () {
         const elm = createElement('x-css-container', { is: Container });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const p = elm.shadowRoot.querySelector('p');
-            expect(p).not.toBeNull();
-
-            const styles = window.getComputedStyle(p);
-            expect(styles.borderBottomStyle).toContain('dashed');
-            expect(styles.color).toContain('rgb(255, 0, 0)');
-            expect(styles.backgroundColor).toContain('rgb(138, 43, 226)');
-        });
+        await Promise.resolve();
+        const p = elm.shadowRoot.querySelector('p');
+        expect(p).not.toBeNull();
+        const styles = window.getComputedStyle(p);
+        expect(styles.borderBottomStyle).toContain('dashed');
+        expect(styles.color).toContain('rgb(255, 0, 0)');
+        expect(styles.backgroundColor).toContain('rgb(138, 43, 226)');
     });
 
-    it('should support CSS only module referencing other CSS only modules', () => {
+    it('should support CSS only module referencing other CSS only modules', async () => {
         const elm = createElement('x-css-container-composition', { is: ContainerComposition });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const p = elm.shadowRoot.querySelector('p');
-            expect(window.getComputedStyle(p).borderBottomStyle).toContain('dashed');
-
-            const div = elm.shadowRoot.querySelector('div');
-            expect(window.getComputedStyle(div).borderBottomStyle).toContain('dashed');
-
-            const span = elm.shadowRoot.querySelector('span');
-            expect(window.getComputedStyle(span).borderBottomStyle).toContain('dashed');
-        });
+        await Promise.resolve();
+        const p = elm.shadowRoot.querySelector('p');
+        expect(window.getComputedStyle(p).borderBottomStyle).toContain('dashed');
+        const div = elm.shadowRoot.querySelector('div');
+        expect(window.getComputedStyle(div).borderBottomStyle).toContain('dashed');
+        const span = elm.shadowRoot.querySelector('span');
+        expect(window.getComputedStyle(span).borderBottomStyle).toContain('dashed');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/component/LightningElement.connectedCallback/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/LightningElement.connectedCallback/index.spec.js
@@ -52,14 +52,13 @@ it('should associate the component stack when the invocation throws', () => {
 });
 
 describe('addEventListner in `connectedCallback`', () => {
-    it('clicking force button should update value', function () {
+    it('clicking force button should update value', async () => {
         const elm = createElement('x-slotted-parent', { is: XSlottedParent });
         document.body.appendChild(elm);
         const child = elm.shadowRoot.querySelector('x-child');
         child.dispatchEventOnHost();
-        return Promise.resolve().then(() => {
-            expect(elm.eventHandled).toBe(true);
-            expect(elm.shadowRoot.querySelector('p').textContent).toBe('Was clicked: true');
-        });
+        await Promise.resolve();
+        expect(elm.eventHandled).toBe(true);
+        expect(elm.shadowRoot.querySelector('p').textContent).toBe('Was clicked: true');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/component/LightningElement.disconnectedCallback/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/LightningElement.disconnectedCallback/index.spec.js
@@ -171,14 +171,13 @@ describe('disconnectedCallback for components with a explicit render()', () => {
         expect(disconnectedCallbackInvoked).toBe(true);
     });
 
-    it('should invoke disconnectedCallback for children when parent switches template', () => {
+    it('should invoke disconnectedCallback for children when parent switches template', async () => {
         const parent = createElement('x-parent', { is: DualTemplate });
         document.body.appendChild(parent);
         const child = parent.shadowRoot.querySelector('x-test');
         child.disconnect = disconnectedCallback;
         parent.hideChild = true;
-        return Promise.resolve().then(() => {
-            expect(disconnectedCallbackInvoked).toBe(true);
-        });
+        await Promise.resolve();
+        expect(disconnectedCallbackInvoked).toBe(true);
     });
 });

--- a/packages/@lwc/integration-not-karma/test/component/LightningElement.disconnectedCallback/issue-1506.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/LightningElement.disconnectedCallback/issue-1506.spec.js
@@ -1,7 +1,7 @@
 import { createElement } from 'lwc';
 import Parent from 'x/dualTemplate1506';
 
-it('setting tracked value in disconnectedCallback should not throw', () => {
+it('setting tracked value in disconnectedCallback should not throw', async () => {
     const elm = createElement('x-parent', { is: Parent });
     document.body.appendChild(elm);
     expect(
@@ -9,7 +9,6 @@ it('setting tracked value in disconnectedCallback should not throw', () => {
     ).not.toBeNull();
     elm.toggleTemplate();
 
-    return Promise.resolve().then(() => {
-        expect(elm.shadowRoot.querySelector('div').textContent).toBe('simple template');
-    });
+    await Promise.resolve();
+    expect(elm.shadowRoot.querySelector('div').textContent).toBe('simple template');
 });

--- a/packages/@lwc/integration-not-karma/test/component/LightningElement.errorCallback/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/LightningElement.errorCallback/index.spec.js
@@ -33,109 +33,95 @@ import XNoThrowOnMutate from 'x/noThrowOnMutate';
 import { catchUnhandledRejectionsAndErrors } from '../../../helpers/utils.js';
 
 describe('error boundary', () => {
-    it('should propagate frozen error to errorCallback()', () => {
+    it('should propagate frozen error to errorCallback()', async () => {
         const elm = createElement('x-boundary-rendered-throw-frozen', {
             is: XBoundaryRenderedThrowFrozen,
         });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            expect(elm.getErrorMessage()).toEqual('Child threw frozen error in renderedCallback()');
-        });
+        await Promise.resolve();
+        expect(elm.getErrorMessage()).toEqual('Child threw frozen error in renderedCallback()');
     });
 
-    it('should not add web component stack trace to frozen error', () => {
+    it('should not add web component stack trace to frozen error', async () => {
         const elm = createElement('x-boundary-rendered-throw-frozen', {
             is: XBoundaryRenderedThrowFrozen,
         });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            expect(elm.getErrorWCStack()).toBeUndefined();
-        });
+        await Promise.resolve();
+        expect(elm.getErrorWCStack()).toBeUndefined();
     });
 
-    it('should render alternative view if child throws in renderedCallback()', () => {
+    it('should render alternative view if child throws in renderedCallback()', async () => {
         const elm = createElement('x-boundary-child-rendered-throw', {
             is: XBoundaryChildRenderedThrow,
         });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const alternativeView = elm.shadowRoot.querySelector('.rendered-callback-alternative');
-
-            expect(alternativeView.textContent).toEqual('renderedCallback alternative view');
-            expect(elm.shadowRoot.querySelector('x-child-rendered-throw')).toBe(null);
-        });
+        await Promise.resolve();
+        const alternativeView = elm.shadowRoot.querySelector('.rendered-callback-alternative');
+        expect(alternativeView.textContent).toEqual('renderedCallback alternative view');
+        expect(elm.shadowRoot.querySelector('x-child-rendered-throw')).toBe(null);
     });
 
-    it('should render alternative view if child throws in render()', () => {
+    it('should render alternative view if child throws in render()', async () => {
         const elm = createElement('x-boundary-child-render-throw', {
             is: XBoundaryChildRenderThrow,
         });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const alternativeView = elm.shadowRoot.querySelector('.render-alternative');
-
-            expect(alternativeView.textContent).toEqual('render alternative view');
-            expect(elm.shadowRoot.querySelector('x-child-render-throw')).toBe(null);
-        });
+        await Promise.resolve();
+        const alternativeView = elm.shadowRoot.querySelector('.render-alternative');
+        expect(alternativeView.textContent).toEqual('render alternative view');
+        expect(elm.shadowRoot.querySelector('x-child-render-throw')).toBe(null);
     });
 
-    it('should render alternative view if child throws in constructor()', () => {
+    it('should render alternative view if child throws in constructor()', async () => {
         const elm = createElement('x-boundary-child-constructor-throw', {
             is: XBoundaryChildConstructorThrow,
         });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const alternativeView = elm.shadowRoot.querySelector('.constructor-alternative');
-
-            expect(alternativeView.textContent).toEqual('constructor alternative view');
-            expect(elm.shadowRoot.querySelector('x-child-constructor-throw')).toBe(null);
-            expect(elm.shadowRoot.querySelector('x-child-constructor-wrapper')).toBe(null);
-        });
+        await Promise.resolve();
+        const alternativeView = elm.shadowRoot.querySelector('.constructor-alternative');
+        expect(alternativeView.textContent).toEqual('constructor alternative view');
+        expect(elm.shadowRoot.querySelector('x-child-constructor-throw')).toBe(null);
+        expect(elm.shadowRoot.querySelector('x-child-constructor-wrapper')).toBe(null);
     });
 
-    it('should render alternative view if child throws in connectedCallback()', () => {
+    it('should render alternative view if child throws in connectedCallback()', async () => {
         const elm = createElement('x-boundary-child-connected-throw', {
             is: XBoundaryChildConnectedThrow,
         });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const alternativeView = elm.shadowRoot.querySelector('.connected-callback-alternative');
-
-            expect(alternativeView.textContent).toEqual('connectedCallback alternative view');
-            expect(elm.shadowRoot.querySelector('x-child-connected-throw')).toBe(null);
-        });
+        await Promise.resolve();
+        const alternativeView = elm.shadowRoot.querySelector('.connected-callback-alternative');
+        expect(alternativeView.textContent).toEqual('connectedCallback alternative view');
+        expect(elm.shadowRoot.querySelector('x-child-connected-throw')).toBe(null);
     });
 
-    it('should render alternative view if child slot throws in render()', () => {
+    it('should render alternative view if child slot throws in render()', async () => {
         const elm = createElement('x-boundary-child-slot-throw', { is: XBoundaryChildSlotThrow });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const alternativeView = elm.shadowRoot.querySelector('.slot-alternative');
-
-            expect(alternativeView.textContent).toEqual('slot alternative view');
-            expect(elm.shadowRoot.querySelector('x-child-slot-host')).toBe(null);
-        });
+        await Promise.resolve();
+        const alternativeView = elm.shadowRoot.querySelector('.slot-alternative');
+        expect(alternativeView.textContent).toEqual('slot alternative view');
+        expect(elm.shadowRoot.querySelector('x-child-slot-host')).toBe(null);
     });
 
-    it('should render alternative view if nested child throws in render()', () => {
+    it('should render alternative view if nested child throws in render()', async () => {
         const elm = createElement('x-nested-boundary-child-throw', {
             is: XNestedBoundaryChildThrow,
         });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const alternativeView = elm.shadowRoot.querySelector('.boundary-alt-view');
-
-            expect(alternativeView.textContent).toEqual('alternative view');
-            expect(elm.shadowRoot.querySelector('x-nested-grand-child-throw')).toBe(null);
-        });
+        await Promise.resolve();
+        const alternativeView = elm.shadowRoot.querySelector('.boundary-alt-view');
+        expect(alternativeView.textContent).toEqual('alternative view');
+        expect(elm.shadowRoot.querySelector('x-nested-grand-child-throw')).toBe(null);
     });
 
     it('should render alternative view if child throws during self rehydration cycle', async () => {
@@ -157,20 +143,19 @@ describe('error boundary', () => {
         expect(elm.shadowRoot.querySelector('x-child-self-rehydrate-throw')).toBe(null);
     });
 
-    it('should fail to unmount alternative offender when root element is not a boundary', () => {
+    it('should fail to unmount alternative offender when root element is not a boundary', async () => {
         const elm = createElement('x-boundary-alternative-view-throw', {
             is: XBoundaryAlternativeViewThrow,
         });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            // ensure offender still exists since boundary failed to recover
-            expect(
-                elm.shadowRoot
-                    .querySelector('x-alt-child-boundary-view-throw')
-                    .shadowRoot.querySelector('x-post-error-child-view')
-            ).not.toBe(null);
-        });
+        await Promise.resolve();
+        // ensure offender still exists since boundary failed to recover
+        expect(
+            elm.shadowRoot
+                .querySelector('x-alt-child-boundary-view-throw')
+                .shadowRoot.querySelector('x-post-error-child-view')
+        ).not.toBe(null);
     });
 });
 
@@ -303,42 +288,32 @@ describe('errorCallback throws after value mutation', () => {
     });
 
     function testStub(testcase, hostSelector, hostClass, expectAfterThrowingChildToExist) {
-        it(`parent errorCallback throws after value mutation ${testcase}`, () => {
+        it(`parent errorCallback throws after value mutation ${testcase}`, async () => {
             const throwElm = createElement(hostSelector, { is: hostClass });
             const noThrowElm = createElement('x-no-throw-on-mutate', { is: XNoThrowOnMutate });
             document.body.appendChild(throwElm);
             document.body.appendChild(noThrowElm);
-            return (
-                Promise.resolve()
-                    .then(() => {
-                        throwElm.show = true;
-                        noThrowElm.show = true;
-                    })
-                    // Need to wait a few ticks so flushRehydrationQueue can finish
-                    .then(() => new Promise((resolve) => setTimeout(resolve)))
-                    .then(() => new Promise((resolve) => setTimeout(resolve)))
-                    .then(() => {
-                        // error is thrown by parent's errorCallback
-                        expect(caughtError).not.toBeUndefined();
-                        expect(caughtError.message).toMatch(
-                            /error in the parent error callback after value mutation/
-                        );
-                        // child after the throwing child is not rendered
-                        // TODO [#3261]: strange observable difference between native vs synthetic lifecycle
-                        const afterThrowingChild =
-                            throwElm.shadowRoot.querySelector('x-after-throwing-child');
-                        if (expectAfterThrowingChildToExist) {
-                            expect(afterThrowingChild).not.toBeNull();
-                        } else {
-                            expect(afterThrowingChild).toBeNull();
-                        }
-                        // An unrelated element rendered after the throwing parent still renders. I.e. we didn't
-                        // give up rendering entirely just because one element threw in errorCallback.
-                        expect(noThrowElm.shadowRoot.querySelector('div').textContent).toEqual(
-                            'shown'
-                        );
-                    })
+            await Promise.resolve();
+            throwElm.show = true;
+            noThrowElm.show = true;
+            await new Promise((resolve) => setTimeout(resolve));
+            await new Promise((resolve_1) => setTimeout(resolve_1));
+            // error is thrown by parent's errorCallback
+            expect(caughtError).not.toBeUndefined();
+            expect(caughtError.message).toMatch(
+                /error in the parent error callback after value mutation/
             );
+            // child after the throwing child is not rendered
+            // TODO [#3261]: strange observable difference between native vs synthetic lifecycle
+            const afterThrowingChild = throwElm.shadowRoot.querySelector('x-after-throwing-child');
+            if (expectAfterThrowingChildToExist) {
+                expect(afterThrowingChild).not.toBeNull();
+            } else {
+                expect(afterThrowingChild).toBeNull();
+            }
+            // An unrelated element rendered after the throwing parent still renders. I.e. we didn't
+            // give up rendering entirely just because one element threw in errorCallback.
+            expect(noThrowElm.shadowRoot.querySelector('div').textContent).toEqual('shown');
         });
     }
 

--- a/packages/@lwc/integration-not-karma/test/component/LightningElement.render/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/LightningElement.render/index.spec.js
@@ -71,7 +71,7 @@ it('supports returning a template', () => {
     expect(elm.shadowRoot.textContent).toBe('Template 1');
 });
 
-it('supports returning different templates', () => {
+it('supports returning different templates', async () => {
     const elm = createElement('x-dynamic-template', { is: DynamicTemplate });
     elm.template = template1;
     document.body.appendChild(elm);
@@ -79,9 +79,8 @@ it('supports returning different templates', () => {
     expect(elm.shadowRoot.textContent).toBe('Template 1');
 
     elm.template = template2;
-    return Promise.resolve().then(() => {
-        expect(elm.shadowRoot.textContent).toBe('Template 2');
-    });
+    await Promise.resolve();
+    expect(elm.shadowRoot.textContent).toBe('Template 2');
 });
 
 it('throws an error when render() returns an invalid value', () => {

--- a/packages/@lwc/integration-not-karma/test/component/decorators/api/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/decorators/api/index.spec.js
@@ -26,28 +26,26 @@ describe('properties', () => {
         }).toLogWarningDev(/Add the @api annotation to the property declaration/);
     });
 
-    it('should make the public property reactive if used in the template', () => {
+    it('should make the public property reactive if used in the template', async () => {
         const elm = createElement('x-reactive', { is: Reactivity });
         document.body.appendChild(elm);
 
         expect(elm.getRenderCount()).toBe(1);
 
         elm.reactive = 'reactive';
-        return Promise.resolve().then(() => {
-            expect(elm.getRenderCount()).toBe(2);
-        });
+        await Promise.resolve();
+        expect(elm.getRenderCount()).toBe(2);
     });
 
-    it('should make the public property not reactive if not used in the template', () => {
+    it('should make the public property not reactive if not used in the template', async () => {
         const elm = createElement('x-reactive', { is: Reactivity });
         document.body.appendChild(elm);
 
         expect(elm.getRenderCount()).toBe(1);
 
         elm.nonReactive = 'reactive';
-        return Promise.resolve().then(() => {
-            expect(elm.getRenderCount()).toBe(1);
-        });
+        await Promise.resolve();
+        expect(elm.getRenderCount()).toBe(1);
     });
 
     it('throws an error when attempting set a property of a public property', () => {
@@ -257,7 +255,7 @@ describe('non-LightningElement `this` when calling accessor', () => {
 
 describe('regression [W-9927596]', () => {
     describe('public property with duplicate observed field', () => {
-        it('log errors when evaluated and preserve the public property', () => {
+        it('log errors when evaluated and preserve the public property', async () => {
             let Ctor;
 
             expect(() => {
@@ -282,9 +280,8 @@ describe('regression [W-9927596]', () => {
             expect(elm.shadowRoot.querySelector('p').textContent).toBe('public');
 
             elm.foo = 'updated';
-            return Promise.resolve().then(() => {
-                expect(elm.shadowRoot.querySelector('p').textContent).toBe('updated');
-            });
+            await Promise.resolve();
+            expect(elm.shadowRoot.querySelector('p').textContent).toBe('updated');
         });
     });
 

--- a/packages/@lwc/integration-not-karma/test/component/decorators/track/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/decorators/track/index.spec.js
@@ -7,28 +7,26 @@ import SetTrackedValueToNull from 'x/setTrackedValueToNull';
 import StaticProperty from 'x/staticProperty';
 import duplicatePropertyTemplate from 'x/duplicatePropertyTemplate';
 
-it('rerenders the component when a track property is updated - literal', () => {
+it('rerenders the component when a track property is updated - literal', async () => {
     const elm = createElement('x-properties', { is: Properties });
     document.body.appendChild(elm);
 
     expect(elm.shadowRoot.querySelector('.prop').textContent).toBe('0');
 
     elm.mutateCmp((cmp) => (cmp.prop = 1));
-    return Promise.resolve().then(() => {
-        expect(elm.shadowRoot.querySelector('.prop').textContent).toBe('1');
-    });
+    await Promise.resolve();
+    expect(elm.shadowRoot.querySelector('.prop').textContent).toBe('1');
 });
 
-it('rerenders the component when a track property is updated - object', () => {
+it('rerenders the component when a track property is updated - object', async () => {
     const elm = createElement('x-properties', { is: Properties });
     document.body.appendChild(elm);
 
     expect(elm.shadowRoot.querySelector('.obj').textContent).toBe('0');
 
     elm.mutateCmp((cmp) => (cmp.obj.value = 1));
-    return Promise.resolve().then(() => {
-        expect(elm.shadowRoot.querySelector('.obj').textContent).toBe('1');
-    });
+    await Promise.resolve();
+    expect(elm.shadowRoot.querySelector('.obj').textContent).toBe('1');
 });
 
 it("doesn't work for decorated static props", () => {
@@ -81,31 +79,29 @@ describe('restrictions', () => {
 });
 
 describe('object mutations', () => {
-    it('rerenders the component when a property is updated', () => {
+    it('rerenders the component when a property is updated', async () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 
         expect(elm.shadowRoot.querySelector('.nested-obj').textContent).toBe('0');
 
         elm.mutateCmp((cmp) => (cmp.nestedObj.value.nestedValue = 1));
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.nested-obj').textContent).toBe('1');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.nested-obj').textContent).toBe('1');
     });
 
-    it('rerenders the component when a property is deleted', () => {
+    it('rerenders the component when a property is deleted', async () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 
         elm.mutateCmp((cmp) => {
             delete cmp.obj.value;
         });
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.obj').textContent).toBe('');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.obj').textContent).toBe('');
     });
 
-    it('rerenders the component when a track is defined using Object.defineProperty', () => {
+    it('rerenders the component when a track is defined using Object.defineProperty', async () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 
@@ -114,12 +110,11 @@ describe('object mutations', () => {
                 value: 1,
             });
         });
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.obj').textContent).toBe('1');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.obj').textContent).toBe('1');
     });
 
-    it('should support freezing tracked property', () => {
+    it('should support freezing tracked property', async () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 
@@ -127,9 +122,8 @@ describe('object mutations', () => {
             cmp.obj = { value: 1 };
             Object.freeze(cmp.obj);
         });
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.obj').textContent).toBe('1');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.obj').textContent).toBe('1');
     });
 
     it('should not log an error when setting tracked value to null', () => {
@@ -140,34 +134,31 @@ describe('object mutations', () => {
 });
 
 describe('array mutations', () => {
-    it('rerenders the component if a new item is added via Array.prototype.push', () => {
+    it('rerenders the component if a new item is added via Array.prototype.push', async () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 
         elm.mutateCmp((cmp) => cmp.array.push(4));
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.array').textContent).toBe('1234');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.array').textContent).toBe('1234');
     });
 
-    it('rerenders the component if an item is removed via Array.prototype.pop', () => {
+    it('rerenders the component if an item is removed via Array.prototype.pop', async () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 
         elm.mutateCmp((cmp) => cmp.array.pop());
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.array').textContent).toBe('12');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.array').textContent).toBe('12');
     });
 
-    it('rerenders the component if an item is removed via Array.prototype.pop', () => {
+    it('rerenders the component if an item is removed via Array.prototype.pop', async () => {
         const elm = createElement('x-properties', { is: Properties });
         document.body.appendChild(elm);
 
         elm.mutateCmp((cmp) => cmp.array.unshift(4));
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.array').textContent).toBe('4123');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.array').textContent).toBe('4123');
     });
 });
 
@@ -184,7 +175,7 @@ describe('non-observable values', () => {
 });
 
 describe('regression [W-9927596] - track field with duplicate observed field', () => {
-    it('log errors when evaluated and preserve the public property', () => {
+    it('log errors when evaluated and preserve the public property', async () => {
         let Ctor;
 
         expect(() => {
@@ -213,8 +204,7 @@ describe('regression [W-9927596] - track field with duplicate observed field', (
         expect(elm.shadowRoot.querySelector('p').textContent).toBe('track');
 
         elm.updateProperty('updated');
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('p').textContent).toBe('updated');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('p').textContent).toBe('updated');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/component/dynamic-component/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/dynamic-component/index.spec.js
@@ -9,60 +9,51 @@ import ForwardedScopedSlotParent from 'x/forwardedScopedSlotParent';
 import Conditional from 'x/conditional';
 
 describe('dynamic components', () => {
-    it('basic dynamic component', () => {
+    it('basic dynamic component', async () => {
         const elm = createElement('x-basic', { is: Basic });
         document.body.appendChild(elm);
 
-        return Promise.resolve()
-            .then(() => {
-                // Constructor not set
-                const children = elm.shadowRoot.children;
-                expect(children.length).toBe(0);
-                elm.loadFoo();
-            })
-            .then(() => {
-                // Set constructor to foo
-                const children = elm.shadowRoot.children;
-                expect(children.length).toBe(1);
-                expect(children[0].tagName.toLowerCase()).toBe('x-foo');
-                elm.loadBar();
-            })
-            .then(() => {
-                // Change constructor to bar
-                const children = elm.shadowRoot.children;
-                expect(children.length).toBe(1);
-                expect(children[0].tagName.toLowerCase()).toBe('x-bar');
-                elm.clearCtor();
-            })
-            .then(() => {
-                // Change constructor to null
-                const children = elm.shadowRoot.children;
-                expect(children.length).toBe(0);
-            });
+        await Promise.resolve();
+        // Constructor not set
+        const children = elm.shadowRoot.children;
+        expect(children.length).toBe(0);
+        elm.loadFoo();
+        await Promise.resolve();
+        // Set constructor to foo
+        const children_1 = elm.shadowRoot.children;
+        expect(children_1.length).toBe(1);
+        expect(children_1[0].tagName.toLowerCase()).toBe('x-foo');
+        elm.loadBar();
+        await Promise.resolve();
+        // Change constructor to bar
+        const children_2 = elm.shadowRoot.children;
+        expect(children_2.length).toBe(1);
+        expect(children_2[0].tagName.toLowerCase()).toBe('x-bar');
+        elm.clearCtor();
+        await Promise.resolve();
+        // Change constructor to null
+        const children_3 = elm.shadowRoot.children;
+        expect(children_3.length).toBe(0);
     });
 
-    it('attributes assigned to dynamic components', () => {
+    it('attributes assigned to dynamic components', async () => {
         const elm = createElement('x-attributes', { is: Attributes });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const foo = elm.shadowRoot.querySelector('x-foo');
-            const bar = elm.shadowRoot.querySelector('x-bar');
-
-            expect(foo).not.toBeNull();
-            expect(bar).not.toBeNull();
-
-            // declaratively assigned
-            expect(foo.className).toContain('slds-snazzy');
-            expect(elm.clickEvtSrcElement).toBeNull();
-            foo.click();
-            expect(elm.clickEvtSrcElement).toBe('x-foo');
-
-            // imperatively assigned
-            expect(bar.className).toContain('slds-more-snazzy');
-            bar.click();
-            expect(elm.clickEvtSrcElement).toBe('x-bar');
-        });
+        await Promise.resolve();
+        const foo = elm.shadowRoot.querySelector('x-foo');
+        const bar = elm.shadowRoot.querySelector('x-bar');
+        expect(foo).not.toBeNull();
+        expect(bar).not.toBeNull();
+        // declaratively assigned
+        expect(foo.className).toContain('slds-snazzy');
+        expect(elm.clickEvtSrcElement).toBeNull();
+        foo.click();
+        expect(elm.clickEvtSrcElement).toBe('x-foo');
+        // imperatively assigned
+        expect(bar.className).toContain('slds-more-snazzy');
+        bar.click();
+        expect(elm.clickEvtSrcElement).toBe('x-bar');
     });
 
     describe('dynamic list', () => {
@@ -87,20 +78,18 @@ describe('dynamic components', () => {
             verifyListContent(['x-foo', 'x-bar', 'x-baz', 'x-fred']);
         });
 
-        it('maintains correct order when constructor assigned to each item in the list changes', () => {
+        it('maintains correct order when constructor assigned to each item in the list changes', async () => {
             container.swapConstructors();
-            return Promise.resolve().then(() => {
-                // New order after each item changes constructor
-                verifyListContent(['x-baz', 'x-fred', 'x-foo', 'x-bar']);
-            });
+            await Promise.resolve();
+            // New order after each item changes constructor
+            verifyListContent(['x-baz', 'x-fred', 'x-foo', 'x-bar']);
         });
 
-        it('renders components in correct order when constructors are removed', () => {
+        it('renders components in correct order when constructors are removed', async () => {
             container.removeConstructors();
-            return Promise.resolve().then(() => {
-                // Set 2 of the constructors to null
-                verifyListContent(['x-bar', 'x-fred']);
-            });
+            await Promise.resolve();
+            // Set 2 of the constructors to null
+            verifyListContent(['x-bar', 'x-fred']);
         });
     });
 
@@ -143,69 +132,59 @@ describe('dynamic components', () => {
             document.body.appendChild(container);
         });
 
-        it('renders parent dynamic component without children', () => {
+        it('renders parent dynamic component without children', async () => {
             container.loadParent();
-            return Promise.resolve().then(() => {
-                const parent = container.shadowRoot.querySelector('x-slottable');
-                expect(parent).not.toBeNull();
-
-                const child = container.shadowRoot.querySelector('x-foo');
-                expect(child).toBeNull();
-            });
+            await Promise.resolve();
+            const parent = container.shadowRoot.querySelector('x-slottable');
+            expect(parent).not.toBeNull();
+            const child = container.shadowRoot.querySelector('x-foo');
+            expect(child).toBeNull();
         });
 
-        it('renders parent and child dynamic elements properly', () => {
+        it('renders parent and child dynamic elements properly', async () => {
             container.loadParent();
             container.loadChild();
-            return Promise.resolve().then(() => {
-                const parent = container.shadowRoot.querySelector('x-slottable');
-                expect(parent).not.toBeNull();
-
-                const child = container.shadowRoot.querySelector('x-foo');
-                expect(child).not.toBeNull();
-            });
+            await Promise.resolve();
+            const parent = container.shadowRoot.querySelector('x-slottable');
+            expect(parent).not.toBeNull();
+            const child = container.shadowRoot.querySelector('x-foo');
+            expect(child).not.toBeNull();
         });
 
-        it('does not render children when parent does not have constructor', () => {
+        it('does not render children when parent does not have constructor', async () => {
             container.loadChild();
-            return Promise.resolve().then(() => {
-                const parent = container.shadowRoot.querySelector('x-slottable');
-                expect(parent).toBeNull();
-
-                const child = container.shadowRoot.querySelector('x-foo');
-                expect(child).toBeNull();
-            });
+            await Promise.resolve();
+            const parent = container.shadowRoot.querySelector('x-slottable');
+            expect(parent).toBeNull();
+            const child = container.shadowRoot.querySelector('x-foo');
+            expect(child).toBeNull();
         });
     });
 
     describe('scoped slots', () => {
-        it('properly renders dynamic components when constructor is passed from slot child to parent', () => {
+        it('properly renders dynamic components when constructor is passed from slot child to parent', async () => {
             const elm = createElement('x-scoped-slot-parent', { is: ScopedSlotParent });
             document.body.appendChild(elm);
-            return Promise.resolve().then(() => {
-                const childSlot = elm.shadowRoot.querySelector('x-scoped-slot-child');
-                expect(childSlot).not.toBeNull();
-
-                const slottedContent = childSlot.children;
-                expect(slottedContent.length).toBe(3);
-                expect(slottedContent[0].tagName.toLowerCase()).toBe('x-foo');
-                expect(slottedContent[1].tagName.toLowerCase()).toBe('x-bar');
-                expect(slottedContent[2].tagName.toLowerCase()).toBe('x-fred');
-            });
+            await Promise.resolve();
+            const childSlot = elm.shadowRoot.querySelector('x-scoped-slot-child');
+            expect(childSlot).not.toBeNull();
+            const slottedContent = childSlot.children;
+            expect(slottedContent.length).toBe(3);
+            expect(slottedContent[0].tagName.toLowerCase()).toBe('x-foo');
+            expect(slottedContent[1].tagName.toLowerCase()).toBe('x-bar');
+            expect(slottedContent[2].tagName.toLowerCase()).toBe('x-fred');
         });
 
-        it('properly renders slotted content inside a dynamically created scoped slot child', () => {
+        it('properly renders slotted content inside a dynamically created scoped slot child', async () => {
             const elm = createElement('x-forwarded-scoped-slot-parent', {
                 is: ForwardedScopedSlotParent,
             });
             document.body.appendChild(elm);
-            return Promise.resolve().then(() => {
-                const childSlot = elm.shadowRoot.querySelector('x-forwarded-scoped-slot-child');
-                expect(childSlot).not.toBeNull();
-
-                const slottedContent = childSlot.querySelector('x-baz');
-                expect(slottedContent).not.toBeNull();
-            });
+            await Promise.resolve();
+            const childSlot = elm.shadowRoot.querySelector('x-forwarded-scoped-slot-child');
+            expect(childSlot).not.toBeNull();
+            const slottedContent = childSlot.querySelector('x-baz');
+            expect(slottedContent).not.toBeNull();
         });
     });
 
@@ -217,46 +196,39 @@ describe('dynamic components', () => {
             document.body.appendChild(container);
         });
 
-        it('properly renders inside lwc:if', () => {
+        it('properly renders inside lwc:if', async () => {
             expect(container.shadowRoot.children.length).toBe(0);
             container.setIfCtor();
-            return Promise.resolve()
-                .then(() => {
-                    // Does not render until if condition is met
-                    expect(container.shadowRoot.children.length).toBe(0);
-                    container.showIf = true;
-                })
-                .then(() => {
-                    const children = container.shadowRoot.children;
-                    expect(children.length).toBe(1);
-                    expect(children[0].tagName.toLowerCase()).toBe('x-foo');
-                });
+            await Promise.resolve();
+            // Does not render until if condition is met
+            expect(container.shadowRoot.children.length).toBe(0);
+            container.showIf = true;
+            await Promise.resolve();
+            const children = container.shadowRoot.children;
+            expect(children.length).toBe(1);
+            expect(children[0].tagName.toLowerCase()).toBe('x-foo');
         });
 
-        it('properly renders inside lwc:elseif', () => {
+        it('properly renders inside lwc:elseif', async () => {
             expect(container.shadowRoot.children.length).toBe(0);
             container.setElseIfCtor();
-            return Promise.resolve()
-                .then(() => {
-                    // Does not render until elseif condition is met
-                    expect(container.shadowRoot.children.length).toBe(0);
-                    container.showElseIf = true;
-                })
-                .then(() => {
-                    const children = container.shadowRoot.children;
-                    expect(children.length).toBe(1);
-                    expect(children[0].tagName.toLowerCase()).toBe('x-bar');
-                });
+            await Promise.resolve();
+            // Does not render until elseif condition is met
+            expect(container.shadowRoot.children.length).toBe(0);
+            container.showElseIf = true;
+            await Promise.resolve();
+            const children = container.shadowRoot.children;
+            expect(children.length).toBe(1);
+            expect(children[0].tagName.toLowerCase()).toBe('x-bar');
         });
 
-        it('properly renders inside lwc:else', () => {
+        it('properly renders inside lwc:else', async () => {
             expect(container.shadowRoot.children.length).toBe(0);
             container.setElseCtor();
-            return Promise.resolve().then(() => {
-                const children = container.shadowRoot.children;
-                expect(children.length).toBe(1);
-                expect(children[0].tagName.toLowerCase()).toBe('x-baz');
-            });
+            await Promise.resolve();
+            const children = container.shadowRoot.children;
+            expect(children.length).toBe(1);
+            expect(children[0].tagName.toLowerCase()).toBe('x-baz');
         });
     });
 });

--- a/packages/@lwc/integration-not-karma/test/component/lifecycle-callbacks/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/lifecycle-callbacks/index.spec.js
@@ -84,7 +84,7 @@ it('should invoke the component lifecycle hooks in the right order when removing
     ]);
 });
 
-it('should call children component lifecycle hooks when rendered dynamically via the template', () => {
+it('should call children component lifecycle hooks when rendered dynamically via the template', async () => {
     const elm = createElement('x-parent-if', { is: ParentIf });
     document.body.appendChild(elm);
 
@@ -96,27 +96,23 @@ it('should call children component lifecycle hooks when rendered dynamically via
     resetTimingBuffer();
     elm.childVisible = true;
 
-    return Promise.resolve()
-        .then(() => {
-            expect(window.timingBuffer).toEqual([
-                'child:constructor',
-                'child:connectedCallback',
-                'child:renderedCallback',
-                'parentIf:renderedCallback',
-            ]);
-
-            resetTimingBuffer();
-            elm.childVisible = false;
-        })
-        .then(() => {
-            expect(window.timingBuffer).toEqual([
-                'child:disconnectedCallback',
-                'parentIf:renderedCallback',
-            ]);
-        });
+    await Promise.resolve();
+    expect(window.timingBuffer).toEqual([
+        'child:constructor',
+        'child:connectedCallback',
+        'child:renderedCallback',
+        'parentIf:renderedCallback',
+    ]);
+    resetTimingBuffer();
+    elm.childVisible = false;
+    await Promise.resolve();
+    expect(window.timingBuffer).toEqual([
+        'child:disconnectedCallback',
+        'parentIf:renderedCallback',
+    ]);
 });
 
-it('should call children component lifecycle hooks when a public property change', () => {
+it('should call children component lifecycle hooks when a public property change', async () => {
     const elm = createElement('x-parent-prop', { is: ParentProp });
     document.body.appendChild(elm);
 
@@ -131,15 +127,10 @@ it('should call children component lifecycle hooks when a public property change
     resetTimingBuffer();
     elm.value = 'bar';
 
-    return Promise.resolve().then(() => {
-        expect(window.timingBuffer).toEqual([
-            'child:renderedCallback',
-            'parentProp:renderedCallback',
-        ]);
-
-        resetTimingBuffer();
-        elm.childVisible = false;
-    });
+    await Promise.resolve();
+    expect(window.timingBuffer).toEqual(['child:renderedCallback', 'parentProp:renderedCallback']);
+    resetTimingBuffer();
+    elm.childVisible = false;
 });
 
 describe('invocation order', () => {

--- a/packages/@lwc/integration-not-karma/test/component/observed-fields/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/observed-fields/index.spec.js
@@ -7,24 +7,22 @@ import FieldForCache from 'x/fieldForCache';
 import duplicatePropertyTemplate from 'x/duplicatePropertyTemplate';
 
 describe('observed-fields', () => {
-    it('should rerender component when field is mutated', () => {
+    it('should rerender component when field is mutated', async () => {
         const elm = createElement('x-simple', { is: Simple });
         document.body.appendChild(elm);
 
         elm.setValue('simpleValue', 'mutated');
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.simple-value').textContent).toBe('mutated');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.simple-value').textContent).toBe('mutated');
     });
 
-    it('should not rerender component when expando field is mutated', () => {
+    it('should not rerender component when expando field is mutated', async () => {
         const elm = createElement('x-simple', { is: Simple });
         document.body.appendChild(elm);
 
         elm.setValue('expandoField', 'mutated');
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.expando-value').textContent).toBe('initial');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.expando-value').textContent).toBe('initial');
     });
 
     it('should preserve object identity when saving object in fields', () => {
@@ -40,27 +38,23 @@ describe('observed-fields', () => {
         expect(elm.getValue('complexValue')).toBe(testObj);
     });
 
-    it('should not rerender component when field value is mutated', () => {
+    it('should not rerender component when field value is mutated', async () => {
         const elm = createElement('x-simple', { is: Simple });
         document.body.appendChild(elm);
 
         elm.mutateComplexValue();
 
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.complex-value').textContent).toBe('foo-bar');
-
-            // will trigger a rerender and will render the mutated complex values
-            elm.setValue('simpleValue', 'mutated');
-
-            return Promise.resolve().then(() => {
-                expect(elm.shadowRoot.querySelector('.complex-value').textContent).toBe(
-                    'mutated name-mutated lastName'
-                );
-            });
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.complex-value').textContent).toBe('foo-bar');
+        // will trigger a rerender and will render the mutated complex values
+        elm.setValue('simpleValue', 'mutated');
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.complex-value').textContent).toBe(
+            'mutated name-mutated lastName'
+        );
     });
 
-    it('should have same behavior as an expando field when has side effects during render', () => {
+    it('should have same behavior as an expando field when has side effects during render', async () => {
         const elm = createElement('x-side-effect', { is: SideEffect });
         const elmUsingExpando = createElement('x-side-effect', { is: SideEffect });
         elmUsingExpando.useExpando = true;
@@ -71,54 +65,47 @@ describe('observed-fields', () => {
         document.body.appendChild(elm);
         document.body.appendChild(elmUsingExpando);
 
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.label').textContent).toBe('label txt');
-            expect(elm.shadowRoot.querySelector('.rendered-times').textContent).toBe('1');
-            expect(elmUsingExpando.shadowRoot.querySelector('.expando').textContent).toBe('1');
-
-            elm.label = 'label modified';
-            elmUsingExpando.label = 'label modified';
-            return Promise.resolve().then(() => {
-                expect(elm.shadowRoot.querySelector('.label').textContent).toBe('label modified');
-                expect(elm.shadowRoot.querySelector('.rendered-times').textContent).toBe('2');
-                expect(elmUsingExpando.shadowRoot.querySelector('.expando').textContent).toBe('2');
-            });
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.label').textContent).toBe('label txt');
+        expect(elm.shadowRoot.querySelector('.rendered-times').textContent).toBe('1');
+        expect(elmUsingExpando.shadowRoot.querySelector('.expando').textContent).toBe('1');
+        elm.label = 'label modified';
+        elmUsingExpando.label = 'label modified';
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.label').textContent).toBe('label modified');
+        expect(elm.shadowRoot.querySelector('.rendered-times').textContent).toBe('2');
+        expect(elmUsingExpando.shadowRoot.querySelector('.expando').textContent).toBe('2');
     });
 
-    it('should not throw when has side effects in a getter during render', () => {
+    it('should not throw when has side effects in a getter during render', async () => {
         const elm = createElement('x-field-for-cache', { is: FieldForCache });
         elm.label = 'label txt';
 
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.label').textContent).toBe('label txt');
-            expect(elm.shadowRoot.querySelector('.computedLabel').textContent).toBe(
-                'label txt computed'
-            );
-
-            elm.label = 'label modified';
-            return Promise.resolve().then(() => {
-                expect(elm.shadowRoot.querySelector('.label').textContent).toBe('label modified');
-                expect(elm.shadowRoot.querySelector('.computedLabel').textContent).toBe(
-                    'label txt computed'
-                );
-            });
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.label').textContent).toBe('label txt');
+        expect(elm.shadowRoot.querySelector('.computedLabel').textContent).toBe(
+            'label txt computed'
+        );
+        elm.label = 'label modified';
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.label').textContent).toBe('label modified');
+        expect(elm.shadowRoot.querySelector('.computedLabel').textContent).toBe(
+            'label txt computed'
+        );
     });
 
-    it('should rerender component when inherited field is mutated', () => {
+    it('should rerender component when inherited field is mutated', async () => {
         const elm = createElement('x-simple', { is: Simple });
         document.body.appendChild(elm);
 
         elm.setValue('inheritedValue', 'mutated');
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.inherited-value').textContent).toBe('mutated');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.inherited-value').textContent).toBe('mutated');
     });
 
-    it('should allow decorated reserved words as field names', () => {
+    it('should allow decorated reserved words as field names', async () => {
         const elm = createElement('x-simple', { is: Simple });
         elm.static = 'static value';
         document.body.appendChild(elm);
@@ -126,11 +113,10 @@ describe('observed-fields', () => {
         expect(elm.shadowRoot.querySelector('.static-value').textContent).toBe('static value');
         elm.static = 'static value modified';
 
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('.static-value').textContent).toBe(
-                'static value modified'
-            );
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.static-value').textContent).toBe(
+            'static value modified'
+        );
     });
 
     describe('restrictions', () => {

--- a/packages/@lwc/integration-not-karma/test/component/refs/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/component/refs/index.spec.js
@@ -90,7 +90,7 @@ describe('refs', () => {
         expect(Object.isFrozen(refs)).toEqual(true);
     });
 
-    it('multi templates', () => {
+    it('multi templates', async () => {
         const elm = createElement('x-multi', { is: Multi });
 
         document.body.appendChild(elm);
@@ -101,23 +101,20 @@ describe('refs', () => {
         expect(elm.getRef('b')).toBeUndefined();
 
         elm.next();
-        return Promise.resolve()
-            .then(() => {
-                expect(elm.getRef('b').textContent).toEqual('b');
-                expect(elm.getRef('shared').textContent).toEqual('b-shared');
-                expect(elm.getRef('deepShared').textContent).toEqual('b-deepShared');
-                expect(elm.getRef('a')).toBeUndefined();
-                elm.next();
-            })
-            .then(() => {
-                expect(elm.getRef('a').textContent).toEqual('a');
-                expect(elm.getRef('shared').textContent).toEqual('a-shared');
-                expect(elm.getRef('deepShared').textContent).toEqual('a-deepShared');
-                expect(elm.getRef('b')).toBeUndefined();
-            });
+        await Promise.resolve();
+        expect(elm.getRef('b').textContent).toEqual('b');
+        expect(elm.getRef('shared').textContent).toEqual('b-shared');
+        expect(elm.getRef('deepShared').textContent).toEqual('b-deepShared');
+        expect(elm.getRef('a')).toBeUndefined();
+        elm.next();
+        await Promise.resolve();
+        expect(elm.getRef('a').textContent).toEqual('a');
+        expect(elm.getRef('shared').textContent).toEqual('a-shared');
+        expect(elm.getRef('deepShared').textContent).toEqual('a-deepShared');
+        expect(elm.getRef('b')).toBeUndefined();
     });
 
-    it('multi templates - no refs in one', () => {
+    it('multi templates - no refs in one', async () => {
         const elm = createElement('x-multi-no-refs-in-one', { is: MultiNoRefsInOne });
 
         document.body.appendChild(elm);
@@ -125,26 +122,22 @@ describe('refs', () => {
         expect(elm.getRefs()).toBeUndefined();
 
         elm.next();
-        return Promise.resolve()
-            .then(() => {
-                expect(elm.getRefs().foo.textContent).toEqual('foo');
-                elm.next();
-            })
-            .then(() => {
-                expect(elm.getRefs()).toBeUndefined();
-            });
+        await Promise.resolve();
+        expect(elm.getRefs().foo.textContent).toEqual('foo');
+        elm.next();
+        await Promise.resolve();
+        expect(elm.getRefs()).toBeUndefined();
     });
 
-    it('can overwrite refs', () => {
+    it('can overwrite refs', async () => {
         const elm = createElement('x-overwrite', { is: Overwrite });
 
         document.body.appendChild(elm);
 
         expect(elm.shadowRoot.querySelector('h1').textContent).toEqual('yolo');
         elm.next();
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('h1').textContent).toEqual('woohoo');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('h1').textContent).toEqual('woohoo');
     });
 
     it('can overwrite refs with an expando', () => {
@@ -238,7 +231,7 @@ describe('refs', () => {
         expect(elm.getRefTextContent('foo')).toEqual('foo');
     });
 
-    it('ref on a dynamic component - lwc:dynamic', () => {
+    it('ref on a dynamic component - lwc:dynamic', async () => {
         const elm = createElement('x-dynamic', { is: LwcDynamic });
         document.body.appendChild(elm);
 
@@ -248,15 +241,14 @@ describe('refs', () => {
         // Set the constructor
         elm.setDynamicConstructor();
 
-        return Promise.resolve().then(() => {
-            const dynamic = elm.getRef('dynamic');
-            // Ref is available after constructor set
-            expect(dynamic.tagName.toLowerCase()).toEqual('x-dynamic-cmp');
-            expect(dynamic.getRefTextContent('first')).toEqual('first');
-        });
+        await Promise.resolve();
+        const dynamic = elm.getRef('dynamic');
+        // Ref is available after constructor set
+        expect(dynamic.tagName.toLowerCase()).toEqual('x-dynamic-cmp');
+        expect(dynamic.getRefTextContent('first')).toEqual('first');
     });
 
-    it('ref on a dynamic component - <lwc:component lwc:is={}>', () => {
+    it('ref on a dynamic component - <lwc:component lwc:is={}>', async () => {
         const elm = createElement('x-dynamic', { is: Dynamic });
         document.body.appendChild(elm);
 
@@ -266,15 +258,14 @@ describe('refs', () => {
         // Set the constructor
         elm.setDynamicConstructor();
 
-        return Promise.resolve().then(() => {
-            const dynamic = elm.getRef('dynamic');
-            // Ref is available after constructor set
-            expect(dynamic.tagName.toLowerCase()).toEqual('x-basic');
-            expect(dynamic.getRefTextContent('first')).toEqual('first');
-        });
+        await Promise.resolve();
+        const dynamic = elm.getRef('dynamic');
+        // Ref is available after constructor set
+        expect(dynamic.tagName.toLowerCase()).toEqual('x-basic');
+        expect(dynamic.getRefTextContent('first')).toEqual('first');
     });
 
-    it('ref with conditional', () => {
+    it('ref with conditional', async () => {
         const elm = createElement('x-conditional', { is: Conditional });
         document.body.appendChild(elm);
 
@@ -283,20 +274,17 @@ describe('refs', () => {
         expect(elm.getRef('onlyTails').textContent).toEqual('only tails');
         expect(elm.getRefNames()).toEqual(['coinflip', 'onlyTails']);
         elm.next();
-        return Promise.resolve()
-            .then(() => {
-                expect(elm.getRef('coinflip').textContent).toEqual('heads');
-                expect(elm.getRef('onlyTails')).toBeUndefined();
-                expect(elm.getRef('onlyHeads').textContent).toEqual('only heads');
-                expect(elm.getRefNames()).toEqual(['coinflip', 'onlyHeads']);
-                elm.next();
-            })
-            .then(() => {
-                expect(elm.getRef('coinflip').textContent).toEqual('tails');
-                expect(elm.getRef('onlyHeads')).toBeUndefined();
-                expect(elm.getRef('onlyTails').textContent).toEqual('only tails');
-                expect(elm.getRefNames()).toEqual(['coinflip', 'onlyTails']);
-            });
+        await Promise.resolve();
+        expect(elm.getRef('coinflip').textContent).toEqual('heads');
+        expect(elm.getRef('onlyTails')).toBeUndefined();
+        expect(elm.getRef('onlyHeads').textContent).toEqual('only heads');
+        expect(elm.getRefNames()).toEqual(['coinflip', 'onlyHeads']);
+        elm.next();
+        await Promise.resolve();
+        expect(elm.getRef('coinflip').textContent).toEqual('tails');
+        expect(elm.getRef('onlyHeads')).toBeUndefined();
+        expect(elm.getRef('onlyTails').textContent).toEqual('only tails');
+        expect(elm.getRefNames()).toEqual(['coinflip', 'onlyTails']);
     });
 
     it('ref with slot', () => {
@@ -398,24 +386,21 @@ describe('refs', () => {
             expect(elm.result).toEqual('foo');
         });
 
-        it('works in render', () => {
+        it('works in render', async () => {
             const elm = createElement('x-render', { is: Render });
             expect(() => {
                 document.body.appendChild(elm);
             }).toLogErrorDev(
                 /Error: \[LWC error]: this\.refs is undefined for <x-render>\. This is either because the attached template has no "lwc:ref" directive, or this.refs was invoked before renderedCallback\(\). Use this\.refs only when the referenced HTML elements have been rendered to the DOM, such as within renderedCallback\(\) or disconnectedCallback\(\)\./
             );
-            return Promise.resolve()
-                .then(() => {
-                    expect(elm.results).toEqual([undefined]);
-                    elm.next();
-                })
-                .then(() => {
-                    expect(elm.results).toEqual([undefined, 'foo']);
-                });
+            await Promise.resolve();
+            expect(elm.results).toEqual([undefined]);
+            elm.next();
+            await Promise.resolve();
+            expect(elm.results).toEqual([undefined, 'foo']);
         });
 
-        it('logs error if this.refs is accessed during render', () => {
+        it('logs error if this.refs is accessed during render', async () => {
             const elm = createElement('x-access-during-render', { is: AccessDuringRender });
             expect(() => {
                 document.body.appendChild(elm);
@@ -426,10 +411,9 @@ describe('refs', () => {
 
             // this.refs should be undefined during rendering
             expect(ids.refTextContent.textContent).toEqual('refs are undefined');
-            return Promise.resolve().then(() => {
-                expect(ids.refTextContent.textContent).toEqual('refs are undefined');
-                expect(elm.refTextContent).toEqual('content in ref');
-            });
+            await Promise.resolve();
+            expect(ids.refTextContent.textContent).toEqual('refs are undefined');
+            expect(elm.refTextContent).toEqual('content in ref');
         });
     });
 });

--- a/packages/@lwc/integration-not-karma/test/custom-elements/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/custom-elements/index.spec.js
@@ -27,7 +27,7 @@ const notAConstructorError =
 const undefinedElementError = /(Illegal constructor|does not define a custom element)/;
 
 describe('customElements.get and customElements.whenDefined', () => {
-    it('using CustomElementConstructor', () => {
+    it('using CustomElementConstructor', async () => {
         // Nonce elements should be defined only once in the entire Karma test suite
         const tagName = 'x-nonce1';
         expect(customElements.get(tagName)).toBeUndefined();
@@ -39,14 +39,10 @@ describe('customElements.get and customElements.whenDefined', () => {
         expect(Ctor).toBe(Nonce1.CustomElementConstructor);
         document.body.appendChild(elm);
         expect(elm.expectedTagName).toEqual(tagName);
-        return promise
-            .then((Ctor) => {
-                expect(Ctor).toBe(Nonce1.CustomElementConstructor);
-                return customElements.whenDefined(tagName);
-            })
-            .then((Ctor) => {
-                expect(Ctor).toBe(Nonce1.CustomElementConstructor);
-            });
+        const Ctor_1 = await promise;
+        expect(Ctor_1).toBe(Nonce1.CustomElementConstructor);
+        const Ctor_2 = await customElements.whenDefined(tagName);
+        expect(Ctor_2).toBe(Nonce1.CustomElementConstructor);
     });
 });
 
@@ -105,46 +101,35 @@ describe('patched registry', () => {
             expect(secondCtor).toBe(firstCtor);
         });
 
-        it('whenDefined() should always return the same constructor - defined before whenDefined', () => {
+        it('whenDefined() should always return the same constructor - defined before whenDefined', async () => {
             createElement('x-nonce6', { is: Nonce6 });
-            let firstCtor;
-            return customElements
-                .whenDefined('x-nonce6')
-                .then((Ctor) => {
-                    expect(Ctor).not.toBeUndefined();
-                    firstCtor = Ctor;
-                    // Create an lwc with same tag but different constructor, this will register a pivot for the same tag
-                    createElement('x-nonce6', { is: Nonce7 });
-                    return customElements.whenDefined('x-nonce6');
-                })
-                .then((Ctor) => {
-                    expect(Ctor).not.toBeUndefined();
-                    expect(Ctor).toBe(firstCtor);
-                });
+            const Ctor = await customElements.whenDefined('x-nonce6');
+            expect(Ctor).not.toBeUndefined();
+            const firstCtor = Ctor;
+            // Create an lwc with same tag but different constructor, this will register a pivot for the same tag
+            createElement('x-nonce6', { is: Nonce7 });
+            const Ctor_1 = await customElements.whenDefined('x-nonce6');
+            expect(Ctor_1).not.toBeUndefined();
+            expect(Ctor_1).toBe(firstCtor);
         });
 
-        it('whenDefined() should always return the same constructor - defined after whenDefined', () => {
+        it('whenDefined() should always return the same constructor - defined after whenDefined', async () => {
             // Check `cE.whenDefined()` called _before_ `cE.define()`
             const promise = customElements.whenDefined('x-nonce12');
             createElement('x-nonce12', { is: Nonce12 });
-            let firstCtor;
-            return promise
-                .then((Ctor) => {
-                    expect(Ctor).not.toBeUndefined();
-                    firstCtor = Ctor;
-                    // Check `cE.whenDefined()` called _after_ `cE.define()`
-                    const promise = customElements.whenDefined('x-nonce12');
-                    createElement('x-nonce12', { is: Nonce13 });
-                    return promise;
-                })
-                .then((Ctor) => {
-                    expect(Ctor).not.toBeUndefined();
-                    expect(Ctor).toBe(firstCtor);
-                });
+            const Ctor = await promise;
+            expect(Ctor).not.toBeUndefined();
+            const firstCtor = Ctor;
+            // Check `cE.whenDefined()` called _after_ `cE.define()`
+            const promise_1 = customElements.whenDefined('x-nonce12');
+            createElement('x-nonce12', { is: Nonce13 });
+            const Ctor_1 = await promise_1;
+            expect(Ctor_1).not.toBeUndefined();
+            expect(Ctor_1).toBe(firstCtor);
         });
     });
 
-    it('vanilla element should be an instance of the right class', () => {
+    it('vanilla element should be an instance of the right class', async () => {
         const tagName = 'x-check-ctor-instanceof';
         class MyElement extends HTMLElement {}
 
@@ -162,15 +147,10 @@ describe('patched registry', () => {
         expect(Ctor).toBe(MyElement);
 
         // check cE.whenDefined() when the promise is created _before_ cE.define()
-        return whenDefinedPromiseBeforeDefine
-            .then((Ctor) => {
-                expect(Ctor).toBe(MyElement);
-                // check cE.whenDefined() when the promise is created _after_ cE.define()
-                return customElements.whenDefined(tagName);
-            })
-            .then((Ctor) => {
-                expect(Ctor).toBe(MyElement);
-            });
+        const Ctor_1 = await whenDefinedPromiseBeforeDefine;
+        expect(Ctor_1).toBe(MyElement);
+        const Ctor_2 = await customElements.whenDefined(tagName);
+        expect(Ctor_2).toBe(MyElement);
     });
 
     describe('defining an invalid tag name', () => {

--- a/packages/@lwc/integration-not-karma/test/dom-manual/moving-node-to-document/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/dom-manual/moving-node-to-document/index.spec.js
@@ -17,64 +17,44 @@ function createTestContainer(classForSpanInPortal) {
 }
 
 describe('Moving elements from inside lwc:dom=manual', () => {
-    it('should return correct parentNode', () => {
+    it('should return correct parentNode', async () => {
         const { portalElement, spanInPortal } = createTestContainer();
         portalElement.appendChild(spanInPortal);
 
-        return Promise.resolve().then(() => {
-            document.body.appendChild(spanInPortal);
-
-            // There is a drawback: The mutation observer is async, therefore if we access it immediately,
-            // it will still have an owner key.
-            return Promise.resolve().then(() => {
-                expect(spanInPortal.parentNode).toBe(document.body);
-            });
-        });
+        await Promise.resolve();
+        document.body.appendChild(spanInPortal);
+        await Promise.resolve();
+        expect(spanInPortal.parentNode).toBe(document.body);
     });
 
-    it('should return correct results in querySelector', () => {
+    it('should return correct results in querySelector', async () => {
         const { portalElement, spanInPortal } = createTestContainer('qs-lwc-dom-manual');
         portalElement.appendChild(spanInPortal);
 
-        return Promise.resolve().then(() => {
-            document.body.appendChild(spanInPortal);
-
-            // There is a drawback: The mutation observer is async, therefore if we access it immediately,
-            // it will still have an owner key.
-            return Promise.resolve().then(() => {
-                expect(document.querySelector('.qs-lwc-dom-manual')).toBe(spanInPortal);
-            });
-        });
+        await Promise.resolve();
+        document.body.appendChild(spanInPortal);
+        await Promise.resolve();
+        expect(document.querySelector('.qs-lwc-dom-manual')).toBe(spanInPortal);
     });
 
-    it('should return correct results in querySelectorAll', () => {
+    it('should return correct results in querySelectorAll', async () => {
         const { portalElement, spanInPortal } = createTestContainer('qs-all-lwc-dom-manual');
         portalElement.appendChild(spanInPortal);
 
-        return Promise.resolve().then(() => {
-            document.body.appendChild(spanInPortal);
-
-            // There is a drawback: The mutation observer is async, therefore if we access it immediately,
-            // it will still have an owner key.
-            return Promise.resolve().then(() => {
-                expect(document.querySelectorAll('.qs-all-lwc-dom-manual')[0]).toBe(spanInPortal);
-            });
-        });
+        await Promise.resolve();
+        document.body.appendChild(spanInPortal);
+        await Promise.resolve();
+        expect(document.querySelectorAll('.qs-all-lwc-dom-manual')[0]).toBe(spanInPortal);
     });
 
-    it('should return correct results in querySelector when node is added/removed on the same tick', () => {
+    it('should return correct results in querySelector when node is added/removed on the same tick', async () => {
         const { portalElement, spanInPortal } = createTestContainer('qs-mm-lwc-dom-manual');
         portalElement.appendChild(spanInPortal);
         portalElement.removeChild(spanInPortal);
 
-        return Promise.resolve().then(() => {
-            document.body.appendChild(spanInPortal);
-
-            // There is a drawback: The mutation observer is async, therefore if we access it immediately,
-            // it will still have an owner key.
-            return Promise.resolve().then(() => {
-                expect(document.querySelector('.qs-mm-lwc-dom-manual')).toBe(spanInPortal);
-            });
-        });
+        await Promise.resolve();
+        document.body.appendChild(spanInPortal);
+        await Promise.resolve();
+        expect(document.querySelector('.qs-mm-lwc-dom-manual')).toBe(spanInPortal);
     });
 });

--- a/packages/@lwc/integration-not-karma/test/light-dom/multiple-templates/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/light-dom/multiple-templates/index.spec.js
@@ -4,7 +4,7 @@ import Multi from 'x/multi';
 import MultiNoStyleInFirst from 'x/multiNoStyleInFirst';
 
 describe('multiple templates', () => {
-    it('can render multiple templates with different styles', () => {
+    it('can render multiple templates with different styles', async () => {
         const element = createElement('x-multi', { is: Multi });
 
         document.body.appendChild(element);
@@ -14,47 +14,31 @@ describe('multiple templates', () => {
         expect(getComputedStyle(element.querySelector('div')).marginLeft).toEqual('0px');
         element.querySelector('div').setAttribute('foo', '');
         element.next();
-        return Promise.resolve().then(() => {
-            expect(element.querySelector('div').textContent).toEqual('b');
-            expect(getComputedStyle(element.querySelector('div')).color).toEqual(
-                'rgb(233, 150, 122)'
-            );
-            expect(getComputedStyle(element.querySelector('div')).marginLeft).toEqual('10px');
-            // element should not be dirty after template change
-            expect(element.querySelector('div').hasAttribute('foo')).toEqual(false);
-        });
+        await Promise.resolve();
+        expect(element.querySelector('div').textContent).toEqual('b');
+        expect(getComputedStyle(element.querySelector('div')).color).toEqual('rgb(233, 150, 122)');
+        expect(getComputedStyle(element.querySelector('div')).marginLeft).toEqual('10px');
+        // element should not be dirty after template change
+        expect(element.querySelector('div').hasAttribute('foo')).toEqual(false);
     });
 
-    it('works when first template has no scoped style but second template does', () => {
+    it('works when first template has no scoped style but second template does', async () => {
         const element = createElement('x-multi-no-style-in-first', { is: MultiNoStyleInFirst });
         document.body.appendChild(element);
-        return Promise.resolve()
-            .then(() => {
-                expect(getComputedStyle(element.querySelector('.red')).color).toEqual(
-                    'rgb(0, 0, 0)'
-                );
-                expect(getComputedStyle(element).marginLeft).toEqual('0px');
-                element.next();
-            })
-            .then(() => {
-                expect(getComputedStyle(element.querySelector('.red')).color).toEqual(
-                    'rgb(255, 0, 0)'
-                );
-                expect(getComputedStyle(element).marginLeft).toEqual('5px');
-                element.next();
-            })
-            .then(() => {
-                expect(getComputedStyle(element.querySelector('.red')).color).toEqual(
-                    'rgb(0, 0, 0)'
-                );
-                expect(getComputedStyle(element).marginLeft).toEqual('0px');
-                element.next();
-            })
-            .then(() => {
-                expect(getComputedStyle(element.querySelector('.red')).color).toEqual(
-                    'rgb(255, 0, 0)'
-                );
-                expect(getComputedStyle(element).marginLeft).toEqual('5px');
-            });
+        await Promise.resolve();
+        expect(getComputedStyle(element.querySelector('.red')).color).toEqual('rgb(0, 0, 0)');
+        expect(getComputedStyle(element).marginLeft).toEqual('0px');
+        element.next();
+        await Promise.resolve();
+        expect(getComputedStyle(element.querySelector('.red')).color).toEqual('rgb(255, 0, 0)');
+        expect(getComputedStyle(element).marginLeft).toEqual('5px');
+        element.next();
+        await Promise.resolve();
+        expect(getComputedStyle(element.querySelector('.red')).color).toEqual('rgb(0, 0, 0)');
+        expect(getComputedStyle(element).marginLeft).toEqual('0px');
+        element.next();
+        await Promise.resolve();
+        expect(getComputedStyle(element.querySelector('.red')).color).toEqual('rgb(255, 0, 0)');
+        expect(getComputedStyle(element).marginLeft).toEqual('5px');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/light-dom/scoped-slot/if-block/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/light-dom/scoped-slot/if-block/index.spec.js
@@ -6,7 +6,7 @@ import { USE_COMMENTS_FOR_FRAGMENT_BOOKENDS } from '../../../../helpers/constant
 const vFragBookend = USE_COMMENTS_FOR_FRAGMENT_BOOKENDS ? '<!---->' : '';
 
 describe('if-block', () => {
-    it('should work when parent and child have matching slot types', () => {
+    it('should work when parent and child have matching slot types', async () => {
         const elm = createElement('x-parent', { is: MixedSlotParent });
         elm.showStandard = true;
         document.body.appendChild(elm);
@@ -18,14 +18,13 @@ describe('if-block', () => {
         // Switch off the if branch and switch on the elseif branch
         elm.showStandard = false;
         elm.showVariant = true;
-        return Promise.resolve().then(() => {
-            expect(child.innerHTML).toBe(
-                `${vFragBookend}${vFragBookend}${vFragBookend}<span>1 - slots and if block</span>${vFragBookend}${vFragBookend}${vFragBookend}`
-            );
-        });
+        await Promise.resolve();
+        expect(child.innerHTML).toBe(
+            `${vFragBookend}${vFragBookend}${vFragBookend}<span>1 - slots and if block</span>${vFragBookend}${vFragBookend}${vFragBookend}`
+        );
     });
 
-    it('should throw error when parent and child have mismatched slot types', () => {
+    it('should throw error when parent and child have mismatched slot types', async () => {
         let errorMsg;
         const consoleErrorSpy = spyOn(console, 'error').and.callFake((error) => {
             errorMsg = error.message;
@@ -38,20 +37,17 @@ describe('if-block', () => {
         // Switch off the if branch and switch on the elseif branch
         elm.showStandard = false;
         elm.showVariant = true;
-        return Promise.resolve()
-            .then(() => {
-                child.switchFromVariantToStandard();
-            })
-            .then(() => {
-                if (process.env.NODE_ENV === 'production') {
-                    expect(consoleErrorSpy).not.toHaveBeenCalled();
-                } else {
-                    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-                    expect(errorMsg).toMatch(/Mismatched slot types for \(default\) slot/);
-                }
-                expect(child.innerHTML).toBe(
-                    `${vFragBookend}${vFragBookend}${vFragBookend}${vFragBookend}`
-                );
-            });
+        await Promise.resolve();
+        child.switchFromVariantToStandard();
+        await Promise.resolve();
+        if (process.env.NODE_ENV === 'production') {
+            expect(consoleErrorSpy).not.toHaveBeenCalled();
+        } else {
+            expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+            expect(errorMsg).toMatch(/Mismatched slot types for \(default\) slot/);
+        }
+        expect(child.innerHTML).toBe(
+            `${vFragBookend}${vFragBookend}${vFragBookend}${vFragBookend}`
+        );
     });
 });

--- a/packages/@lwc/integration-not-karma/test/light-dom/scoped-slot/reactivity/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/light-dom/scoped-slot/reactivity/index.spec.js
@@ -19,74 +19,58 @@ describe('reactivity in scoped slots', () => {
         window.timingBuffer = [];
     }
 
-    it('rerenders slotted content when mutating value passed from parent to child', () => {
+    it('rerenders slotted content when mutating value passed from parent to child', async () => {
         const elm = createElement('x-list-parent', { is: ListParentApiData });
         elm.reactivityTestCaseEnabled = true;
         document.body.appendChild(elm);
 
         resetTimingBuffer();
         elm.changeItemsNestedKey();
-        return Promise.resolve()
-            .then(() => {
-                const spans = elm.shadowRoot.querySelectorAll('span');
-                expect(spans).toHaveSize(2);
-                expect(spans[0].innerHTML).toBe('38 - Audio');
-                expect(spans[1].innerHTML).toBe('40 - Video');
-                expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback', // value(items) in child's template was changed, so call child's renderedCallback
-                    'parent:renderedCallback', // item.id is being observed in parent's template, so call its renderedCallback
-                ]);
-
-                // reset timing buffer before next rerender
-                resetTimingBuffer();
-                elm.changeItemsRow();
-                // contents of items is being observed by x-child and not by x-parent.
-                // Adding a new row or changing an entire row will only trigger renderedCallback of x-child and not of the parent
-            })
-            .then(() => {
-                const spans = elm.shadowRoot.querySelectorAll('span');
-                expect(spans).toHaveSize(2);
-                expect(spans[0].innerHTML).toBe('37 - Tape');
-                expect(spans[1].innerHTML).toBe('40 - Video');
-                expect(window.timingBuffer).toEqual(['child:renderedCallback']);
-            });
+        await Promise.resolve();
+        const spans = elm.shadowRoot.querySelectorAll('span');
+        expect(spans).toHaveSize(2);
+        expect(spans[0].innerHTML).toBe('38 - Audio');
+        expect(spans[1].innerHTML).toBe('40 - Video');
+        expect(window.timingBuffer).toEqual([
+            'child:renderedCallback', // value(items) in child's template was changed, so call child's renderedCallback
+            'parent:renderedCallback', // item.id is being observed in parent's template, so call its renderedCallback
+        ]);
+        // reset timing buffer before next rerender
+        resetTimingBuffer();
+        elm.changeItemsRow();
+        await Promise.resolve();
+        const spans_1 = elm.shadowRoot.querySelectorAll('span');
+        expect(spans_1).toHaveSize(2);
+        expect(spans_1[0].innerHTML).toBe('37 - Tape');
+        expect(spans_1[1].innerHTML).toBe('40 - Video');
+        expect(window.timingBuffer).toEqual(['child:renderedCallback']);
     });
 
-    it("rerenders slotted content when mutating value of child's tracked field", () => {
+    it("rerenders slotted content when mutating value of child's tracked field", async () => {
         const elm = createElement('x-list-parent', { is: ListParentTrackedData });
         document.body.appendChild(elm);
 
         resetTimingBuffer();
         const child = elm.shadowRoot.querySelector('x-list-child-tracked-data');
         child.changeItemsNestedKey();
-        return Promise.resolve()
-            .then(() => {
-                const spans = elm.shadowRoot.querySelectorAll('span');
-                expect(spans).toHaveSize(2);
-                expect(spans[0].innerHTML).toBe('38 - Audio');
-                expect(spans[1].innerHTML).toBe('40 - Video');
-                expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback',
-                    'parent:renderedCallback',
-                ]);
-
-                // reset timing buffer before next rerender
-                resetTimingBuffer();
-                child.changeItemsRow();
-            })
-            .then(() => {
-                const spans = elm.shadowRoot.querySelectorAll('span');
-                expect(spans).toHaveSize(2);
-                expect(spans[0].innerHTML).toBe('37 - Tape');
-                expect(spans[1].innerHTML).toBe('40 - Video');
-                expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback',
-                    // Since the parent observes changes to the contents of the individual rows and not the items itself the parent's renderedCallback isn't invoked
-                ]);
-            });
+        await Promise.resolve();
+        const spans = elm.shadowRoot.querySelectorAll('span');
+        expect(spans).toHaveSize(2);
+        expect(spans[0].innerHTML).toBe('38 - Audio');
+        expect(spans[1].innerHTML).toBe('40 - Video');
+        expect(window.timingBuffer).toEqual(['child:renderedCallback', 'parent:renderedCallback']);
+        // reset timing buffer before next rerender
+        resetTimingBuffer();
+        child.changeItemsRow();
+        await Promise.resolve();
+        const spans_1 = elm.shadowRoot.querySelectorAll('span');
+        expect(spans_1).toHaveSize(2);
+        expect(spans_1[0].innerHTML).toBe('37 - Tape');
+        expect(spans_1[1].innerHTML).toBe('40 - Video');
+        expect(window.timingBuffer).toEqual(['child:renderedCallback']);
     });
 
-    it('<slot> tag with key attribute: rerenders slotted content only when iteration key changes', () => {
+    it('<slot> tag with key attribute: rerenders slotted content only when iteration key changes', async () => {
         function verifyContentAndCallbacks(expectedContent, expectedCallbacks) {
             expect(
                 [...elm.shadowRoot.querySelectorAll('x-slotted-with-callbacks')].map(
@@ -103,56 +87,50 @@ describe('reactivity in scoped slots', () => {
         resetTimingBuffer();
         // Step 1: Change key of iteration entry
         elm.changeItemsNestedKey();
-        return Promise.resolve()
-            .then(() => {
-                verifyContentAndCallbacks(
-                    ['38 - Audio', '40 - Video'],
-                    [
-                        'child:constructor', // mounts a new child for the new entry
-                        'child-38:connectedCallback', // Connect and render edited entry
-                        'child-38:renderedCallback',
-                        'child-39:disconnectedCallback', // Removed list entry is disconnected
-                        'childSlotTagWithKey:renderedCallback', // slot receiver has been rendered
-                        'parent:renderedCallback', // item.id is being observed in parent's template, so call its renderedCallback
-                    ]
-                );
-
-                // reset timing buffer before next rerender
-                resetTimingBuffer();
-                // Step 2: Change value of iteration entry, should only rehydrate existing element
-                elm.changeItemsNestedValue();
-            })
-            .then(() => {
-                verifyContentAndCallbacks(
-                    ['38 - Light', '40 - Video'],
-                    [
-                        'child-38:renderedCallback',
-                        'childSlotTagWithKey:renderedCallback',
-                        'parent:renderedCallback',
-                    ]
-                );
-
-                // reset timing buffer before next rerender
-                resetTimingBuffer();
-                // Step 3: Add new iteration entry
-                elm.changeItemsRow();
-            })
-            .then(() => {
-                verifyContentAndCallbacks(
-                    ['37 - Tape', '40 - Video'],
-                    [
-                        'child:constructor',
-                        'child-37:connectedCallback',
-                        'child-37:renderedCallback',
-                        'child-38:disconnectedCallback',
-                        'childSlotTagWithKey:renderedCallback',
-                    ]
-                );
-            });
+        await Promise.resolve();
+        verifyContentAndCallbacks(
+            ['38 - Audio', '40 - Video'],
+            [
+                'child:constructor', // mounts a new child for the new entry
+                'child-38:connectedCallback', // Connect and render edited entry
+                'child-38:renderedCallback',
+                'child-39:disconnectedCallback', // Removed list entry is disconnected
+                'childSlotTagWithKey:renderedCallback', // slot receiver has been rendered
+                'parent:renderedCallback', // item.id is being observed in parent's template, so call its renderedCallback
+            ]
+        );
+        // reset timing buffer before next rerender
+        resetTimingBuffer();
+        // Step 2: Change value of iteration entry, should only rehydrate existing element
+        elm.changeItemsNestedValue();
+        await Promise.resolve();
+        verifyContentAndCallbacks(
+            ['38 - Light', '40 - Video'],
+            [
+                'child-38:renderedCallback',
+                'childSlotTagWithKey:renderedCallback',
+                'parent:renderedCallback',
+            ]
+        );
+        // reset timing buffer before next rerender
+        resetTimingBuffer();
+        // Step 3: Add new iteration entry
+        elm.changeItemsRow();
+        await Promise.resolve();
+        verifyContentAndCallbacks(
+            ['37 - Tape', '40 - Video'],
+            [
+                'child:constructor',
+                'child-37:connectedCallback',
+                'child-37:renderedCallback',
+                'child-38:disconnectedCallback',
+                'childSlotTagWithKey:renderedCallback',
+            ]
+        );
     });
 
     describe('slot content containing parent bindings', () => {
-        it('is reactive when parent binding value is changed', () => {
+        it('is reactive when parent binding value is changed', async () => {
             const elm = createElement('x-parent', { is: WithParentBindings });
             document.body.appendChild(elm);
 
@@ -162,18 +140,17 @@ describe('reactivity in scoped slots', () => {
 
             resetTimingBuffer();
             elm.changeLabel();
-            return Promise.resolve().then(() => {
-                const div = elm.shadowRoot.querySelectorAll('div');
-                expect(div).toHaveSize(1);
-                expect(div[0].innerHTML).toBe('2000 hits');
-                expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback',
-                    'parent:renderedCallback', // label is part of parent's template, call its renderedCallback
-                ]);
-            });
+            await Promise.resolve();
+            const div_1 = elm.shadowRoot.querySelectorAll('div');
+            expect(div_1).toHaveSize(1);
+            expect(div_1[0].innerHTML).toBe('2000 hits');
+            expect(window.timingBuffer).toEqual([
+                'child:renderedCallback',
+                'parent:renderedCallback', // label is part of parent's template, call its renderedCallback
+            ]);
         });
 
-        it("rerenders parent and child when bindings are used in parent's non slot content", () => {
+        it("rerenders parent and child when bindings are used in parent's non slot content", async () => {
             const elm = createElement('x-parent', { is: ParentBindingsOutsideSlotContent });
             document.body.appendChild(elm);
 
@@ -183,23 +160,22 @@ describe('reactivity in scoped slots', () => {
 
             resetTimingBuffer();
             elm.changeLabel();
-            return Promise.resolve().then(() => {
-                const div = elm.shadowRoot.querySelectorAll('div');
-                // verify child is rerendered
-                expect(div).toHaveSize(1);
-                expect(div[0].innerHTML).toBe('2000 hits');
-                // verify  parent is rerendered
-                expect(elm.shadowRoot.querySelector('p').innerHTML).toBe('2000 hits');
-                expect(window.timingBuffer).toEqual([
-                    'child:renderedCallback',
-                    'parent:renderedCallback',
-                ]);
-            });
+            await Promise.resolve();
+            const div_1 = elm.shadowRoot.querySelectorAll('div');
+            // verify child is rerendered
+            expect(div_1).toHaveSize(1);
+            expect(div_1[0].innerHTML).toBe('2000 hits');
+            // verify  parent is rerendered
+            expect(elm.shadowRoot.querySelector('p').innerHTML).toBe('2000 hits');
+            expect(window.timingBuffer).toEqual([
+                'child:renderedCallback',
+                'parent:renderedCallback',
+            ]);
         });
     });
 
     describe('nested directives', () => {
-        it('slot content can contain if:true directive and is reactive', () => {
+        it('slot content can contain if:true directive and is reactive', async () => {
             function verifySlotContent(expectedContent) {
                 expect([...elm.shadowRoot.querySelectorAll('div')].map((_) => _.innerHTML)).toEqual(
                     expectedContent
@@ -210,34 +186,26 @@ describe('reactivity in scoped slots', () => {
             const child = elm.shadowRoot.querySelector('x-child-for-conditional-slot-content');
 
             verifySlotContent([]);
-            return Promise.resolve()
-                .then(() => {
-                    verifySlotContent([]);
-                    // toggle visibility flag in child
-                    child.visible = true;
-                })
-                .then(() => {
-                    // Verify that parent's scoped slot content is rendered
-                    verifySlotContent(['Variation 1']);
-
-                    // Verify that slot content is reactive to changes in parent's tracked data
-                    elm.enableVariation2();
-                })
-                .then(() => {
-                    verifySlotContent(['Variation 1', 'Variation 2']);
-                    // Switch of all slot content. Should still work because the vfragement still has empty text nodes that will be allocated
-                    elm.disableAllVariations();
-                })
-                .then(() => {
-                    verifySlotContent([]);
-
-                    // toggle off visibility flag in child and verify that content is reset
-                    elm.enableVariation2();
-                    child.visible = false;
-                })
-                .then(() => {
-                    verifySlotContent([]);
-                });
+            await Promise.resolve();
+            verifySlotContent([]);
+            // toggle visibility flag in child
+            child.visible = true;
+            await Promise.resolve();
+            // Verify that parent's scoped slot content is rendered
+            verifySlotContent(['Variation 1']);
+            // Verify that slot content is reactive to changes in parent's tracked data
+            elm.enableVariation2();
+            await Promise.resolve();
+            verifySlotContent(['Variation 1', 'Variation 2']);
+            // Switch of all slot content. Should still work because the vfragement still has empty text nodes that will be allocated
+            elm.disableAllVariations();
+            await Promise.resolve();
+            verifySlotContent([]);
+            // toggle off visibility flag in child and verify that content is reset
+            elm.enableVariation2();
+            child.visible = false;
+            await Promise.resolve();
+            verifySlotContent([]);
         });
     });
 });

--- a/packages/@lwc/integration-not-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/light-dom/scoped-slot/rehydration-issue-w-12965122/index.spec.js
@@ -22,169 +22,146 @@ describe('Should clean up content between rehydration', () => {
         ).toEqual(expectedContent);
     }
 
-    it('Issue W-12965122 automation: Elements are not leaked when parent binding and child binding is mutated', () => {
+    it('Issue W-12965122 automation: Elements are not leaked when parent binding and child binding is mutated', async () => {
         const elm = createElement('x-parent', { is: Parent });
         document.body.appendChild(elm);
         resetTimingBuffer();
         elm.flag = true;
         elm.changeAttr(); // counter 0
-        return Promise.resolve()
-            .then(() => {
-                verifySlotContent(elm, ['Slotted content: Parent0 Fiat']);
-                expect(window.timingBuffer).toEqual([
-                    'slotted:renderedCallback',
-                    'child:renderedCallback',
-                    'parent:renderedCallback',
-                ]);
-                // reset timing buffer before next rerender
-                resetTimingBuffer();
-                elm.flag = false;
-                elm.changeAttr(); // counter 1
-            })
-            .then(() => {
-                verifySlotContent(elm, []);
-                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
-                expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
-                // reset timing buffer before next rerender
-                resetTimingBuffer();
-                elm.flag = true;
-                elm.changeAttr(); // counter 2
-            })
-            .then(() => {
-                verifySlotContent(elm, ['Slotted content: Parent2 Fiat']);
-                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
-                expect(window.timingBuffer).toEqual([
-                    'slotted:renderedCallback',
-                    'child:renderedCallback',
-                    'parent:renderedCallback',
-                ]);
-                // reset timing buffer before next rerender
-                resetTimingBuffer();
-                elm.flag = false;
-                elm.changeAttr(); // counter 3
-            })
-            .then(() => {
-                verifySlotContent(elm, []);
-                // Prior to the bug fix, there would be two additional 'slotted:renderedCallback' entry(the leaked elements grow)
-                expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
-                // reset timing buffer before next rerender
-                resetTimingBuffer();
-                elm.flag = true;
-                elm.changeAttr();
-            })
-            .then(() => {
-                verifySlotContent(elm, ['Slotted content: Parent4 Fiat']);
-                expect(window.timingBuffer).toEqual([
-                    'slotted:renderedCallback',
-                    'child:renderedCallback',
-                    'parent:renderedCallback',
-                ]);
-            });
+        await Promise.resolve();
+        verifySlotContent(elm, ['Slotted content: Parent0 Fiat']);
+        expect(window.timingBuffer).toEqual([
+            'slotted:renderedCallback',
+            'child:renderedCallback',
+            'parent:renderedCallback',
+        ]);
+        // reset timing buffer before next rerender
+        resetTimingBuffer();
+        elm.flag = false;
+        elm.changeAttr(); // counter 1
+        await Promise.resolve();
+        verifySlotContent(elm, []);
+        // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+        expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
+        // reset timing buffer before next rerender
+        resetTimingBuffer();
+        elm.flag = true;
+        elm.changeAttr(); // counter 2
+        await Promise.resolve();
+        verifySlotContent(elm, ['Slotted content: Parent2 Fiat']);
+        // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+        expect(window.timingBuffer).toEqual([
+            'slotted:renderedCallback',
+            'child:renderedCallback',
+            'parent:renderedCallback',
+        ]);
+        // reset timing buffer before next rerender
+        resetTimingBuffer();
+        elm.flag = false;
+        elm.changeAttr(); // counter 3
+        await Promise.resolve();
+        verifySlotContent(elm, []);
+        // Prior to the bug fix, there would be two additional 'slotted:renderedCallback' entry(the leaked elements grow)
+        expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
+        // reset timing buffer before next rerender
+        resetTimingBuffer();
+        elm.flag = true;
+        elm.changeAttr();
+        await Promise.resolve();
+        verifySlotContent(elm, ['Slotted content: Parent4 Fiat']);
+        expect(window.timingBuffer).toEqual([
+            'slotted:renderedCallback',
+            'child:renderedCallback',
+            'parent:renderedCallback',
+        ]);
     });
 
-    it("Should rerender when only child's value is mutated", () => {
+    it("Should rerender when only child's value is mutated", async () => {
         const elm = createElement('x-parent', { is: Parent });
         document.body.appendChild(elm);
         resetTimingBuffer();
         elm.flag = true;
-        return Promise.resolve()
-            .then(() => {
-                // reset timing buffer before next rerender
-                resetTimingBuffer();
-                // Only change child's tracked value
-                elm.shadowRoot.querySelector('x-child').changeLabel();
-            })
-            .then(() => {
-                verifySlotContent(elm, ['Slotted content: Parent Peugeot']);
-                expect(window.timingBuffer).toEqual([
-                    'slotted:renderedCallback',
-                    'child:renderedCallback',
-                    'parent:renderedCallback',
-                ]);
-                resetTimingBuffer();
-                elm.flag = false;
-                elm.changeAttr(); // counter 3
-            })
-            .then(() => {
-                verifySlotContent(elm, []);
-                // Verify there are no dangling x-slotted
-                expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
-            });
+        await Promise.resolve();
+        // reset timing buffer before next rerender
+        resetTimingBuffer();
+        // Only change child's tracked value
+        elm.shadowRoot.querySelector('x-child').changeLabel();
+        await Promise.resolve();
+        verifySlotContent(elm, ['Slotted content: Parent Peugeot']);
+        expect(window.timingBuffer).toEqual([
+            'slotted:renderedCallback',
+            'child:renderedCallback',
+            'parent:renderedCallback',
+        ]);
+        resetTimingBuffer();
+        elm.flag = false;
+        elm.changeAttr(); // counter 3
+        await Promise.resolve();
+        verifySlotContent(elm, []);
+        // Verify there are no dangling x-slotted
+        expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
     });
 
-    it("Should rerender when child's value is mutated before parent's value is mutated", () => {
+    it("Should rerender when child's value is mutated before parent's value is mutated", async () => {
         const elm = createElement('x-parent', { is: Parent });
         document.body.appendChild(elm);
         resetTimingBuffer();
         elm.flag = true;
-        return Promise.resolve()
-            .then(() => {
-                elm.flag = false;
-            })
-            .then(() => {
-                verifySlotContent(elm, []);
-                elm.flag = true;
-            })
-            .then(() => {
-                resetTimingBuffer();
-                elm.shadowRoot.querySelector('x-child').changeLabel(); // Peugeot
-                elm.changeAttr(); // Counter 0
-            })
-            .then(() => {
-                verifySlotContent(elm, ['Slotted content: Parent0 Peugeot']);
-                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
-                expect(window.timingBuffer).toEqual([
-                    'slotted:renderedCallback',
-                    'child:renderedCallback',
-                    'parent:renderedCallback',
-                ]);
-            });
+        await Promise.resolve();
+        elm.flag = false;
+        await Promise.resolve();
+        verifySlotContent(elm, []);
+        elm.flag = true;
+        await Promise.resolve();
+        resetTimingBuffer();
+        elm.shadowRoot.querySelector('x-child').changeLabel(); // Peugeot
+        elm.changeAttr(); // Counter 0
+        await Promise.resolve();
+        verifySlotContent(elm, ['Slotted content: Parent0 Peugeot']);
+        // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+        expect(window.timingBuffer).toEqual([
+            'slotted:renderedCallback',
+            'child:renderedCallback',
+            'parent:renderedCallback',
+        ]);
     });
 
-    it("Should rerender when child's value is mutated after then parent's value is mutated", () => {
+    it("Should rerender when child's value is mutated after then parent's value is mutated", async () => {
         const elm = createElement('x-parent', { is: Parent });
         document.body.appendChild(elm);
         resetTimingBuffer();
         elm.flag = true;
-        return Promise.resolve()
-            .then(() => {
-                elm.flag = false;
-            })
-            .then(() => {
-                verifySlotContent(elm, []);
-                elm.flag = true;
-            })
-            .then(() => {
-                resetTimingBuffer();
-                elm.changeAttr(); // Counter 0
-                elm.shadowRoot.querySelector('x-child').changeLabel(); // Peugeot
-            })
-            .then(() => {
-                verifySlotContent(elm, ['Slotted content: Parent0 Peugeot']);
-                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
-                expect(window.timingBuffer).toEqual([
-                    'slotted:renderedCallback',
-                    'child:renderedCallback',
-                    'parent:renderedCallback',
-                ]);
-            });
+        await Promise.resolve();
+        elm.flag = false;
+        await Promise.resolve();
+        verifySlotContent(elm, []);
+        elm.flag = true;
+        await Promise.resolve();
+        resetTimingBuffer();
+        elm.changeAttr(); // Counter 0
+        elm.shadowRoot.querySelector('x-child').changeLabel(); // Peugeot
+        await Promise.resolve();
+        verifySlotContent(elm, ['Slotted content: Parent0 Peugeot']);
+        // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+        expect(window.timingBuffer).toEqual([
+            'slotted:renderedCallback',
+            'child:renderedCallback',
+            'parent:renderedCallback',
+        ]);
     });
 
-    it('Should not leak slotted content if its changed by child before cleanup', () => {
+    it('Should not leak slotted content if its changed by child before cleanup', async () => {
         const elm = createElement('x-parent', { is: Parent });
         document.body.appendChild(elm);
         resetTimingBuffer();
         elm.flag = true;
-        return Promise.resolve()
-            .then(() => {
-                resetTimingBuffer();
-                elm.shadowRoot.querySelector('x-child').changeLabel(); // Mutate child's value before parent turns off the branch containing x-child
-                elm.flag = false; // turn off the branch
-            })
-            .then(() => {
-                verifySlotContent(elm, []);
-                // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
-                expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
-            });
+        await Promise.resolve();
+        resetTimingBuffer();
+        elm.shadowRoot.querySelector('x-child').changeLabel(); // Mutate child's value before parent turns off the branch containing x-child
+        elm.flag = false; // turn off the branch
+        await Promise.resolve();
+        verifySlotContent(elm, []);
+        // Prior to the bug fix, there would be one additional 'slotted:renderedCallback' entry(the leaked element)
+        expect(window.timingBuffer).toEqual(['parent:renderedCallback']);
     });
 });

--- a/packages/@lwc/integration-not-karma/test/light-dom/scoped-styles/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/light-dom/scoped-styles/index.spec.js
@@ -26,7 +26,7 @@ describe('Light DOM scoped CSS', () => {
         expect(otherComputed.marginRight).toEqual('5px');
     });
 
-    it('should replace scoped styles correctly with dynamic templates', () => {
+    it('should replace scoped styles correctly with dynamic templates', async () => {
         const elm = createElement('x-switchable', { is: Switchable });
 
         document.body.appendChild(elm);
@@ -37,23 +37,17 @@ describe('Light DOM scoped CSS', () => {
         expect(getComputedStyle(elm).marginLeft).toEqual('0px');
         expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(0, 0, 0)');
         elm.next();
-        return rafPromise()
-            .then(() => {
-                expect(getComputedStyle(elm).marginLeft).toEqual('20px');
-                expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(255, 0, 0)');
-                elm.next();
-                return rafPromise();
-            })
-            .then(() => {
-                expect(getComputedStyle(elm).marginLeft).toEqual('0px');
-                expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(0, 0, 0)');
-                elm.next();
-                return rafPromise();
-            })
-            .then(() => {
-                expect(getComputedStyle(elm).marginLeft).toEqual('30px');
-                expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(0, 0, 255)');
-            });
+        await rafPromise();
+        expect(getComputedStyle(elm).marginLeft).toEqual('20px');
+        expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(255, 0, 0)');
+        elm.next();
+        await rafPromise();
+        expect(getComputedStyle(elm).marginLeft).toEqual('0px');
+        expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(0, 0, 0)');
+        elm.next();
+        await rafPromise();
+        expect(getComputedStyle(elm).marginLeft).toEqual('30px');
+        expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(0, 0, 255)');
     });
 
     it('only applies styling tokens if scoped styles are present', () => {

--- a/packages/@lwc/integration-not-karma/test/misc/performance-timing/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/misc/performance-timing/index.spec.js
@@ -21,16 +21,15 @@ function testConstructor(expected) {
 }
 
 function testRerender(expected) {
-    it('component rerender', () => {
+    it('component rerender', async () => {
         const elm = createElement('x-child', { is: Child });
         document.body.appendChild(elm);
 
         resetMeasures();
         elm.value = 1;
 
-        return Promise.resolve().then(() => {
-            expectMeasureEquals(expected);
-        });
+        await Promise.resolve();
+        expectMeasureEquals(expected);
     });
 }
 
@@ -44,16 +43,15 @@ function testNestedTree(expected) {
 }
 
 function testNestedRerender(expected) {
-    it('captures component nested component tree rerender', () => {
+    it('captures component nested component tree rerender', async () => {
         const elm = createElement('x-parent', { is: Parent });
         document.body.appendChild(elm);
 
         resetMeasures();
         elm.value = 1;
 
-        return Promise.resolve().then(() => {
-            expectMeasureEquals(expected);
-        });
+        await Promise.resolve();
+        expectMeasureEquals(expected);
     });
 }
 

--- a/packages/@lwc/integration-not-karma/test/mixed-shadow-mode/composed-path/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/mixed-shadow-mode/composed-path/index.spec.js
@@ -3,43 +3,39 @@ import Test from 'x/test';
 import { jasmine } from '../../../helpers/jasmine.js';
 
 describe('event.composedPath() of event dispatched from closed shadow root', () => {
-    it('should have shadowed elements when invoked inside the shadow root', () => {
+    it('should have shadowed elements when invoked inside the shadow root', async () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            elm.clickShadowedButton();
-
-            expect(elm.getShadowedComposedPath()).toEqual([
-                jasmine.any(HTMLElement), // button
-                jasmine.any(Object), // #shadow-root(closed)
-                elm.child,
-                elm.shadowRoot,
-                elm,
-                document.body,
-                document.documentElement,
-                document,
-                window,
-            ]);
-        });
+        await Promise.resolve();
+        elm.clickShadowedButton();
+        expect(elm.getShadowedComposedPath()).toEqual([
+            jasmine.any(HTMLElement), // button
+            jasmine.any(Object), // #shadow-root(closed)
+            elm.child,
+            elm.shadowRoot,
+            elm,
+            document.body,
+            document.documentElement,
+            document,
+            window,
+        ]);
     });
 
-    it('should not have shadowed elements when invoked outside the shadow root', () => {
+    it('should not have shadowed elements when invoked outside the shadow root', async () => {
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            elm.clickShadowedButton();
-
-            expect(elm.getComposedPath()).toEqual([
-                elm.child,
-                elm.shadowRoot,
-                elm,
-                document.body,
-                document.documentElement,
-                document,
-                window,
-            ]);
-        });
+        await Promise.resolve();
+        elm.clickShadowedButton();
+        expect(elm.getComposedPath()).toEqual([
+            elm.child,
+            elm.shadowRoot,
+            elm,
+            document.body,
+            document.documentElement,
+            document,
+            window,
+        ]);
     });
 });

--- a/packages/@lwc/integration-not-karma/test/mixed-shadow-mode/retargeting/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/mixed-shadow-mode/retargeting/index.spec.js
@@ -2,18 +2,16 @@ import { createElement } from 'lwc';
 import SyntheticParent from 'x/syntheticParent';
 
 function testSelector(name, selector) {
-    it(name, () => {
+    it(name, async () => {
         const elm = createElement('x-synthetic-parent', { is: SyntheticParent });
         document.body.appendChild(elm);
-        return Promise.resolve().then(() => {
-            let target;
-            elm.addEventListener('click', (event) => {
-                target = event.target;
-            });
-            elm.shadowRoot.querySelector(selector).click();
-
-            expect(target).toBe(elm);
+        await Promise.resolve();
+        let target;
+        elm.addEventListener('click', (event) => {
+            target = event.target;
         });
+        elm.shadowRoot.querySelector(selector).click();
+        expect(target).toBe(elm);
     });
 }
 

--- a/packages/@lwc/integration-not-karma/test/native-shadow/force-shadow-migrate-mode/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/native-shadow/force-shadow-migrate-mode/index.spec.js
@@ -3,9 +3,10 @@ import Native from 'x/native';
 import Synthetic from 'x/synthetic';
 import StyledLight from 'x/styledLight';
 
-function doubleMicrotask() {
+async function doubleMicrotask() {
     // wait for applyShadowMigrateMode()
-    return Promise.resolve().then(() => Promise.resolve());
+    await Promise.resolve();
+    return await Promise.resolve();
 }
 
 function isActuallyNativeShadow(shadowRoot) {

--- a/packages/@lwc/integration-not-karma/test/polyfills/document-properties/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/polyfills/document-properties/index.spec.js
@@ -39,25 +39,24 @@ describe('should not provide access to elements inside shadow tree', () => {
 });
 
 describe('dynamic nodes', () => {
-    it('if parent node has lwc:dom="manual", child node is not accessible', () => {
+    it('if parent node has lwc:dom="manual", child node is not accessible', async () => {
         const elm = createElement('x-test-with-lwc-dom-manual', { is: XWithLwcDomManual });
         document.body.appendChild(elm);
         const span = document.createElement('span');
         span.classList.add('manual-span');
         const div = elm.shadowRoot.querySelector('div');
         div.appendChild(span);
-        return new Promise((resolve) => {
+        await new Promise((resolve) => {
             setTimeout(resolve);
-        }).then(() => {
-            expect(document.querySelector('span.manual-span')).toBe(null);
         });
+        expect(document.querySelector('span.manual-span')).toBe(null);
     });
     // TODO [#1252]: old behavior that is still used by some pieces of the platform
     // that is only useful in synthetic mode where elements inserted manually without lwc:dom="manual"
     // are still considered global elements
     it.skipIf(process.env.NATIVE_SHADOW)(
         'if parent node does not have lwc:dom="manual", child node is accessible',
-        () => {
+        async () => {
             const elm = createElement('x-test', { is: XTest });
             document.body.appendChild(elm);
             spyOn(console, 'warn'); // ignore warning about manipulating node without lwc:dom="manual
@@ -66,11 +65,10 @@ describe('dynamic nodes', () => {
             h2.classList.add('manual-h2');
             const div = elm.shadowRoot.querySelector('.in-the-shadow');
             div.appendChild(h2);
-            return new Promise((resolve) => {
+            await new Promise((resolve) => {
                 setTimeout(resolve);
-            }).then(() => {
-                expect(document.querySelector('h2.manual-h2')).toBe(h2);
             });
+            expect(document.querySelector('h2.manual-h2')).toBe(h2);
         }
     );
 });

--- a/packages/@lwc/integration-not-karma/test/reactivity/render/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/reactivity/render/index.spec.js
@@ -2,7 +2,7 @@ import { createElement } from 'lwc';
 
 import Test from 'x/test';
 
-it('computes reactivity graph per render cycle', () => {
+it('computes reactivity graph per render cycle', async () => {
     const elm = createElement('x-test', { is: Test });
     elm.dynamicValue = 1;
     elm.renderDynamic = false;
@@ -12,35 +12,25 @@ it('computes reactivity graph per render cycle', () => {
 
     // Updating dynamic value if it is not part of the template should not trigger a rerender.
     elm.dynamicValue = 2;
-    return Promise.resolve()
-        .then(() => {
-            expect(elm.getRenderCount()).toBe(1);
-
-            // Toggling the visibility should trigger a rerender.
-            elm.dynamicValue = 3;
-            elm.renderDynamic = true;
-        })
-        .then(() => {
-            expect(elm.getRenderCount()).toBe(2);
-
-            // The dynamic value is rendered so updating it trigger a rerender.
-            elm.dynamicValue = 4;
-        })
-        .then(() => {
-            expect(elm.getRenderCount()).toBe(3);
-
-            // Toggling the visibility should trigger a rerender.
-            elm.dynamicValue = 5;
-            elm.renderDynamic = false;
-        })
-        .then(() => {
-            expect(elm.getRenderCount()).toBe(4);
-
-            // Now that the dynamic value is not rendered any more updating the value should not
-            // trigger a render cycle.
-            elm.dynamicValue = 6;
-        })
-        .then(() => {
-            expect(elm.getRenderCount()).toBe(4);
-        });
+    await Promise.resolve();
+    expect(elm.getRenderCount()).toBe(1);
+    // Toggling the visibility should trigger a rerender.
+    elm.dynamicValue = 3;
+    elm.renderDynamic = true;
+    await Promise.resolve();
+    expect(elm.getRenderCount()).toBe(2);
+    // The dynamic value is rendered so updating it trigger a rerender.
+    elm.dynamicValue = 4;
+    await Promise.resolve();
+    expect(elm.getRenderCount()).toBe(3);
+    // Toggling the visibility should trigger a rerender.
+    elm.dynamicValue = 5;
+    elm.renderDynamic = false;
+    await Promise.resolve();
+    expect(elm.getRenderCount()).toBe(4);
+    // Now that the dynamic value is not rendered any more updating the value should not
+    // trigger a render cycle.
+    elm.dynamicValue = 6;
+    await Promise.resolve();
+    expect(elm.getRenderCount()).toBe(4);
 });

--- a/packages/@lwc/integration-not-karma/test/rendering/callback-invocation-order/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/callback-invocation-order/index.spec.js
@@ -164,7 +164,7 @@ for (const { tagName, ctor, connect, disconnect } of fixtures) {
     });
 }
 
-it('should invoke callbacks on the right order (issue #1199 and #1198)', () => {
+it('should invoke callbacks on the right order (issue #1199 and #1198)', async () => {
     const elm = createElement('x-toggle-container', { is: ToggleContainer });
 
     document.body.appendChild(elm);
@@ -203,32 +203,31 @@ it('should invoke callbacks on the right order (issue #1199 and #1198)', () => {
     resetTimingBuffer();
 
     elm.hide = true;
-    return Promise.resolve().then(() => {
-        expect(window.timingBuffer).toEqual(
-            !lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
-                ? [
-                      'shadowContainer:disconnectedCallback',
-                      'leaf:after-slot:disconnectedCallback',
-                      'leaf:before-slot:disconnectedCallback',
-                      'parent:a:disconnectedCallback',
-                      'leaf:a:disconnectedCallback',
-                      'parent:b:disconnectedCallback',
-                      'leaf:b:disconnectedCallback',
-                  ]
-                : [
-                      'shadowContainer:disconnectedCallback',
-                      'leaf:after-slot:disconnectedCallback',
-                      'leaf:before-slot:disconnectedCallback',
-                      'parent:a:disconnectedCallback',
-                      'leaf:a:disconnectedCallback',
-                      'parent:b:disconnectedCallback',
-                      'leaf:b:disconnectedCallback',
-                  ]
-        );
-    });
+    await Promise.resolve();
+    expect(window.timingBuffer).toEqual(
+        !lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
+            ? [
+                  'shadowContainer:disconnectedCallback',
+                  'leaf:after-slot:disconnectedCallback',
+                  'leaf:before-slot:disconnectedCallback',
+                  'parent:a:disconnectedCallback',
+                  'leaf:a:disconnectedCallback',
+                  'parent:b:disconnectedCallback',
+                  'leaf:b:disconnectedCallback',
+              ]
+            : [
+                  'shadowContainer:disconnectedCallback',
+                  'leaf:after-slot:disconnectedCallback',
+                  'leaf:before-slot:disconnectedCallback',
+                  'parent:a:disconnectedCallback',
+                  'leaf:a:disconnectedCallback',
+                  'parent:b:disconnectedCallback',
+                  'leaf:b:disconnectedCallback',
+              ]
+    );
 });
 
-it('should invoke callbacks on the right order when multiple templates are used with lwc:if', () => {
+it('should invoke callbacks on the right order when multiple templates are used with lwc:if', async () => {
     const elm = createElement('x-multi-template-conditionals', { is: MultiTemplateConditionals });
     elm.show = true;
     document.body.appendChild(elm);
@@ -246,54 +245,51 @@ it('should invoke callbacks on the right order when multiple templates are used 
     resetTimingBuffer();
     elm.next();
 
-    return Promise.resolve()
-        .then(() => {
-            // disconnect x-shadow-parent +
-            // connect x-shadow-container with 2 parents, 'a' and 'b'
-            expect(window.timingBuffer).toEqual(
-                !lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
-                    ? [
-                          'leaf:T1-1:disconnectedCallback',
-                          'leaf:T1-2:disconnectedCallback',
-                          'leaf:T1-3:disconnectedCallback',
-                          'leaf:T1-4:disconnectedCallback',
-                          'leaf:T1-5:disconnectedCallback',
-                          'leaf:T1-6:disconnectedCallback',
-                          'leaf:T2-1:connectedCallback',
-                          'leaf:T2-2:connectedCallback',
-                          'leaf:T2-3:connectedCallback',
-                          'leaf:T2-4:connectedCallback',
-                          'leaf:T2-5:connectedCallback',
-                          'leaf:T2-6:connectedCallback',
-                      ]
-                    : [
-                          'leaf:T1-6:disconnectedCallback',
-                          'leaf:T1-5:disconnectedCallback',
-                          'leaf:T1-4:disconnectedCallback',
-                          'leaf:T1-3:disconnectedCallback',
-                          'leaf:T1-2:disconnectedCallback',
-                          'leaf:T1-1:disconnectedCallback',
-                          'leaf:T2-1:connectedCallback',
-                          'leaf:T2-2:connectedCallback',
-                          'leaf:T2-3:connectedCallback',
-                          'leaf:T2-4:connectedCallback',
-                          'leaf:T2-5:connectedCallback',
-                          'leaf:T2-6:connectedCallback',
-                      ]
-            );
-            resetTimingBuffer();
-            elm.show = false;
-        })
-        .then(() => {
-            expect(window.timingBuffer).toEqual([
-                'leaf:T2-1:disconnectedCallback',
-                'leaf:T2-2:disconnectedCallback',
-                'leaf:T2-3:disconnectedCallback',
-                'leaf:T2-4:disconnectedCallback',
-                'leaf:T2-5:disconnectedCallback',
-                'leaf:T2-6:disconnectedCallback',
-            ]);
-        });
+    await Promise.resolve();
+    // disconnect x-shadow-parent +
+    // connect x-shadow-container with 2 parents, 'a' and 'b'
+    expect(window.timingBuffer).toEqual(
+        !lwcRuntimeFlags.DISABLE_NATIVE_CUSTOM_ELEMENT_LIFECYCLE
+            ? [
+                  'leaf:T1-1:disconnectedCallback',
+                  'leaf:T1-2:disconnectedCallback',
+                  'leaf:T1-3:disconnectedCallback',
+                  'leaf:T1-4:disconnectedCallback',
+                  'leaf:T1-5:disconnectedCallback',
+                  'leaf:T1-6:disconnectedCallback',
+                  'leaf:T2-1:connectedCallback',
+                  'leaf:T2-2:connectedCallback',
+                  'leaf:T2-3:connectedCallback',
+                  'leaf:T2-4:connectedCallback',
+                  'leaf:T2-5:connectedCallback',
+                  'leaf:T2-6:connectedCallback',
+              ]
+            : [
+                  'leaf:T1-6:disconnectedCallback',
+                  'leaf:T1-5:disconnectedCallback',
+                  'leaf:T1-4:disconnectedCallback',
+                  'leaf:T1-3:disconnectedCallback',
+                  'leaf:T1-2:disconnectedCallback',
+                  'leaf:T1-1:disconnectedCallback',
+                  'leaf:T2-1:connectedCallback',
+                  'leaf:T2-2:connectedCallback',
+                  'leaf:T2-3:connectedCallback',
+                  'leaf:T2-4:connectedCallback',
+                  'leaf:T2-5:connectedCallback',
+                  'leaf:T2-6:connectedCallback',
+              ]
+    );
+    resetTimingBuffer();
+    elm.show = false;
+    await Promise.resolve();
+    expect(window.timingBuffer).toEqual([
+        'leaf:T2-1:disconnectedCallback',
+        'leaf:T2-2:disconnectedCallback',
+        'leaf:T2-3:disconnectedCallback',
+        'leaf:T2-4:disconnectedCallback',
+        'leaf:T2-5:disconnectedCallback',
+        'leaf:T2-6:disconnectedCallback',
+    ]);
 });
 
 describe('regression test (#3827)', () => {

--- a/packages/@lwc/integration-not-karma/test/rendering/duplicate-text-rendering/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/duplicate-text-rendering/index.spec.js
@@ -2,21 +2,18 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Dynamic text nodes rendering duplicate text', () => {
-    it('should not render duplicate text', function () {
+    it('should not render duplicate text', async () => {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 
         elm.click();
 
-        return Promise.resolve().then(() => {
-            const textInFirstCheck = elm.shadowRoot.textContent;
-            // This first check is to verify that there is no extra text an any moment.
-            expect(textInFirstCheck).not.toBe('ab');
-
-            return Promise.resolve().then(() => {
-                const textInFirstCheck = elm.shadowRoot.textContent;
-                expect(textInFirstCheck).toBe('b');
-            });
-        });
+        await Promise.resolve();
+        const textInFirstCheck = elm.shadowRoot.textContent;
+        // This first check is to verify that there is no extra text an any moment.
+        expect(textInFirstCheck).not.toBe('ab');
+        await Promise.resolve();
+        const textInFirstCheck_1 = elm.shadowRoot.textContent;
+        expect(textInFirstCheck_1).toBe('b');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/rendering/dynamic-childrens-inside-if/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/dynamic-childrens-inside-if/index.spec.js
@@ -4,70 +4,58 @@ import LwcDynamic from 'x/lwcDynamic';
 import Dynamic from 'x/dynamic';
 
 describe('for:each', () => {
-    it('should remove/add elements when if is toggled', function () {
+    it('should remove/add elements when if is toggled', async () => {
         const elm = createElement('x-container', { is: ForEachCmp });
         document.body.appendChild(elm);
         const divWithChildrenWrappedByIf = elm.shadowRoot.querySelector('div');
 
         elm.shadowRoot.querySelector('button').click();
 
-        return Promise.resolve()
-            .then(() => {
-                expect(divWithChildrenWrappedByIf.textContent).toBe('item 1item 2');
-                elm.shadowRoot.querySelector('button').click();
-            })
-            .then(() => {
-                expect(divWithChildrenWrappedByIf.textContent).toBe('');
-                elm.shadowRoot.querySelector('button').click();
-            })
-            .then(() => {
-                expect(divWithChildrenWrappedByIf.textContent).toBe('item 1item 2');
-            });
+        await Promise.resolve();
+        expect(divWithChildrenWrappedByIf.textContent).toBe('item 1item 2');
+        elm.shadowRoot.querySelector('button').click();
+        await Promise.resolve();
+        expect(divWithChildrenWrappedByIf.textContent).toBe('');
+        elm.shadowRoot.querySelector('button').click();
+        await Promise.resolve();
+        expect(divWithChildrenWrappedByIf.textContent).toBe('item 1item 2');
     });
 });
 
 describe('lwc:dynamic', () => {
-    it('should remove/add elements when if is toggled', function () {
+    it('should remove/add elements when if is toggled', async () => {
         const elm = createElement('x-container', { is: LwcDynamic });
         document.body.appendChild(elm);
 
         const divWithChildrenWrappedByIf = elm.shadowRoot.querySelector('div');
         elm.shadowRoot.querySelector('button').click();
 
-        return Promise.resolve()
-            .then(() => {
-                expect(divWithChildrenWrappedByIf.textContent).toBe('item');
-                elm.shadowRoot.querySelector('button').click();
-            })
-            .then(() => {
-                expect(divWithChildrenWrappedByIf.textContent).toBe('');
-                elm.shadowRoot.querySelector('button').click();
-            })
-            .then(() => {
-                expect(divWithChildrenWrappedByIf.textContent).toBe('item');
-            });
+        await Promise.resolve();
+        expect(divWithChildrenWrappedByIf.textContent).toBe('item');
+        elm.shadowRoot.querySelector('button').click();
+        await Promise.resolve();
+        expect(divWithChildrenWrappedByIf.textContent).toBe('');
+        elm.shadowRoot.querySelector('button').click();
+        await Promise.resolve();
+        expect(divWithChildrenWrappedByIf.textContent).toBe('item');
     });
 });
 
 describe('dynamic components', () => {
-    it('should remove/add elements when if is toggled', function () {
+    it('should remove/add elements when if is toggled', async () => {
         const elm = createElement('x-container', { is: Dynamic });
         document.body.appendChild(elm);
 
         const divWithChildrenWrappedByIf = elm.shadowRoot.querySelector('div');
         elm.shadowRoot.querySelector('button').click();
 
-        return Promise.resolve()
-            .then(() => {
-                expect(divWithChildrenWrappedByIf.textContent).toBe('item');
-                elm.shadowRoot.querySelector('button').click();
-            })
-            .then(() => {
-                expect(divWithChildrenWrappedByIf.textContent).toBe('');
-                elm.shadowRoot.querySelector('button').click();
-            })
-            .then(() => {
-                expect(divWithChildrenWrappedByIf.textContent).toBe('item');
-            });
+        await Promise.resolve();
+        expect(divWithChildrenWrappedByIf.textContent).toBe('item');
+        elm.shadowRoot.querySelector('button').click();
+        await Promise.resolve();
+        expect(divWithChildrenWrappedByIf.textContent).toBe('');
+        elm.shadowRoot.querySelector('button').click();
+        await Promise.resolve();
+        expect(divWithChildrenWrappedByIf.textContent).toBe('item');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/rendering/element-orders/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/element-orders/index.spec.js
@@ -5,55 +5,51 @@ import WithEach from 'x/withEach';
 import WithDynamic from 'x/withDynamic';
 
 describe('updateDynamicChildren diffing algo', () => {
-    it('should render slot default elements in correct order', function () {
+    it('should render slot default elements in correct order', async function () {
         const elm = createElement('x-slot-fallback', { is: SlotFallback });
         document.body.appendChild(elm);
 
         expect(elm.shadowRoot.textContent).toBe('25');
         elm.triggerDiffingAlgo();
 
-        return Promise.resolve().then(() => {
-            const content = elm.shadowRoot.textContent;
-            expect(content).toBe('1235');
-        });
+        await Promise.resolve();
+        const content = elm.shadowRoot.textContent;
+        expect(content).toBe('1235');
     });
 
-    it('should render template with foreach in correct order', function () {
+    it('should render template with foreach in correct order', async function () {
         const elm = createElement('x-with-each', { is: WithEach });
         document.body.appendChild(elm);
 
         expect(elm.shadowRoot.textContent).toBe('25');
         elm.triggerDiffingAlgo();
 
-        return Promise.resolve().then(() => {
-            const content = elm.shadowRoot.textContent;
-            expect(content).toBe('1235');
-        });
+        await Promise.resolve();
+        const content = elm.shadowRoot.textContent;
+        expect(content).toBe('1235');
     });
 
-    it('should render template with dynamic component in correct order using lwc:dynamic', function () {
+    it('should render template with dynamic component in correct order using lwc:dynamic', async function () {
         const elm = createElement('x-with-dynamic', { is: WithLwcDynamic });
         document.body.appendChild(elm);
 
         expect(elm.shadowRoot.textContent).toBe('25');
         elm.triggerDiffingAlgo();
 
-        return Promise.resolve().then(() => {
-            const content = elm.shadowRoot.textContent;
-            expect(content).toBe('1235');
-        });
+        await Promise.resolve();
+        const content = elm.shadowRoot.textContent;
+        expect(content).toBe('1235');
     });
 
-    it('should render template with dynamic component in correct order', function () {
+    it('should render template with dynamic component in correct order', async () => {
         const elm = createElement('x-with-dynamic', { is: WithDynamic });
         document.body.appendChild(elm);
 
         expect(elm.shadowRoot.textContent).toBe('25');
         elm.triggerDiffingAlgo();
 
-        return Promise.resolve().then(() => {
-            const content = elm.shadowRoot.textContent;
-            expect(content).toBe('1235');
-        });
+        await Promise.resolve();
+        const content = elm.shadowRoot.textContent;
+        expect(content).toBe('1235');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/rendering/elements-are-not-recycled/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/elements-are-not-recycled/index.spec.js
@@ -7,61 +7,54 @@ import Container from 'x/container';
 // In the synthetic shadow however, slot content will be not be present in the DOM when not rendered.
 
 describe('custom elements', () => {
-    it('should not be reused when slotted', function () {
+    it('should not be reused when slotted', async () => {
         const elm = createElement('x-container', { is: Container });
         elm.isCustomElement = true;
         document.body.appendChild(elm);
 
         const child = elm.shadowRoot.querySelector('x-child');
-        let firstRenderCustomElement;
 
-        return Promise.resolve()
-            .then(() => (child.open = true))
-            .then(() => {
-                firstRenderCustomElement = elm.shadowRoot.querySelector('x-simple');
-                child.open = false;
-            })
-            .then(() => (child.open = true))
-            .then(() => {
-                const xSimple = elm.shadowRoot.querySelector('x-simple');
-
-                expect(xSimple).not.toBeNull();
-                expect(xSimple.assignedSlot).not.toBeNull();
-                expect(elm.shadowRoot.querySelector('.mark')).not.toBeNull();
-
-                if (!process.env.NATIVE_SHADOW) {
-                    expect(xSimple).not.toBe(firstRenderCustomElement);
-                }
-            });
+        await Promise.resolve();
+        child.open = true;
+        await Promise.resolve();
+        const firstRenderCustomElement = elm.shadowRoot.querySelector('x-simple');
+        child.open = false;
+        await Promise.resolve();
+        child.open = true;
+        await Promise.resolve();
+        const xSimple = elm.shadowRoot.querySelector('x-simple');
+        expect(xSimple).not.toBeNull();
+        expect(xSimple.assignedSlot).not.toBeNull();
+        expect(elm.shadowRoot.querySelector('.mark')).not.toBeNull();
+        if (!process.env.NATIVE_SHADOW) {
+            expect(xSimple).not.toBe(firstRenderCustomElement);
+        }
     });
 });
 
 describe('elements', () => {
-    it.skipIf(process.env.NATIVE_SHADOW)('should not be reused when slotted', function () {
+    it.skipIf(process.env.NATIVE_SHADOW)('should not be reused when slotted', async () => {
         const elm = createElement('x-container', { is: Container });
         elm.isElement = true;
         document.body.appendChild(elm);
 
         const child = elm.shadowRoot.querySelector('x-child');
-        let firstRenderElement;
 
-        return Promise.resolve()
-            .then(() => (child.open = true))
-            .then(() => {
-                firstRenderElement = elm.shadowRoot.querySelector('button');
-                child.open = false;
-            })
-            .then(() => (child.open = true))
-            .then(() => {
-                const btnElement = elm.shadowRoot.querySelector('button');
-
-                expect(btnElement).not.toBeNull();
-                expect(btnElement.assignedSlot).not.toBeNull();
-                expect(btnElement).not.toBe(firstRenderElement);
-            });
+        await Promise.resolve();
+        child.open = true;
+        await Promise.resolve();
+        const firstRenderElement = elm.shadowRoot.querySelector('button');
+        child.open = false;
+        await Promise.resolve();
+        child.open = true;
+        await Promise.resolve();
+        const btnElement = elm.shadowRoot.querySelector('button');
+        expect(btnElement).not.toBeNull();
+        expect(btnElement.assignedSlot).not.toBeNull();
+        expect(btnElement).not.toBe(firstRenderElement);
     });
 
-    it('should not add listener multiple times', function () {
+    it('should not add listener multiple times', async () => {
         const elm = createElement('x-container', { is: Container });
         elm.isElement = true;
         document.body.appendChild(elm);
@@ -70,49 +63,41 @@ describe('elements', () => {
 
         const child = elm.shadowRoot.querySelector('x-child');
 
-        return Promise.resolve()
-            .then(() => (child.open = true))
-            .then(() => {
-                const btnElement = elm.shadowRoot.querySelector('button');
-
-                listenerCalledTimes = 0;
-                btnElement.click();
-                expect(listenerCalledTimes).toBe(1);
-
-                child.open = false;
-            })
-            .then(() => (child.open = true))
-            .then(() => {
-                const btnElement = elm.shadowRoot.querySelector('button');
-
-                listenerCalledTimes = 0;
-                btnElement.click();
-                expect(listenerCalledTimes).toBe(1);
-            });
+        await Promise.resolve();
+        child.open = true;
+        await Promise.resolve();
+        const btnElement = elm.shadowRoot.querySelector('button');
+        listenerCalledTimes = 0;
+        btnElement.click();
+        expect(listenerCalledTimes).toBe(1);
+        child.open = false;
+        await Promise.resolve();
+        child.open = true;
+        await Promise.resolve();
+        const btnElement_1 = elm.shadowRoot.querySelector('button');
+        listenerCalledTimes = 0;
+        btnElement_1.click();
+        expect(listenerCalledTimes).toBe(1);
     });
 });
 
 it.runIf(process.env.NATIVE_SHADOW)(
     'should render same styles for custom element instances',
-    function () {
+    async () => {
         const elm = createElement('x-container', { is: Container });
         elm.isStyleCheck = true;
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const styles = Array.from(elm.shadowRoot.querySelectorAll('x-simple')).map(
-                (xSimple) => {
-                    // If constructable stylesheets are supported, return that rather than <style> tags
-                    // In Chrome 99+, adoptedStyleSheets is a proxy, so we have to clone it to compare
-                    return xSimple.shadowRoot.adoptedStyleSheets
-                        ? [...xSimple.shadowRoot.adoptedStyleSheets]
-                        : xSimple.shadowRoot.querySelector('style');
-                }
-            );
-
-            expect(styles[0]).toBeTruthy();
-            expect(styles[0]).toEqual(styles[1]);
-            expect(styles[1]).toEqual(styles[2]);
+        await Promise.resolve();
+        const styles = Array.from(elm.shadowRoot.querySelectorAll('x-simple')).map((xSimple) => {
+            // If constructable stylesheets are supported, return that rather than <style> tags
+            // In Chrome 99+, adoptedStyleSheets is a proxy, so we have to clone it to compare
+            return xSimple.shadowRoot.adoptedStyleSheets
+                ? [...xSimple.shadowRoot.adoptedStyleSheets]
+                : xSimple.shadowRoot.querySelector('style');
         });
+        expect(styles[0]).toBeTruthy();
+        expect(styles[0]).toEqual(styles[1]);
+        expect(styles[1]).toEqual(styles[2]);
     }
 );

--- a/packages/@lwc/integration-not-karma/test/rendering/form-tag/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/form-tag/index.spec.js
@@ -2,15 +2,13 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Form tag rendering', () => {
-    it('should have the right value', function () {
+    it('should have the right value', async () => {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const nodeWithTextInsideForm = elm.shadowRoot.querySelector('.form-text');
-
-            expect(nodeWithTextInsideForm).not.toBeNull();
-            expect(nodeWithTextInsideForm.textContent).toBe('Form did render');
-        });
+        await Promise.resolve();
+        const nodeWithTextInsideForm = elm.shadowRoot.querySelector('.form-text');
+        expect(nodeWithTextInsideForm).not.toBeNull();
+        expect(nodeWithTextInsideForm.textContent).toBe('Form did render');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/rendering/if-inside-custom-render/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/if-inside-custom-render/index.spec.js
@@ -2,13 +2,12 @@ import { createElement } from 'lwc';
 import CustomRender from 'x/customRender';
 
 describe('using custom renderer with lwc:if', () => {
-    it('should replace the entire template when switching templates in a custom render function', async function () {
+    it('should replace the entire template when switching templates in a custom render function', async () => {
         const elm = createElement('x-custom-render', { is: CustomRender });
         document.body.appendChild(elm);
         elm.next();
 
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.textContent).toBe('TEMPLATE 2T2 nested 1T2 nested 2');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.textContent).toBe('TEMPLATE 2T2 nested 1T2 nested 2');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/rendering/iteration/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/iteration/index.spec.js
@@ -51,7 +51,7 @@ describe('iteration rendering', () => {
     components.forEach(({ Ctor, type, iterationType }) => {
         const tag = `x-${type}-${iterationType}`;
 
-        it(`${type} ${iterationType}`, () => {
+        it(`${type} ${iterationType}`, async () => {
             const elm = createElement(tag, { is: Ctor });
             elm.items = [1, 2, 3, 4];
             document.body.appendChild(elm);
@@ -59,14 +59,13 @@ describe('iteration rendering', () => {
             const [c1, c2, c3, c4] = elm.shadowRoot.querySelectorAll('x-item');
 
             elm.items = [3, 1, 2, 4];
-            return Promise.resolve().then(() => {
-                validateRenderedChildren(elm, iterationType);
-                const [c3b, c1b, c2b, c4b] = elm.shadowRoot.querySelectorAll('x-item');
-                expect(c1).toBe(c1b);
-                expect(c2).toBe(c2b);
-                expect(c3).toBe(c3b);
-                expect(c4).toBe(c4b);
-            });
+            await Promise.resolve();
+            validateRenderedChildren(elm, iterationType);
+            const [c3b, c1b, c2b, c4b] = elm.shadowRoot.querySelectorAll('x-item');
+            expect(c1).toBe(c1b);
+            expect(c2).toBe(c2b);
+            expect(c3).toBe(c3b);
+            expect(c4).toBe(c4b);
         });
     });
 });

--- a/packages/@lwc/integration-not-karma/test/rendering/key-outside-iteration/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/key-outside-iteration/index.spec.js
@@ -7,7 +7,7 @@ import ParentWithIfPreceded from 'x/parentWithIfPreceded';
 import ParentWithIfPrecededInverted from 'x/parentWithIfPrecededInverted';
 
 describe('Key outside iteration', () => {
-    it('should work with a key attribute defined outside of an iteration', () => {
+    it('should work with a key attribute defined outside of an iteration', async () => {
         const elm = createElement('x-parent', { is: Parent });
         document.body.appendChild(elm);
 
@@ -16,14 +16,13 @@ describe('Key outside iteration', () => {
         ).toEqual('red');
         elm.color = 'blue';
 
-        return Promise.resolve().then(() => {
-            expect(
-                elm.shadowRoot.querySelector('x-child').shadowRoot.querySelector('div').textContent
-            ).toEqual('blue');
-        });
+        await Promise.resolve();
+        expect(
+            elm.shadowRoot.querySelector('x-child').shadowRoot.querySelector('div').textContent
+        ).toEqual('blue');
     });
 
-    it('dynamic key followed by if - false then true', () => {
+    it('dynamic key followed by if - false then true', async () => {
         const elm = createElement('x-parent-with-if', { is: ParentWithIf });
         document.body.appendChild(elm);
 
@@ -34,16 +33,15 @@ describe('Key outside iteration', () => {
         elm.color = 'blue';
         elm.shown = true;
 
-        return Promise.resolve().then(() => {
-            expect(
-                elm.shadowRoot.querySelector('x-child').shadowRoot.querySelector('div').textContent
-            ).toEqual('blue');
-            expect(elm.shadowRoot.children.length).toEqual(2);
-            expect(elm.shadowRoot.children[1].textContent).toEqual('shown');
-        });
+        await Promise.resolve();
+        expect(
+            elm.shadowRoot.querySelector('x-child').shadowRoot.querySelector('div').textContent
+        ).toEqual('blue');
+        expect(elm.shadowRoot.children.length).toEqual(2);
+        expect(elm.shadowRoot.children[1].textContent).toEqual('shown');
     });
 
-    it('dynamic key followed by if - true then false', () => {
+    it('dynamic key followed by if - true then false', async () => {
         const elm = createElement('x-parent-with-if-inverted', { is: ParentWithIfInverted });
         document.body.appendChild(elm);
 
@@ -55,15 +53,14 @@ describe('Key outside iteration', () => {
         elm.color = 'blue';
         elm.shown = true;
 
-        return Promise.resolve().then(() => {
-            expect(
-                elm.shadowRoot.querySelector('x-child').shadowRoot.querySelector('div').textContent
-            ).toEqual('blue');
-            expect(elm.shadowRoot.children.length).toEqual(1);
-        });
+        await Promise.resolve();
+        expect(
+            elm.shadowRoot.querySelector('x-child').shadowRoot.querySelector('div').textContent
+        ).toEqual('blue');
+        expect(elm.shadowRoot.children.length).toEqual(1);
     });
 
-    it('dynamic key preceded by if - false then true', () => {
+    it('dynamic key preceded by if - false then true', async () => {
         const elm = createElement('x-parent-with-if-preceded', { is: ParentWithIfPreceded });
         document.body.appendChild(elm);
 
@@ -74,16 +71,15 @@ describe('Key outside iteration', () => {
         elm.color = 'blue';
         elm.shown = true;
 
-        return Promise.resolve().then(() => {
-            expect(
-                elm.shadowRoot.querySelector('x-child').shadowRoot.querySelector('div').textContent
-            ).toEqual('blue');
-            expect(elm.shadowRoot.children.length).toEqual(2);
-            expect(elm.shadowRoot.children[0].textContent).toEqual('shown');
-        });
+        await Promise.resolve();
+        expect(
+            elm.shadowRoot.querySelector('x-child').shadowRoot.querySelector('div').textContent
+        ).toEqual('blue');
+        expect(elm.shadowRoot.children.length).toEqual(2);
+        expect(elm.shadowRoot.children[0].textContent).toEqual('shown');
     });
 
-    it('dynamic key preceded by if - true then false', () => {
+    it('dynamic key preceded by if - true then false', async () => {
         const elm = createElement('x-parent-with-if-preceded-inverted', {
             is: ParentWithIfPrecededInverted,
         });
@@ -97,11 +93,10 @@ describe('Key outside iteration', () => {
         elm.color = 'blue';
         elm.shown = true;
 
-        return Promise.resolve().then(() => {
-            expect(
-                elm.shadowRoot.querySelector('x-child').shadowRoot.querySelector('div').textContent
-            ).toEqual('blue');
-            expect(elm.shadowRoot.children.length).toEqual(1);
-        });
+        await Promise.resolve();
+        expect(
+            elm.shadowRoot.querySelector('x-child').shadowRoot.querySelector('div').textContent
+        ).toEqual('blue');
+        expect(elm.shadowRoot.children.length).toEqual(1);
     });
 });

--- a/packages/@lwc/integration-not-karma/test/rendering/nested-state/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/nested-state/index.spec.js
@@ -2,15 +2,13 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Nested state', () => {
-    it('Object keys should have the right value', function () {
+    it('Object keys should have the right value', async () => {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const nodeWithRenderedNestedState = elm.shadowRoot.querySelector('.key');
-
-            expect(nodeWithRenderedNestedState).not.toBeNull();
-            expect(nodeWithRenderedNestedState.textContent).toBe('yes');
-        });
+        await Promise.resolve();
+        const nodeWithRenderedNestedState = elm.shadowRoot.querySelector('.key');
+        expect(nodeWithRenderedNestedState).not.toBeNull();
+        expect(nodeWithRenderedNestedState.textContent).toBe('yes');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/rendering/null-logging/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/null-logging/index.spec.js
@@ -5,16 +5,14 @@ import Container from 'x/container';
  * https://github.com/salesforce/lwc/issues/720
  */
 describe('Issue 720: Wrap all string literal variables with toString method', () => {
-    it('should not have have an error accessing state.foo', function () {
+    it('should not have have an error accessing state.foo', async () => {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const hasError = elm.shadowRoot.querySelector('.has-error');
-            const noError = elm.shadowRoot.querySelector('.no-error');
-
-            expect(hasError).toBeNull();
-            expect(noError).not.toBeNull();
-        });
+        await Promise.resolve();
+        const hasError = elm.shadowRoot.querySelector('.has-error');
+        const noError = elm.shadowRoot.querySelector('.no-error');
+        expect(hasError).toBeNull();
+        expect(noError).not.toBeNull();
     });
 });

--- a/packages/@lwc/integration-not-karma/test/rendering/programmatic-stylesheets/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/programmatic-stylesheets/index.spec.js
@@ -15,121 +15,112 @@ import MixedScopedAndUnscoped from 'x/mixedScopedAndUnscoped';
 import StylesheetsMutation from 'x/stylesheetsMutation';
 
 describe('programmatic stylesheets', () => {
-    it('works for a basic usage of static stylesheets', () => {
+    it('works for a basic usage of static stylesheets', async () => {
         const elm = createElement('x-basic', { is: Basic });
         document.body.appendChild(elm);
         const h1 = document.createElement('h1');
         document.body.appendChild(h1);
 
-        return new Promise((resolve) => requestAnimationFrame(() => resolve())).then(() => {
-            expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
-                'rgb(255, 0, 0)'
-            );
-            // styles do not leak (e.g. synthetic shadow)
-            expect(getComputedStyle(h1).color).toEqual('rgb(0, 0, 0)');
-        });
+        await new Promise(requestAnimationFrame);
+        expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
+            'rgb(255, 0, 0)'
+        );
+        // styles do not leak (e.g. synthetic shadow)
+        expect(getComputedStyle(h1).color).toEqual('rgb(0, 0, 0)');
     });
 
-    it('works for scoped stylesheets in light DOM', () => {
+    it('works for scoped stylesheets in light DOM', async () => {
         const elm = createElement('x-scoped', { is: Scoped });
         document.body.appendChild(elm);
         const h1 = document.createElement('h1');
         document.body.appendChild(h1);
 
-        return new Promise((resolve) => requestAnimationFrame(() => resolve())).then(() => {
-            expect(getComputedStyle(elm.querySelector('h1')).color).toEqual('rgb(0, 128, 0)');
-            // styles do not leak (e.g. synthetic shadow)
-            expect(getComputedStyle(h1).color).toEqual('rgb(0, 0, 0)');
-        });
+        await new Promise(requestAnimationFrame);
+        expect(getComputedStyle(elm.querySelector('h1')).color).toEqual('rgb(0, 128, 0)');
+        // styles do not leak (e.g. synthetic shadow)
+        expect(getComputedStyle(h1).color).toEqual('rgb(0, 0, 0)');
     });
 
-    it('works if you do not wrap stylesheets in an explicit array', () => {
+    it('works if you do not wrap stylesheets in an explicit array', async () => {
         const elm = createElement('x-direct', { is: Direct });
         document.body.appendChild(elm);
 
-        return new Promise((resolve) => requestAnimationFrame(() => resolve())).then(() => {
-            expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
-                'rgb(255, 0, 0)'
-            );
-        });
+        await new Promise(requestAnimationFrame);
+        expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
+            'rgb(255, 0, 0)'
+        );
     });
 
-    it('works with multiple stylesheets', () => {
+    it('works with multiple stylesheets', async () => {
         const elm = createElement('x-multi-styles', { is: MultiStyles });
         document.body.appendChild(elm);
 
-        return new Promise((resolve) => requestAnimationFrame(() => resolve())).then(() => {
-            const style = getComputedStyle(elm.shadowRoot.querySelector('h1'));
-            expect(style.color).toEqual('rgb(255, 0, 0)');
-            expect(style.backgroundColor).toEqual('rgb(0, 128, 0)');
-            expect(style.opacity).toEqual('0');
-            expect(style.display).toEqual('block'); // last style wins
-        });
+        await new Promise(requestAnimationFrame);
+        const style = getComputedStyle(elm.shadowRoot.querySelector('h1'));
+        expect(style.color).toEqual('rgb(255, 0, 0)');
+        expect(style.backgroundColor).toEqual('rgb(0, 128, 0)');
+        expect(style.opacity).toEqual('0');
+        expect(style.display).toEqual('block'); // last style wins
     });
 
-    it('works with mixed scoped and unscoped in light dom', () => {
+    it('works with mixed scoped and unscoped in light dom', async () => {
         const elm = createElement('x-mixed-scoped-and-unscoped', { is: MixedScopedAndUnscoped });
         document.body.appendChild(elm);
         const h1 = document.createElement('h1');
         document.body.appendChild(h1);
 
-        return new Promise((resolve) => requestAnimationFrame(() => resolve())).then(() => {
-            const style = getComputedStyle(elm.querySelector('h1'));
-            expect(style.color).toEqual('rgb(255, 0, 0)');
-            expect(style.backgroundColor).toEqual('rgb(0, 128, 0)');
-            expect(style.opacity).toEqual('0');
-
-            // styles only bleed for the unscoped styles
-            const h1Style = getComputedStyle(h1);
-            expect(h1Style.color).toEqual('rgb(0, 0, 0)');
-            expect(h1Style.backgroundColor).toEqual('rgb(0, 128, 0)');
-            expect(h1Style.opacity).toEqual('0');
-        });
+        await new Promise(requestAnimationFrame);
+        const style = getComputedStyle(elm.querySelector('h1'));
+        expect(style.color).toEqual('rgb(255, 0, 0)');
+        expect(style.backgroundColor).toEqual('rgb(0, 128, 0)');
+        expect(style.opacity).toEqual('0');
+        // styles only bleed for the unscoped styles
+        const h1Style = getComputedStyle(h1);
+        expect(h1Style.color).toEqual('rgb(0, 0, 0)');
+        expect(h1Style.backgroundColor).toEqual('rgb(0, 128, 0)');
+        expect(h1Style.opacity).toEqual('0');
     });
 
     describe('inheritance', () => {
-        it('can attempt to inherit from lightning element which has no stylesheets', () => {
+        it('can attempt to inherit from lightning element which has no stylesheets', async () => {
             const elm = createElement('x-inherit-from-lightning-element', {
                 is: InheritFromLightningElement,
             });
             document.body.appendChild(elm);
 
-            return new Promise((resolve) => requestAnimationFrame(() => resolve())).then(() => {
-                expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
-                    'rgb(255, 0, 0)'
-                );
-            });
+            await new Promise(requestAnimationFrame);
+            expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
+                'rgb(255, 0, 0)'
+            );
         });
 
-        it('can inherit from superclass', () => {
+        it('can inherit from superclass', async () => {
             const elm = createElement('x-inherit', {
                 is: Inherit,
             });
             document.body.appendChild(elm);
 
-            return new Promise((resolve) => requestAnimationFrame(() => resolve())).then(() => {
-                const style = getComputedStyle(elm.shadowRoot.querySelector('h1'));
-                expect(style.color).toEqual('rgb(0, 0, 255)');
-                expect(style.backgroundColor).toEqual('rgb(0, 128, 0)');
-            });
+            await new Promise(requestAnimationFrame);
+            const style = getComputedStyle(elm.shadowRoot.querySelector('h1'));
+            expect(style.color).toEqual('rgb(0, 0, 255)');
+            expect(style.backgroundColor).toEqual('rgb(0, 128, 0)');
         });
 
-        it('can override implicit styles due to ordering', () => {
+        it('can override implicit styles due to ordering', async () => {
             const elm = createElement('x-implicit', {
                 is: Implicit,
             });
             document.body.appendChild(elm);
 
-            return new Promise((resolve) => requestAnimationFrame(() => resolve())).then(() => {
-                expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
-                    'rgb(0, 0, 255)'
-                );
-            });
+            await new Promise(requestAnimationFrame);
+            expect(getComputedStyle(elm.shadowRoot.querySelector('h1')).color).toEqual(
+                'rgb(0, 0, 255)'
+            );
         });
     });
 
     describe('multi-template components', () => {
-        it('can override styles in a multi-template component', () => {
+        it('can override styles in a multi-template component', async () => {
             const elm = createElement('x-multi', {
                 is: Multi,
             });
@@ -142,24 +133,21 @@ describe('programmatic stylesheets', () => {
             // 4. static stylesheet (with B token, if synthetic shadow)
             // In native shadow there are no tokens, so #4 never happens.
 
-            return new Promise((resolve) => requestAnimationFrame(() => resolve()))
-                .then(() => {
-                    const style = getComputedStyle(elm.shadowRoot.querySelector('h1'));
-                    expect(style.color).toEqual('rgb(0, 0, 255)');
-                    expect(style.backgroundColor).toEqual('rgb(255, 215, 0)');
-                    elm.next();
-                })
-                .then(() => {
-                    const style = getComputedStyle(elm.shadowRoot.querySelector('h1'));
-                    // See above note about native vs synthetic shadow
-                    expect(style.color).toEqual(
-                        process.env.NATIVE_SHADOW ? 'rgb(0, 128, 0)' : 'rgb(0, 0, 255)'
-                    );
-                    expect(style.backgroundColor).toEqual('rgb(250, 128, 114)');
-                });
+            await new Promise(requestAnimationFrame);
+            const style = getComputedStyle(elm.shadowRoot.querySelector('h1'));
+            expect(style.color).toEqual('rgb(0, 0, 255)');
+            expect(style.backgroundColor).toEqual('rgb(255, 215, 0)');
+            elm.next();
+            await Promise.resolve();
+            const style_1 = getComputedStyle(elm.shadowRoot.querySelector('h1'));
+            // See above note about native vs synthetic shadow
+            expect(style_1.color).toEqual(
+                process.env.NATIVE_SHADOW ? 'rgb(0, 128, 0)' : 'rgb(0, 0, 255)'
+            );
+            expect(style_1.backgroundColor).toEqual('rgb(250, 128, 114)');
         });
 
-        it('can override scoped styles in a multi-template component', () => {
+        it('can override scoped styles in a multi-template component', async () => {
             const elm = createElement('x-multi-scoped', {
                 is: MultiScoped,
             });
@@ -171,18 +159,15 @@ describe('programmatic stylesheets', () => {
             // 3. B
             // 4. static stylesheet with B token
 
-            return new Promise((resolve) => requestAnimationFrame(() => resolve()))
-                .then(() => {
-                    const style = getComputedStyle(elm.shadowRoot.querySelector('h1'));
-                    expect(style.color).toEqual('rgb(0, 0, 255)');
-                    expect(style.backgroundColor).toEqual('rgb(255, 215, 0)');
-                    elm.next();
-                })
-                .then(() => {
-                    const style = getComputedStyle(elm.shadowRoot.querySelector('h1'));
-                    expect(style.color).toEqual('rgb(0, 0, 255)');
-                    expect(style.backgroundColor).toEqual('rgb(250, 128, 114)');
-                });
+            await new Promise(requestAnimationFrame);
+            const style = getComputedStyle(elm.shadowRoot.querySelector('h1'));
+            expect(style.color).toEqual('rgb(0, 0, 255)');
+            expect(style.backgroundColor).toEqual('rgb(255, 215, 0)');
+            elm.next();
+            await Promise.resolve();
+            const style_1 = getComputedStyle(elm.shadowRoot.querySelector('h1'));
+            expect(style_1.color).toEqual('rgb(0, 0, 255)');
+            expect(style_1.backgroundColor).toEqual('rgb(250, 128, 114)');
         });
     });
 

--- a/packages/@lwc/integration-not-karma/test/rendering/slotted-text-diffing/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/slotted-text-diffing/index.spec.js
@@ -2,23 +2,19 @@ import { createElement } from 'lwc';
 import Container from 'x/container';
 
 describe('Dynamic diffing algo for slotted text', () => {
-    it('should not confuse text vnodes when moving elements', function () {
+    it('should not confuse text vnodes when moving elements', async () => {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
 
         expect(elm.shadowRoot.textContent).toBe('first textDisplay Boolean Value: truesecond text');
         elm.toggleVisibility();
 
-        return Promise.resolve()
-            .then(() => {
-                const text = elm.shadowRoot.textContent;
-                expect(text).toBe('Display Boolean Value: false');
-
-                elm.toggleVisibility();
-            })
-            .then(() => {
-                const text = elm.shadowRoot.textContent;
-                expect(text).toBe('first textDisplay Boolean Value: truesecond text');
-            });
+        await Promise.resolve();
+        const text = elm.shadowRoot.textContent;
+        expect(text).toBe('Display Boolean Value: false');
+        elm.toggleVisibility();
+        await Promise.resolve();
+        const text_1 = elm.shadowRoot.textContent;
+        expect(text_1).toBe('first textDisplay Boolean Value: truesecond text');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/rendering/slotting/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/slotting/index.spec.js
@@ -8,7 +8,7 @@ import UnknownSlotLight from 'x/unknownSlotLight';
 import { spyOn } from '@vitest/spy';
 
 // TODO [#1617]: Engine currently has trouble with slotting and invocation of the renderedCallback.
-xit('should not render if the slotted content changes', () => {
+xit('should not render if the slotted content changes', async () => {
     const elm = createElement('x-render-count-parent', { is: RenderCountParent });
     elm.value = 'initial';
     document.body.appendChild(elm);
@@ -19,11 +19,10 @@ xit('should not render if the slotted content changes', () => {
 
     elm.value = 'updated';
 
-    return Promise.resolve().then(() => {
-        expect(elm.getRenderCount()).toBe(2);
-        expect(elm.shadowRoot.querySelector('x-render-count-child').getRenderCount()).toBe(1);
-        expect(elm.shadowRoot.querySelector('div').textContent).toBe('updated');
-    });
+    await Promise.resolve();
+    expect(elm.getRenderCount()).toBe(2);
+    expect(elm.shadowRoot.querySelector('x-render-count-child').getRenderCount()).toBe(1);
+    expect(elm.shadowRoot.querySelector('div').textContent).toBe('updated');
 });
 
 [
@@ -38,7 +37,7 @@ xit('should not render if the slotted content changes', () => {
         Ctor: FallbackContentReuseDynamicKeyParent,
     },
 ].forEach(({ type, tag, Ctor }) => {
-    it(`#663 - should not reuse elements from the fallback slot content - ${type} key`, () => {
+    it(`#663 - should not reuse elements from the fallback slot content - ${type} key`, async () => {
         const childTag = tag.replace('parent', 'child');
         const elm = createElement(tag, {
             is: Ctor,
@@ -48,11 +47,10 @@ xit('should not render if the slotted content changes', () => {
         expect(elm.shadowRoot.querySelector(childTag).innerHTML).toBe('');
         elm.renderSlotted = true;
 
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector(childTag).innerHTML).toBe(
-                '<div>Default slotted</div><div slot="foo">Named slotted</div>'
-            );
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector(childTag).innerHTML).toBe(
+            '<div>Default slotted</div><div slot="foo">Named slotted</div>'
+        );
     });
 });
 

--- a/packages/@lwc/integration-not-karma/test/rendering/slotting/x/regressionSlot/regressionSlot.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/slotting/x/regressionSlot/regressionSlot.js
@@ -3,11 +3,10 @@ import { LightningElement } from 'lwc';
 export default class FocusTrap extends LightningElement {
     counter = 1;
 
-    handleContentChange() {
-        // trigger rehydration.
-        // triggering the rehydration on the next tick throws.
-        void Promise.resolve().then(() => this.counter++);
-        // triggering the rehydration on this tick is fine:
-        // this.counter++;
+    async handleContentChange() {
+        // this.counter++; // triggering the rehydration on this tick is fine:
+
+        await Promise.resolve(); // trigger rehydration
+        this.counter++; // triggering the rehydration on the next tick throws.
     }
 }

--- a/packages/@lwc/integration-not-karma/test/rendering/stylesheet-caching/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/stylesheet-caching/index.spec.js
@@ -4,16 +4,15 @@ import Shadow from 'x/shadow';
 import Light from 'x/light';
 
 describe('stylesheet caching', () => {
-    it('renders correctly when shadow and light component have identical CSS', () => {
+    it('renders correctly when shadow and light component have identical CSS', async () => {
         const shadow = createElement('x-shadow', { is: Shadow });
         const light = createElement('x-light', { is: Light });
         document.body.appendChild(light);
         document.body.appendChild(shadow);
-        return new Promise((resolve) => requestAnimationFrame(resolve)).then(() => {
-            expect(getComputedStyle(shadow.shadowRoot.querySelector('h1')).color).toEqual(
-                'rgb(255, 0, 255)'
-            );
-            expect(getComputedStyle(light.querySelector('h1')).color).toEqual('rgb(255, 0, 255)');
-        });
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        expect(getComputedStyle(shadow.shadowRoot.querySelector('h1')).color).toEqual(
+            'rgb(255, 0, 255)'
+        );
+        expect(getComputedStyle(light.querySelector('h1')).color).toEqual('rgb(255, 0, 255)');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/rendering/table-diffing/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/rendering/table-diffing/index.spec.js
@@ -11,7 +11,7 @@ describe('Table diffing', () => {
         expect(elm.shadowRoot.querySelectorAll('x-row').length).toBe(3);
     });
 
-    it('should reuse existing component if the data is unchanged', () => {
+    it('should reuse existing component if the data is unchanged', async () => {
         const elm = createElement('x-table', { is: Table });
         elm.rows = [{ id: 0 }, { id: 1 }, { id: 2 }];
         document.body.appendChild(elm);
@@ -19,16 +19,15 @@ describe('Table diffing', () => {
         const [e1, e2, e3] = elm.shadowRoot.querySelectorAll('x-row');
         elm.rows = [...elm.rows, { id: 3 }, { id: 4 }];
 
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelectorAll('x-row').length).toBe(5);
-            const [r1, r2, r3] = elm.shadowRoot.querySelectorAll('x-row');
-            expect(r1).toBe(e1);
-            expect(r2).toBe(e2);
-            expect(r3).toBe(e3);
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelectorAll('x-row').length).toBe(5);
+        const [r1, r2, r3] = elm.shadowRoot.querySelectorAll('x-row');
+        expect(r1).toBe(e1);
+        expect(r2).toBe(e2);
+        expect(r3).toBe(e3);
     });
 
-    it('should reuse the elements when reversing the data', () => {
+    it('should reuse the elements when reversing the data', async () => {
         const data = [{ id: 0 }, { id: 1 }, { id: 2 }];
 
         const elm = createElement('x-table', { is: Table });
@@ -38,16 +37,15 @@ describe('Table diffing', () => {
         const [e1, e2, e3] = elm.shadowRoot.querySelectorAll('x-row');
         elm.rows = [...data].reverse();
 
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelectorAll('x-row').length).toBe(3);
-            const [r1, r2, r3] = elm.shadowRoot.querySelectorAll('x-row');
-            expect(r1).toBe(e3);
-            expect(r2).toBe(e2);
-            expect(r3).toBe(e1);
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelectorAll('x-row').length).toBe(3);
+        const [r1, r2, r3] = elm.shadowRoot.querySelectorAll('x-row');
+        expect(r1).toBe(e3);
+        expect(r2).toBe(e2);
+        expect(r3).toBe(e1);
     });
 
-    it('should reuse the elements when removing and adding data at the beginning and the end', () => {
+    it('should reuse the elements when removing and adding data at the beginning and the end', async () => {
         const elm = createElement('x-table', { is: Table });
         elm.rows = [{ id: 0 }, { id: 1 }, { id: 2 }];
         document.body.appendChild(elm);
@@ -55,15 +53,14 @@ describe('Table diffing', () => {
         const [, e2, e3] = elm.shadowRoot.querySelectorAll('x-row');
         elm.rows = [{ id: 2 }, { id: 1 }, { id: 3 }];
 
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelectorAll('x-row').length).toBe(3);
-            const [r1, r2] = elm.shadowRoot.querySelectorAll('x-row');
-            expect(r1).toBe(e3);
-            expect(r2).toBe(e2);
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelectorAll('x-row').length).toBe(3);
+        const [r1, r2] = elm.shadowRoot.querySelectorAll('x-row');
+        expect(r1).toBe(e3);
+        expect(r2).toBe(e2);
     });
 
-    it('should reuse the elements when moving the end to the start and adding new to the end', () => {
+    it('should reuse the elements when moving the end to the start and adding new to the end', async () => {
         const elm = createElement('x-table', { is: Table });
         elm.rows = [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }];
         document.body.appendChild(elm);
@@ -78,17 +75,16 @@ describe('Table diffing', () => {
         expect(getRowContents()).toEqual([0, 1, 2, 3]);
         elm.rows = [{ id: 3 }, { id: 1 }, { id: 2 }, { id: 4 }];
 
-        return Promise.resolve().then(() => {
-            expect(getRowContents()).toEqual([3, 1, 2, 4]);
-            expect(elm.shadowRoot.querySelectorAll('x-row').length).toBe(4);
-            const [r1, r2, r3] = elm.shadowRoot.querySelectorAll('x-row');
-            expect(r2).toBe(e2);
-            expect(r3).toBe(e3);
-            expect(r1).toBe(e4);
-        });
+        await Promise.resolve();
+        expect(getRowContents()).toEqual([3, 1, 2, 4]);
+        expect(elm.shadowRoot.querySelectorAll('x-row').length).toBe(4);
+        const [r1, r2, r3] = elm.shadowRoot.querySelectorAll('x-row');
+        expect(r2).toBe(e2);
+        expect(r3).toBe(e3);
+        expect(r1).toBe(e4);
     });
 
-    it('sorting a table', () => {
+    it('sorting a table', async () => {
         const elm = createElement('x-table', { is: Table });
         const ids = [0, 9, 1, 5, 2, 3, 8, 4, 6, 7];
         elm.rows = ids.map((id) => ({ id }));
@@ -105,8 +101,7 @@ describe('Table diffing', () => {
 
         elm.rows = sortedIds.map((id) => ({ id }));
 
-        return Promise.resolve().then(() => {
-            expect(getRowContents()).toEqual(sortedIds);
-        });
+        await Promise.resolve();
+        expect(getRowContents()).toEqual(sortedIds);
     });
 });

--- a/packages/@lwc/integration-not-karma/test/shadow-dom/HTMLElement-properties/GlobalHTML.properties.spec.js
+++ b/packages/@lwc/integration-not-karma/test/shadow-dom/HTMLElement-properties/GlobalHTML.properties.spec.js
@@ -79,18 +79,17 @@ describe('global HTML Properties', () => {
                 expect(element[prop]).toBe(value);
             });
 
-            it(`${prop} should be reactive by default`, () => {
+            it(`${prop} should be reactive by default`, async () => {
                 resetReactiveRenderCount();
                 const element = createElement(`prop-${prop}-reactive`, { is: AttributeIsReactive });
                 document.body.appendChild(element);
 
                 element[prop] = value;
-                return Promise.resolve().then(() => {
-                    expect(attributeIsReactiveRenderCount).toBe(2);
-                    expect(element.shadowRoot.querySelector(`div.${prop}`).textContent).toBe(
-                        `${value}`
-                    );
-                });
+                await Promise.resolve();
+                expect(attributeIsReactiveRenderCount).toBe(2);
+                expect(element.shadowRoot.querySelector(`div.${prop}`).textContent).toBe(
+                    `${value}`
+                );
             });
             it('should throw an error when setting default value in constructor', () => {
                 propertyAndValueToSetInConstructor(prop, value);
@@ -110,16 +109,15 @@ describe('global HTML Properties', () => {
 
                     expect(attributeSetterCounter).toBe(1);
                 });
-                it('should not be reactive when defining own setter', () => {
+                it('should not be reactive when defining own setter', async () => {
                     const element = createElement(`prop-setter-${prop}-reactive`, {
                         is: AttributeMutations,
                     });
                     document.body.appendChild(element);
 
                     element[prop] = value;
-                    return Promise.resolve().then(() => {
-                        expect(attributeRenderCounter).toBe(1);
-                    });
+                    await Promise.resolve();
+                    expect(attributeRenderCounter).toBe(1);
                 });
                 it('should call getter defined in component', () => {
                     const element = createElement(`prop-getter-${prop}-imperative`, {
@@ -164,13 +162,12 @@ describe('#tabIndex', function () {
         expect(elm.getTabIndex()).toBe(2);
     });
 
-    it('should not trigger render cycle', function () {
+    it('should not trigger render cycle', async function () {
         const elm = createElement('x-foo', { is: TabIndexSetInConnectedCallback });
         elm.setAttribute('tabindex', 3);
         document.body.appendChild(elm);
-        return Promise.resolve().then(() => {
-            expect(elm.renderCount).toBe(1);
-        });
+        await Promise.resolve();
+        expect(elm.renderCount).toBe(1);
     });
 
     it('should allow parent component to overwrite internally set tabIndex', function () {

--- a/packages/@lwc/integration-not-karma/test/shadow-dom/HTMLSlotElement-events/HTMLSlotElement.slotchange.spec.js
+++ b/packages/@lwc/integration-not-karma/test/shadow-dom/HTMLSlotElement-events/HTMLSlotElement.slotchange.spec.js
@@ -27,43 +27,39 @@ it('should fire non-composed slotchange', () => {
     expect(parent.getSlotChangeCount()).toBe(0);
 });
 
-it('should fire slotchange on add', () => {
+it('should fire slotchange on add', async () => {
     child.setSlotChangeCount(0);
     parent.add();
 
-    return waitForSlotChange().then(() => {
-        expect(child.getSlotChangeCount()).toBe(1);
-    });
+    await waitForSlotChange();
+    expect(child.getSlotChangeCount()).toBe(1);
 });
 
-it('should fire slotchange on remove', () => {
+it('should fire slotchange on remove', async () => {
     child.setSlotChangeCount(0);
     parent.clear();
 
-    return waitForSlotChange().then(() => {
-        expect(child.getSlotChangeCount()).toBe(1);
-    });
+    await waitForSlotChange();
+    expect(child.getSlotChangeCount()).toBe(1);
 });
 
-it('should fire slotchange on replace', () => {
+it('should fire slotchange on replace', async () => {
     child.setSlotChangeCount(0);
     parent.replace();
 
-    return waitForSlotChange().then(() => {
-        expect(child.getSlotChangeCount()).toBe(1);
-    });
+    await waitForSlotChange();
+    expect(child.getSlotChangeCount()).toBe(1);
 });
 
-it('should fire slotchange when slot is removed', () => {
+it('should fire slotchange when slot is removed', async () => {
     child.setSlotChangeCount(0);
     child.removeSlot();
 
-    return waitForSlotChange().then(() => {
-        expect(child.getSlotChangeCount()).toBe(1);
-    });
+    await waitForSlotChange();
+    expect(child.getSlotChangeCount()).toBe(1);
 });
 
-it('should fire slotchange when listener added programmatically', () => {
+it('should fire slotchange when listener added programmatically', async () => {
     let count = 0;
 
     child.shadowRoot.querySelector('slot').addEventListener('slotchange', () => {
@@ -72,7 +68,6 @@ it('should fire slotchange when listener added programmatically', () => {
 
     parent.add();
 
-    return waitForSlotChange().then(() => {
-        expect(count).toBe(1);
-    });
+    await waitForSlotChange();
+    expect(count).toBe(1);
 });

--- a/packages/@lwc/integration-not-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
+++ b/packages/@lwc/integration-not-karma/test/shadow-dom/MutationObserver/MutationObserver.spec.js
@@ -43,47 +43,38 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             await waitForMutationObservedToBeInvoked();
         });
 
-        it('global observer is not called when mutations occur inside shadow tree', () => {
+        it('global observer is not called when mutations occur inside shadow tree', async () => {
             const host = createElement('x-parent', { is: XParent });
             container.appendChild(host);
-            return waitForMutationObservedToBeInvoked()
-                .then(() => {
-                    // The first call will be when x-parent is appended to the container
-                    globalObserverSpy.calls.reset();
-
-                    // Mutate the shadow tree of x-parent
-                    const parentDiv = host.shadowRoot.querySelector('div');
-                    parentDiv.appendChild(document.createElement('p'));
-                    return waitForMutationObservedToBeInvoked().then(() => {
-                        expect(globalObserverSpy).not.toHaveBeenCalled();
-                    });
-                })
-                .then(() => {
-                    // Mutate the shadow tree of x-child
-                    const childElm = host.shadowRoot.querySelector('x-child');
-                    const childDiv = childElm.shadowRoot.querySelector('div');
-                    childDiv.appendChild(document.createElement('p'));
-                    return waitForMutationObservedToBeInvoked().then(() => {
-                        expect(globalObserverSpy).not.toHaveBeenCalled();
-                    });
-                });
+            await waitForMutationObservedToBeInvoked();
+            // The first call will be when x-parent is appended to the container
+            globalObserverSpy.calls.reset();
+            // Mutate the shadow tree of x-parent
+            const parentDiv = host.shadowRoot.querySelector('div');
+            parentDiv.appendChild(document.createElement('p'));
+            await waitForMutationObservedToBeInvoked();
+            expect(globalObserverSpy).not.toHaveBeenCalled();
+            // Mutate the shadow tree of x-child
+            const childElm = host.shadowRoot.querySelector('x-child');
+            const childDiv = childElm.shadowRoot.querySelector('div');
+            childDiv.appendChild(document.createElement('p'));
+            await waitForMutationObservedToBeInvoked();
+            expect(globalObserverSpy).not.toHaveBeenCalled();
         });
 
-        it('global observer is not called when mutations occur in slotted content', () => {
+        it('global observer is not called when mutations occur in slotted content', async () => {
             const parent = createElement('x-slotted-child', { is: XSlottedChild });
             container.appendChild(parent);
-            return waitForMutationObservedToBeInvoked().then(() => {
-                // The first call will be when x-slotted-child is appended to the container
-                globalObserverSpy.calls.reset();
-                const slottedDiv = parent.shadowRoot.querySelector('div.manual');
-                slottedDiv.appendChild(document.createElement('p'));
-                return waitForMutationObservedToBeInvoked().then(() => {
-                    expect(globalObserverSpy).not.toHaveBeenCalled();
-                });
-            });
+            await waitForMutationObservedToBeInvoked();
+            // The first call will be when x-slotted-child is appended to the container
+            globalObserverSpy.calls.reset();
+            const slottedDiv = parent.shadowRoot.querySelector('div.manual');
+            slottedDiv.appendChild(document.createElement('p'));
+            await waitForMutationObservedToBeInvoked();
+            expect(globalObserverSpy).not.toHaveBeenCalled();
         });
 
-        it('should invoke observer on parent when slotted content is altered', () => {
+        it('should invoke observer on parent when slotted content is altered', async () => {
             const parent = createElement('x-slotted-child', { is: XSlottedChild });
             container.appendChild(parent);
             const slottedDiv = parent.shadowRoot.querySelector('div.manual');
@@ -109,15 +100,14 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             );
 
             slottedDiv.appendChild(document.createElement('p'));
-            return waitForMutationObservedToBeInvoked().then(() => {
-                // observer on parent host element should not see mutation
-                expect(parentHostSpy).not.toHaveBeenCalled();
-                // observer on the slot receiver should not see mutation
-                expect(childSRSpy).not.toHaveBeenCalled();
-            });
+            await waitForMutationObservedToBeInvoked();
+            // observer on parent host element should not see mutation
+            expect(parentHostSpy).not.toHaveBeenCalled();
+            // observer on the slot receiver should not see mutation
+            expect(childSRSpy).not.toHaveBeenCalled();
         });
 
-        it('should invoke observer on slot content owner', () => {
+        it('should invoke observer on slot content owner', async () => {
             const parent = createElement('x-nested-slot-container', { is: XNestedSlotContainer });
             container.appendChild(parent);
             const slottedDiv = parent.shadowRoot.querySelector('div.manual');
@@ -150,15 +140,14 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
 
             slottedDiv.appendChild(document.createElement('p'));
             // Skip a macrotask to allow for observers to be invoked, if any
-            return waitForMutationObservedToBeInvoked().then(() => {
-                // observers on the slot receiver should not see mutation
-                expect(childSRSpy).not.toHaveBeenCalled();
-                expect(grandChildSRSpy).not.toHaveBeenCalled();
-                expect(grandChildSlotSpy).not.toHaveBeenCalled();
-            });
+            await waitForMutationObservedToBeInvoked();
+            // observers on the slot receiver should not see mutation
+            expect(childSRSpy).not.toHaveBeenCalled();
+            expect(grandChildSRSpy).not.toHaveBeenCalled();
+            expect(grandChildSlotSpy).not.toHaveBeenCalled();
         });
 
-        it('parent observer not invoked when mutations occur in a nested lwc', () => {
+        it('parent observer not invoked when mutations occur in a nested lwc', async () => {
             const parent = createElement('x-parent', { is: XParent });
             container.appendChild(parent);
 
@@ -171,9 +160,8 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             childDiv.appendChild(document.createElement('p'));
 
             // Skip a macrotask to allow for observers to be invoked, if any
-            return waitForMutationObservedToBeInvoked().then(() => {
-                expect(parentSpy).not.toHaveBeenCalled();
-            });
+            await waitForMutationObservedToBeInvoked();
+            expect(parentSpy).not.toHaveBeenCalled();
         });
     });
     describe('should handle mutations in shadow tree', () => {
@@ -202,45 +190,44 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
                 await waitForMutationObservedToBeInvoked();
             });
 
-            it('should invoke observer with correct MutationRecords when adding child nodes using appendChild', () => {
+            it('should invoke observer with correct MutationRecords when adding child nodes using appendChild', async () => {
                 const parent = createElement('x-parent', { is: XParent });
                 container.appendChild(parent);
-                return new Promise((resolve) => {
+                await new Promise((resolve) => {
                     let observer;
                     const parentDiv = parent.shadowRoot.querySelector('div');
-                    const callback = function (actualMutationRecords, actualObserver) {
+                    const callback = function (actualMutationRecords_1, actualObserver) {
                         expect(actualObserver).toBe(observer);
-                        expect(actualMutationRecords.length).toBe(1);
-                        expect(actualMutationRecords[0].target).toBe(parentDiv);
-                        expect(actualMutationRecords[0].addedNodes.length).toBe(1);
-                        expect(actualMutationRecords[0].addedNodes[0].tagName).toBe('P');
+                        expect(actualMutationRecords_1.length).toBe(1);
+                        expect(actualMutationRecords_1[0].target).toBe(parentDiv);
+                        expect(actualMutationRecords_1[0].addedNodes.length).toBe(1);
+                        expect(actualMutationRecords_1[0].addedNodes[0].tagName).toBe('P');
                         resolve();
                     };
                     observer = new MutationObserver(callback);
                     observer.observe(parent.shadowRoot, observerConfig);
                     // Mutate the shadow tree of x-parent
                     parentDiv.appendChild(document.createElement('p'));
-                }).then(() => {
-                    const childElm = parent.shadowRoot.querySelector('x-child');
-                    const childDiv = childElm.shadowRoot.querySelector('div');
-                    const promise = new Promise((resolve) => {
-                        const callback = function (actualMutationRecords) {
-                            expect(actualMutationRecords.length).toBe(2);
-                            expect(actualMutationRecords[0].target).toBe(childDiv);
-                            expect(actualMutationRecords[0].addedNodes.length).toBe(1);
-                            expect(actualMutationRecords[0].addedNodes[0].tagName).toBe('UL');
-                            expect(actualMutationRecords[1].target).toBe(childDiv);
-                            expect(actualMutationRecords[1].addedNodes.length).toBe(1);
-                            expect(actualMutationRecords[1].addedNodes[0].tagName).toBe('OL');
-                            resolve();
-                        };
-                        new MutationObserver(callback).observe(childElm.shadowRoot, observerConfig);
-                        // Mutate the shadow tree of x-child
-                        childDiv.appendChild(document.createElement('ul'));
-                        childDiv.appendChild(document.createElement('ol'));
-                    });
-                    return promise;
                 });
+                const childElm = parent.shadowRoot.querySelector('x-child');
+                const childDiv = childElm.shadowRoot.querySelector('div');
+                const promise = new Promise((resolve_1) => {
+                    const callback = function (actualMutationRecords_3) {
+                        expect(actualMutationRecords_3.length).toBe(2);
+                        expect(actualMutationRecords_3[0].target).toBe(childDiv);
+                        expect(actualMutationRecords_3[0].addedNodes.length).toBe(1);
+                        expect(actualMutationRecords_3[0].addedNodes[0].tagName).toBe('UL');
+                        expect(actualMutationRecords_3[1].target).toBe(childDiv);
+                        expect(actualMutationRecords_3[1].addedNodes.length).toBe(1);
+                        expect(actualMutationRecords_3[1].addedNodes[0].tagName).toBe('OL');
+                        resolve_1();
+                    };
+                    new MutationObserver(callback).observe(childElm.shadowRoot, observerConfig);
+                    // Mutate the shadow tree of x-child
+                    childDiv.appendChild(document.createElement('ul'));
+                    childDiv.appendChild(document.createElement('ol'));
+                });
+                return await promise;
             });
 
             it('should invoke observer with correct MutationRecords when removing child nodes using innerHTML', async () => {
@@ -314,7 +301,7 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
                 return Promise.all([promise1, promise2]);
             });
 
-            it('should not get notifications after disconnecting observer', () => {
+            it('should not get notifications after disconnecting observer', async () => {
                 const parent = createElement('x-parent', { is: XParent });
                 container.appendChild(parent);
                 const parentSRSpy = jasmine.createSpy();
@@ -325,18 +312,15 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
                 // Mutate the shadow tree of x-parent
                 parentDiv.appendChild(document.createElement('p'));
                 // Wait for a macro task
-                return waitForMutationObservedToBeInvoked().then(() => {
-                    // Make sure the spy is getting called
-                    expect(parentSRSpy).toHaveBeenCalledTimes(1);
-                    parentSRSpy.calls.reset();
-                    // disconnect and verify that spy does not get invoked after
-                    observer.disconnect();
-                    parentDiv.appendChild(document.createElement('ul'));
-                    // Wait for a macro task
-                    return waitForMutationObservedToBeInvoked().then(() => {
-                        expect(parentSRSpy).not.toHaveBeenCalled();
-                    });
-                });
+                await waitForMutationObservedToBeInvoked();
+                // Make sure the spy is getting called
+                expect(parentSRSpy).toHaveBeenCalledTimes(1);
+                parentSRSpy.calls.reset();
+                // disconnect and verify that spy does not get invoked after
+                observer.disconnect();
+                parentDiv.appendChild(document.createElement('ul'));
+                await waitForMutationObservedToBeInvoked();
+                expect(parentSRSpy).not.toHaveBeenCalled();
             });
 
             it('should return expected records when takeRecords is invoked', () => {
@@ -359,7 +343,7 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
             });
         });
 
-        it('should retarget MutationRecord for mutations directly under shadowRoot - added nodes', () => {
+        it('should retarget MutationRecord for mutations directly under shadowRoot - added nodes', async () => {
             const host = createElement('x-template-mutations', { is: XTemplateMutations });
             container.appendChild(host);
 
@@ -383,13 +367,12 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
 
             // Trigger a mutation directly under the shadowRoot
             host.addNode = true;
-            return waitForMutationObservedToBeInvoked().then(() => {
-                expect(globalObserverSpy).not.toHaveBeenCalled();
-                expect(hostSpy).not.toHaveBeenCalled();
-            });
+            await waitForMutationObservedToBeInvoked();
+            expect(globalObserverSpy).not.toHaveBeenCalled();
+            expect(hostSpy).not.toHaveBeenCalled();
         });
 
-        it('should retarget MutationRecord for mutations directly under shadowRoot - removed nodes', () => {
+        it('should retarget MutationRecord for mutations directly under shadowRoot - removed nodes', async () => {
             const host = createElement('x-template-mutations', { is: XTemplateMutations });
             container.appendChild(host);
 
@@ -412,10 +395,9 @@ describe('MutationObserver is synthetic shadow dom aware.', () => {
 
             // Trigger a mutation directly under the shadowRoot
             host.hideNode = true;
-            return waitForMutationObservedToBeInvoked().then(() => {
-                expect(globalObserverSpy).not.toHaveBeenCalled();
-                expect(hostSpy).not.toHaveBeenCalled();
-            });
+            await waitForMutationObservedToBeInvoked();
+            expect(globalObserverSpy).not.toHaveBeenCalled();
+            expect(hostSpy).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/@lwc/integration-not-karma/test/shadow-dom/Node-properties/Node.getRootNode.spec.js
+++ b/packages/@lwc/integration-not-karma/test/shadow-dom/Node-properties/Node.getRootNode.spec.js
@@ -99,7 +99,7 @@ describe('Node.getRootNode', () => {
     });
 
     describe('manual dom mutations', () => {
-        it('nodes appended to parent with lwc:dom="manual" directive', () => {
+        it('nodes appended to parent with lwc:dom="manual" directive', async () => {
             const host = createElement('x-manual-nodes', { is: ManualNodes });
             document.body.appendChild(host);
             const elm = host.shadowRoot.querySelector('div.manual');
@@ -119,20 +119,15 @@ describe('Node.getRootNode', () => {
             // the portal elements would not have been patched yet
             verifyConnectedNodes();
             // allow for engine's mutation observer to pick up the mutations
-            return Promise.resolve()
-                .then(() => {
-                    // reverify, after the portal elements have been patched
-                    verifyConnectedNodes();
-                    // disconnect the manually inserted nodes
-                    elm.removeChild(span);
-                })
-                .then(() => {
-                    expect(span.getRootNode()).toBe(span);
-                    expect(span.getRootNode(composedTrueConfig)).toBe(span);
-
-                    expect(nestedManualElement.getRootNode()).toBe(span);
-                    expect(nestedManualElement.getRootNode(composedTrueConfig)).toBe(span);
-                });
+            await Promise.resolve();
+            // reverify, after the portal elements have been patched
+            verifyConnectedNodes();
+            // disconnect the manually inserted nodes
+            elm.removeChild(span);
+            expect(span.getRootNode()).toBe(span);
+            expect(span.getRootNode(composedTrueConfig)).toBe(span);
+            expect(nestedManualElement.getRootNode()).toBe(span);
+            expect(nestedManualElement.getRootNode(composedTrueConfig)).toBe(span);
         });
 
         it('node appended to parent without lwc:dom="manual" directive', () => {

--- a/packages/@lwc/integration-not-karma/test/shadow-dom/dir-pseudoclass/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/shadow-dom/dir-pseudoclass/index.spec.js
@@ -21,89 +21,67 @@ function supportsDirPseudoclass() {
 
 // In native shadow we delegate to the browser, so it has to support :dir()
 describe.runIf(!process.env.NATIVE_SHADOW || supportsDirPseudoclass())(':dir() pseudoclass', () => {
-    it('can apply styles based on :dir()', () => {
+    it('can apply styles based on :dir()', async () => {
         const elm = createElement('x-parent', { is: Component });
         document.body.appendChild(elm);
 
         elm.setAttribute('dir', 'ltr');
 
-        return Promise.resolve()
-            .then(() => {
-                expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual(
-                    'rgb(0, 0, 1)'
-                );
-                expect(getComputedStyle(elm.shadowRoot.querySelector('.foo')).color).toEqual(
-                    'rgb(0, 0, 3)'
-                );
-                expect(getComputedStyle(elm.shadowRoot.querySelector('.foo.bar')).color).toEqual(
-                    'rgb(0, 0, 5)'
-                );
-                expect(getComputedStyle(elm.shadowRoot.querySelector('.baz span')).color).toEqual(
-                    'rgb(0, 0, 7)'
-                );
-                expect(getComputedStyle(elm.shadowRoot.querySelector('.baz button')).color).toEqual(
-                    'rgb(0, 0, 9)'
-                );
-                elm.setAttribute('dir', 'rtl');
-            })
-            .then(() => {
-                expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual(
-                    'rgb(0, 0, 2)'
-                );
-                expect(getComputedStyle(elm.shadowRoot.querySelector('.foo')).color).toEqual(
-                    'rgb(0, 0, 4)'
-                );
-                expect(getComputedStyle(elm.shadowRoot.querySelector('.foo.bar')).color).toEqual(
-                    'rgb(0, 0, 6)'
-                );
-                expect(getComputedStyle(elm.shadowRoot.querySelector('.baz span')).color).toEqual(
-                    'rgb(0, 0, 8)'
-                );
-                expect(getComputedStyle(elm.shadowRoot.querySelector('.baz button')).color).toEqual(
-                    'rgb(0, 0, 10)'
-                );
-            });
+        await Promise.resolve();
+        expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual('rgb(0, 0, 1)');
+        expect(getComputedStyle(elm.shadowRoot.querySelector('.foo')).color).toEqual(
+            'rgb(0, 0, 3)'
+        );
+        expect(getComputedStyle(elm.shadowRoot.querySelector('.foo.bar')).color).toEqual(
+            'rgb(0, 0, 5)'
+        );
+        expect(getComputedStyle(elm.shadowRoot.querySelector('.baz span')).color).toEqual(
+            'rgb(0, 0, 7)'
+        );
+        expect(getComputedStyle(elm.shadowRoot.querySelector('.baz button')).color).toEqual(
+            'rgb(0, 0, 9)'
+        );
+        elm.setAttribute('dir', 'rtl');
+        expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual('rgb(0, 0, 2)');
+        expect(getComputedStyle(elm.shadowRoot.querySelector('.foo')).color).toEqual(
+            'rgb(0, 0, 4)'
+        );
+        expect(getComputedStyle(elm.shadowRoot.querySelector('.foo.bar')).color).toEqual(
+            'rgb(0, 0, 6)'
+        );
+        expect(getComputedStyle(elm.shadowRoot.querySelector('.baz span')).color).toEqual(
+            'rgb(0, 0, 8)'
+        );
+        expect(getComputedStyle(elm.shadowRoot.querySelector('.baz button')).color).toEqual(
+            'rgb(0, 0, 10)'
+        );
     });
 
-    it('can apply styles based on :dir() for light-within-shadow', () => {
+    it('can apply styles based on :dir() for light-within-shadow', async () => {
         const elm = createElement('x-shadow-container', { is: ShadowContainer });
         document.body.appendChild(elm);
 
         elm.setAttribute('dir', 'ltr');
 
-        return Promise.resolve()
-            .then(() => {
-                expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual(
-                    'rgb(0, 0, 1)'
-                );
-                elm.setAttribute('dir', 'rtl');
-            })
-            .then(() => {
-                expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual(
-                    'rgb(0, 0, 2)'
-                );
-            });
+        await Promise.resolve();
+        expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual('rgb(0, 0, 1)');
+        elm.setAttribute('dir', 'rtl');
+        expect(getComputedStyle(elm.shadowRoot.querySelector('div')).color).toEqual('rgb(0, 0, 2)');
     });
 });
 
 it.runIf(process.env.NATIVE_SHADOW && supportsDirPseudoclass())(
     'can apply styles based on :dir() for light-at-root',
-    () => {
+    async () => {
         const elm = createElement('x-light', { is: Light });
         document.body.appendChild(elm);
 
-        return Promise.resolve()
-            .then(() => {
-                // Unlike [dir], :dir(ltr) matches even when there is no dir attribute anywhere
-                expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(0, 0, 1)');
-                elm.setAttribute('dir', 'rtl');
-            })
-            .then(() => {
-                expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(0, 0, 2)');
-                elm.setAttribute('dir', 'ltr');
-            })
-            .then(() => {
-                expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(0, 0, 1)');
-            });
+        await Promise.resolve();
+        // Unlike [dir], :dir(ltr) matches even when there is no dir attribute anywhere
+        expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(0, 0, 1)');
+        elm.setAttribute('dir', 'rtl');
+        expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(0, 0, 2)');
+        elm.setAttribute('dir', 'ltr');
+        expect(getComputedStyle(elm.querySelector('div')).color).toEqual('rgb(0, 0, 1)');
     }
 );

--- a/packages/@lwc/integration-not-karma/test/shadow-dom/event-in-shadow-tree/event-post-dispatch.spec.js
+++ b/packages/@lwc/integration-not-karma/test/shadow-dom/event-in-shadow-tree/event-post-dispatch.spec.js
@@ -40,28 +40,26 @@ describe('post-dispatch event state', () => {
     });
 
     describe('lwc:dom="manual" element', () => {
-        it('{ bubbles: true, composed: true }', () => {
+        it('{ bubbles: true, composed: true }', async () => {
             const nodes = createComponent();
             const event = new CustomEvent('test', { bubbles: true, composed: true });
             nodes.container_span_manual.dispatchEvent(event);
 
             // lwc:dom=manual is async due to MutationObserver
-            return new Promise(setTimeout).then(() => {
-                assertEventStateReset(event);
-                expect(event.target).toBe(nodes['x-container']);
-            });
+            await new Promise(setTimeout);
+            assertEventStateReset(event);
+            expect(event.target).toBe(nodes['x-container']);
         });
 
-        it('{ bubbles: true, composed: false }', () => {
+        it('{ bubbles: true, composed: false }', async () => {
             const nodes = createComponent();
             const event = new CustomEvent('test', { bubbles: true, composed: false });
             nodes.container_span_manual.dispatchEvent(event);
 
             // lwc:dom=manual is async due to MutationObserver
-            return new Promise(setTimeout).then(() => {
-                assertEventStateReset(event);
-                expect(event.target).toBe(null);
-            });
+            await new Promise(setTimeout);
+            assertEventStateReset(event);
+            expect(event.target).toBe(null);
         });
     });
 

--- a/packages/@lwc/integration-not-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
+++ b/packages/@lwc/integration-not-karma/test/shadow-dom/event-in-shadow-tree/propagation.spec.js
@@ -426,7 +426,7 @@ describe('event propagation', () => {
     });
 
     describe('dispatched on lwc:dom="manual" node', () => {
-        it('{bubbles: true, composed: true}', () => {
+        it('{bubbles: true, composed: true}', async () => {
             const nodes = createTestElement();
             const event = new CustomEvent('test', { bubbles: true, composed: true });
 
@@ -451,13 +451,12 @@ describe('event propagation', () => {
                 [window, nodes['x-container'], composedPath],
             ];
 
-            return new Promise(setTimeout).then(() => {
-                const actualLogs = dispatchEventWithLog(nodes.container_span_manual, nodes, event);
-                expect(actualLogs).toEqual(expectedLogs);
-            });
+            await new Promise(setTimeout);
+            const actualLogs = dispatchEventWithLog(nodes.container_span_manual, nodes, event);
+            expect(actualLogs).toEqual(expectedLogs);
         });
 
-        it('{bubbles: true, composed: false}', () => {
+        it('{bubbles: true, composed: false}', async () => {
             const nodes = createTestElement();
             const event = new CustomEvent('test', { bubbles: true, composed: false });
 
@@ -472,13 +471,12 @@ describe('event propagation', () => {
                 [nodes['x-container'].shadowRoot, nodes.container_span_manual, composedPath],
             ];
 
-            return Promise.resolve().then(() => {
-                const actualLogs = dispatchEventWithLog(nodes.container_span_manual, nodes, event);
-                expect(actualLogs).toEqual(expectedLogs);
-            });
+            await Promise.resolve();
+            const actualLogs = dispatchEventWithLog(nodes.container_span_manual, nodes, event);
+            expect(actualLogs).toEqual(expectedLogs);
         });
 
-        it('{bubbles: false, composed: true}', () => {
+        it('{bubbles: false, composed: true}', async () => {
             const nodes = createTestElement();
             const event = new CustomEvent('test', { bubbles: false, composed: true });
 
@@ -505,13 +503,12 @@ describe('event propagation', () => {
                 ];
             }
 
-            return Promise.resolve().then(() => {
-                const actualLogs = dispatchEventWithLog(nodes.container_span_manual, nodes, event);
-                expect(actualLogs).toEqual(expectedLogs);
-            });
+            await Promise.resolve();
+            const actualLogs = dispatchEventWithLog(nodes.container_span_manual, nodes, event);
+            expect(actualLogs).toEqual(expectedLogs);
         });
 
-        it('{bubbles: false, composed: false}', () => {
+        it('{bubbles: false, composed: false}', async () => {
             const nodes = createTestElement();
             const event = new CustomEvent('test', { bubbles: false, composed: false });
 
@@ -524,10 +521,9 @@ describe('event propagation', () => {
                 [nodes.container_span_manual, nodes.container_span_manual, composedPath],
             ];
 
-            return Promise.resolve().then(() => {
-                const actualLogs = dispatchEventWithLog(nodes.container_span_manual, nodes, event);
-                expect(actualLogs).toEqual(expectedLogs);
-            });
+            await Promise.resolve();
+            const actualLogs = dispatchEventWithLog(nodes.container_span_manual, nodes, event);
+            expect(actualLogs).toEqual(expectedLogs);
         });
     });
 

--- a/packages/@lwc/integration-not-karma/test/shadow-dom/multiple-templates/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/shadow-dom/multiple-templates/index.spec.js
@@ -5,7 +5,7 @@ import MultiNoStyleInFirst from 'x/multiNoStyleInFirst';
 describe.runIf(process.env.NATIVE_SHADOW)(
     'Shadow DOM styling - multiple shadow DOM components',
     () => {
-        it('Does not duplicate styles if template is re-rendered', () => {
+        it('Does not duplicate styles if template is re-rendered', async () => {
             const element = createElement('x-multi', { is: Multi });
 
             const getNumStyleSheets = () => {
@@ -18,88 +18,74 @@ describe.runIf(process.env.NATIVE_SHADOW)(
             };
 
             document.body.appendChild(element);
-            return Promise.resolve()
-                .then(() => {
-                    expect(getComputedStyle(element.shadowRoot.querySelector('div')).color).toEqual(
-                        'rgb(0, 0, 255)'
-                    );
-                    expect(getNumStyleSheets()).toEqual(1);
-                    element.next();
-                })
-                .then(() => {
-                    expect(getComputedStyle(element.shadowRoot.querySelector('div')).color).toEqual(
-                        'rgb(255, 0, 0)'
-                    );
-                    expect(getNumStyleSheets()).toEqual(2);
-                    element.next();
-                })
-                .then(() => {
-                    expect(getComputedStyle(element.shadowRoot.querySelector('div')).color).toEqual(
-                        'rgb(0, 0, 255)'
-                    );
-                    expect(getNumStyleSheets()).toEqual(2);
-                });
+            await Promise.resolve();
+            expect(getComputedStyle(element.shadowRoot.querySelector('div')).color).toEqual(
+                'rgb(0, 0, 255)'
+            );
+            expect(getNumStyleSheets()).toEqual(1);
+            element.next();
+            expect(getComputedStyle(element.shadowRoot.querySelector('div')).color).toEqual(
+                'rgb(255, 0, 0)'
+            );
+            expect(getNumStyleSheets()).toEqual(2);
+            element.next();
+            expect(getComputedStyle(element.shadowRoot.querySelector('div')).color).toEqual(
+                'rgb(0, 0, 255)'
+            );
+            expect(getNumStyleSheets()).toEqual(2);
         });
     }
 );
 
 describe('multiple stylesheets rendered in same component', () => {
-    it('works when first template has no style but second template does', () => {
+    it('works when first template has no style but second template does', async () => {
         const element = createElement('x-multi-no-style-in-first', { is: MultiNoStyleInFirst });
         document.body.appendChild(element);
-        return Promise.resolve()
-            .then(() => {
-                expect(getComputedStyle(element.shadowRoot.querySelector('.red')).color).toEqual(
-                    'rgb(0, 0, 0)'
-                );
-                expect(getComputedStyle(element.shadowRoot.querySelector('.green')).color).toEqual(
-                    'rgb(0, 0, 0)'
-                );
-                expect(getComputedStyle(element).marginLeft).toEqual('0px');
-                element.next();
-                return new Promise((resolve) => requestAnimationFrame(() => resolve()));
-            })
-            .then(() => {
-                expect(getComputedStyle(element.shadowRoot.querySelector('.red')).color).toEqual(
-                    'rgb(255, 0, 0)'
-                );
-                expect(getComputedStyle(element.shadowRoot.querySelector('.green')).color).toEqual(
-                    'rgb(0, 128, 0)'
-                );
-                expect(getComputedStyle(element).marginLeft).toEqual('5px');
-                element.next();
-                return new Promise((resolve) => requestAnimationFrame(() => resolve()));
-            })
-            .then(() => {
-                if (process.env.NATIVE_SHADOW) {
-                    // TODO [#2466]: In native shadow, stylesheets are not removed from the DOM
-                    expect(
-                        getComputedStyle(element.shadowRoot.querySelector('.red')).color
-                    ).toEqual('rgb(255, 0, 0)');
-                    expect(
-                        getComputedStyle(element.shadowRoot.querySelector('.green')).color
-                    ).toEqual('rgb(0, 128, 0)');
-                    expect(getComputedStyle(element).marginLeft).toEqual('5px');
-                } else {
-                    expect(
-                        getComputedStyle(element.shadowRoot.querySelector('.red')).color
-                    ).toEqual('rgb(0, 0, 0)');
-                    expect(
-                        getComputedStyle(element.shadowRoot.querySelector('.green')).color
-                    ).toEqual('rgb(0, 0, 0)');
-                    expect(getComputedStyle(element).marginLeft).toEqual('0px');
-                }
-                element.next();
-                return new Promise((resolve) => requestAnimationFrame(() => resolve()));
-            })
-            .then(() => {
-                expect(getComputedStyle(element.shadowRoot.querySelector('.red')).color).toEqual(
-                    'rgb(255, 0, 0)'
-                );
-                expect(getComputedStyle(element.shadowRoot.querySelector('.green')).color).toEqual(
-                    'rgb(0, 128, 0)'
-                );
-                expect(getComputedStyle(element).marginLeft).toEqual('5px');
-            });
+        await Promise.resolve();
+        expect(getComputedStyle(element.shadowRoot.querySelector('.red')).color).toEqual(
+            'rgb(0, 0, 0)'
+        );
+        expect(getComputedStyle(element.shadowRoot.querySelector('.green')).color).toEqual(
+            'rgb(0, 0, 0)'
+        );
+        expect(getComputedStyle(element).marginLeft).toEqual('0px');
+        element.next();
+        await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+        expect(getComputedStyle(element.shadowRoot.querySelector('.red')).color).toEqual(
+            'rgb(255, 0, 0)'
+        );
+        expect(getComputedStyle(element.shadowRoot.querySelector('.green')).color).toEqual(
+            'rgb(0, 128, 0)'
+        );
+        expect(getComputedStyle(element).marginLeft).toEqual('5px');
+        element.next();
+        await new Promise((resolve_1) => requestAnimationFrame(() => resolve_1()));
+        if (process.env.NATIVE_SHADOW) {
+            // TODO [#2466]: In native shadow, stylesheets are not removed from the DOM
+            expect(getComputedStyle(element.shadowRoot.querySelector('.red')).color).toEqual(
+                'rgb(255, 0, 0)'
+            );
+            expect(getComputedStyle(element.shadowRoot.querySelector('.green')).color).toEqual(
+                'rgb(0, 128, 0)'
+            );
+            expect(getComputedStyle(element).marginLeft).toEqual('5px');
+        } else {
+            expect(getComputedStyle(element.shadowRoot.querySelector('.red')).color).toEqual(
+                'rgb(0, 0, 0)'
+            );
+            expect(getComputedStyle(element.shadowRoot.querySelector('.green')).color).toEqual(
+                'rgb(0, 0, 0)'
+            );
+            expect(getComputedStyle(element).marginLeft).toEqual('0px');
+        }
+        element.next();
+        await new Promise((resolve_2) => requestAnimationFrame(() => resolve_2()));
+        expect(getComputedStyle(element.shadowRoot.querySelector('.red')).color).toEqual(
+            'rgb(255, 0, 0)'
+        );
+        expect(getComputedStyle(element.shadowRoot.querySelector('.green')).color).toEqual(
+            'rgb(0, 128, 0)'
+        );
+        expect(getComputedStyle(element).marginLeft).toEqual('5px');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/shadow-dom/part-and-exportparts/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/shadow-dom/part-and-exportparts/index.spec.js
@@ -3,16 +3,15 @@ import Grandparent from 'x/grandparent';
 import { extractDataIds } from '../../../helpers/utils.js';
 
 describe.runIf(process.env.NATIVE_SHADOW)('part and exportparts', () => {
-    it('supports part and exportparts', () => {
+    it('supports part and exportparts', async () => {
         const elm = createElement('x-grandparent', { is: Grandparent });
         document.body.appendChild(elm);
 
         const ids = extractDataIds(elm);
 
-        return Promise.resolve().then(() => {
-            expect(getComputedStyle(ids.overlay).color).toEqual('rgb(255, 0, 0)');
-            expect(getComputedStyle(ids.text).color).toEqual('rgb(0, 0, 255)');
-            expect(getComputedStyle(ids.badge).color).toEqual('rgb(0, 128, 0)');
-        });
+        await Promise.resolve();
+        expect(getComputedStyle(ids.overlay).color).toEqual('rgb(255, 0, 0)');
+        expect(getComputedStyle(ids.text).color).toEqual('rgb(0, 0, 255)');
+        expect(getComputedStyle(ids.badge).color).toEqual('rgb(0, 128, 0)');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/shadow-dom/stylesheet/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/shadow-dom/stylesheet/index.spec.js
@@ -19,7 +19,7 @@ describe('shadow encapsulation', () => {
         expect(window.getComputedStyle(childDiv).marginLeft).toBe('0px');
     });
 
-    it('should work with multiple templates', () => {
+    it('should work with multiple templates', async () => {
         const elm = createElement('x-multi-template', { is: MultiTemplates });
         document.body.appendChild(elm);
 
@@ -28,11 +28,10 @@ describe('shadow encapsulation', () => {
         expect(window.getComputedStyle(div).marginRight).toBe('0px');
 
         elm.toggleTemplate();
-        return Promise.resolve().then(() => {
-            const div = elm.shadowRoot.querySelector('div');
-            expect(window.getComputedStyle(div).marginLeft).toBe('0px');
-            expect(window.getComputedStyle(div).marginRight).toBe('10px');
-        });
+        await Promise.resolve();
+        const div_1 = elm.shadowRoot.querySelector('div');
+        expect(window.getComputedStyle(div_1).marginLeft).toBe('0px');
+        expect(window.getComputedStyle(div_1).marginRight).toBe('10px');
     });
 });
 

--- a/packages/@lwc/integration-not-karma/test/static-content/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/static-content/index.spec.js
@@ -50,7 +50,7 @@ describe.skipIf(process.env.NATIVE_SHADOW)('Mixed mode for static content', () =
 });
 
 describe('static content when stylesheets change', () => {
-    it('should reflect correct token for scoped styles', () => {
+    it('should reflect correct token for scoped styles', async () => {
         const elm = createElement('x-container', { is: MultipleStyles });
 
         const stylesheetsWarning =
@@ -79,25 +79,21 @@ describe('static content when stylesheets change', () => {
 
         window.__lwcResetAlreadyLoggedMessages();
 
-        return Promise.resolve()
-            .then(() => {
-                const classList = Array.from(elm.shadowRoot.querySelector('div').classList).sort();
-                expect(classList).toEqual([
-                    'foo',
-                    LOWERCASE_SCOPE_TOKENS ? 'lwc-6fpm08fjoch' : 'x-multipleStyles_b',
-                ]);
-
-                expect(() => {
-                    elm.updateTemplate({
-                        name: 'a',
-                        useScopedCss: false,
-                    });
-                }).toLogWarningDev(stylesheetsWarning);
-            })
-            .then(() => {
-                const classList = Array.from(elm.shadowRoot.querySelector('div').classList).sort();
-                expect(classList).toEqual(['foo']);
+        await Promise.resolve();
+        const classList = Array.from(elm.shadowRoot.querySelector('div').classList).sort();
+        expect(classList).toEqual([
+            'foo',
+            LOWERCASE_SCOPE_TOKENS ? 'lwc-6fpm08fjoch' : 'x-multipleStyles_b',
+        ]);
+        expect(() => {
+            elm.updateTemplate({
+                name: 'a',
+                useScopedCss: false,
             });
+        }).toLogWarningDev(stylesheetsWarning);
+        await Promise.resolve();
+        const classList_1 = Array.from(elm.shadowRoot.querySelector('div').classList).sort();
+        expect(classList_1).toEqual(['foo']);
     });
 });
 
@@ -187,7 +183,7 @@ describe('svg and static content', () => {
 });
 
 describe('elements that cannot be parsed as top-level', () => {
-    it('should work with a static <td>', () => {
+    it('should work with a static <td>', async () => {
         const elm = createElement('x-table', { is: Table });
         document.body.appendChild(elm);
 
@@ -195,13 +191,12 @@ describe('elements that cannot be parsed as top-level', () => {
 
         elm.addRow();
 
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelectorAll('td').length).toEqual(1);
-            expect(elm.shadowRoot.querySelector('td').textContent).toEqual('');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelectorAll('td').length).toEqual(1);
+        expect(elm.shadowRoot.querySelector('td').textContent).toEqual('');
     });
 
-    it('works for all elements that cannot be safely parsed as top-level', () => {
+    it('works for all elements that cannot be safely parsed as top-level', async () => {
         const elm = createElement('x-static-unsafe-top-level', { is: StaticUnsafeTopLevel });
         document.body.appendChild(elm);
 
@@ -228,18 +223,14 @@ describe('elements that cannot be parsed as top-level', () => {
 
         expect(getChildrenTagNames()).toEqual([]);
         elm.doRender = true;
-        return Promise.resolve()
-            .then(() => {
-                expect(getChildrenTagNames()).toEqual(expectedChildren);
-                elm.doRender = false;
-            })
-            .then(() => {
-                expect(getChildrenTagNames()).toEqual([]);
-                elm.doRender = true;
-            })
-            .then(() => {
-                expect(getChildrenTagNames()).toEqual(expectedChildren);
-            });
+        await Promise.resolve();
+        expect(getChildrenTagNames()).toEqual(expectedChildren);
+        elm.doRender = false;
+        await Promise.resolve();
+        expect(getChildrenTagNames()).toEqual([]);
+        elm.doRender = true;
+        await Promise.resolve();
+        expect(getChildrenTagNames()).toEqual(expectedChildren);
     });
 });
 

--- a/packages/@lwc/integration-not-karma/test/swapping/components/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/swapping/components/index.spec.js
@@ -11,7 +11,7 @@ import Z from 'base/libraryz';
 
 // Swapping is only enabled in dev mode
 describe.skipIf(process.env.NODE_ENV === 'production')('component swapping', () => {
-    it('should work before and after instantiation', () => {
+    it('should work before and after instantiation', async () => {
         expect(swapComponent(A, B)).toBe(true);
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
@@ -19,11 +19,10 @@ describe.skipIf(process.env.NODE_ENV === 'production')('component swapping', () 
             '<p class="b">b</p>'
         );
         expect(swapComponent(B, C)).toBe(true);
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.firstChild.shadowRoot.firstChild.outerHTML).toBe(
-                '<p class="c">c</p>'
-            );
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.firstChild.shadowRoot.firstChild.outerHTML).toBe(
+            '<p class="c">c</p>'
+        );
     });
 
     it('should return false for root elements', () => {
@@ -50,13 +49,12 @@ describe.skipIf(process.env.NODE_ENV === 'production')('component swapping', () 
         );
     });
 
-    it('should be a no-op for non components', () => {
+    it('should be a no-op for non components', async () => {
         const elm = createElement('x-container', { is: Container });
         document.body.appendChild(elm);
         expect(elm.testValue).toBe('I may look like a component');
         expect(swapComponent(Z, X)).toBe(false);
-        return Promise.resolve().then(() => {
-            expect(elm.testValue).toBe('I may look like a component');
-        });
+        await Promise.resolve();
+        expect(elm.testValue).toBe('I may look like a component');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/swapping/templates/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/swapping/templates/index.spec.js
@@ -9,29 +9,25 @@ const advancedBaseTemplate = Advanced.baseTemplate;
 
 // Swapping is only enabled in dev mode
 describe.skipIf(process.env.NODE_ENV === 'production')('template swapping', () => {
-    it('should work with components with implicit template definition', () => {
+    it('should work with components with implicit template definition', async () => {
         const elm = createElement('x-simple', { is: Simple });
         document.body.appendChild(elm);
         expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="simple">simple</p>');
         swapTemplate(simpleBaseTemplate, first);
-        return Promise.resolve()
-            .then(() => {
-                expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="first">first</p>');
-                swapTemplate(first, second);
-            })
-            .then(() => {
-                expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="second">second</p>');
-            });
+        await Promise.resolve();
+        expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="first">first</p>');
+        swapTemplate(first, second);
+        await Promise.resolve();
+        expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="second">second</p>');
     });
 
-    it('should work with components with explict template definition', () => {
+    it('should work with components with explict template definition', async () => {
         const elm = createElement('x-advanced', { is: Advanced });
         document.body.appendChild(elm);
         expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="advanced">advanced</p>');
         swapTemplate(advancedBaseTemplate, second);
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="second">second</p>');
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.firstChild.outerHTML).toBe('<p class="second">second</p>');
     });
 
     it('should throw for invalid old template', () => {

--- a/packages/@lwc/integration-not-karma/test/synthetic-shadow/dom-manual-sharing-nodes/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/synthetic-shadow/dom-manual-sharing-nodes/index.spec.js
@@ -8,53 +8,43 @@ afterEach(() => {
 });
 
 describe('dom manual sharing nodes', () => {
-    it('has correct styles when sharing nodes from styled to unstyled component', () => {
+    it('has correct styles when sharing nodes from styled to unstyled component', async () => {
         const unstyled = createElement('x-unstyled', { is: Unstyled });
         const styled = createElement('x-styled', { is: Styled });
         document.body.appendChild(unstyled);
         document.body.appendChild(styled);
 
-        return new Promise((resolve) => requestAnimationFrame(() => resolve()))
-            .then(() => {
-                expect(
-                    getComputedStyle(unstyled.shadowRoot.querySelector('.manual')).color
-                ).toEqual('rgb(0, 0, 0)');
-                expect(getComputedStyle(styled.shadowRoot.querySelector('.manual')).color).toEqual(
-                    'rgb(255, 0, 0)'
-                );
-
-                styled.insertManualNode(unstyled.getManualNode());
-                return new Promise((resolve) => requestAnimationFrame(() => resolve()));
-            })
-            .then(() => {
-                expect(getComputedStyle(styled.shadowRoot.querySelector('.manual')).color).toEqual(
-                    'rgb(255, 0, 0)'
-                );
-            });
+        await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+        expect(getComputedStyle(unstyled.shadowRoot.querySelector('.manual')).color).toEqual(
+            'rgb(0, 0, 0)'
+        );
+        expect(getComputedStyle(styled.shadowRoot.querySelector('.manual')).color).toEqual(
+            'rgb(255, 0, 0)'
+        );
+        styled.insertManualNode(unstyled.getManualNode());
+        await new Promise((resolve_1) => requestAnimationFrame(() => resolve_1()));
+        expect(getComputedStyle(styled.shadowRoot.querySelector('.manual')).color).toEqual(
+            'rgb(255, 0, 0)'
+        );
     });
 
-    it('has correct styles when sharing nodes from unstyled to styled component', () => {
+    it('has correct styles when sharing nodes from unstyled to styled component', async () => {
         const unstyled = createElement('x-unstyled', { is: Unstyled });
         const styled = createElement('x-styled', { is: Styled });
         document.body.appendChild(unstyled);
         document.body.appendChild(styled);
 
-        return new Promise((resolve) => requestAnimationFrame(() => resolve()))
-            .then(() => {
-                expect(
-                    getComputedStyle(unstyled.shadowRoot.querySelector('.manual')).color
-                ).toEqual('rgb(0, 0, 0)');
-                expect(getComputedStyle(styled.shadowRoot.querySelector('.manual')).color).toEqual(
-                    'rgb(255, 0, 0)'
-                );
-
-                unstyled.insertManualNode(styled.getManualNode());
-                return new Promise((resolve) => requestAnimationFrame(() => resolve()));
-            })
-            .then(() => {
-                expect(
-                    getComputedStyle(unstyled.shadowRoot.querySelector('.manual')).color
-                ).toEqual('rgb(0, 0, 0)');
-            });
+        await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+        expect(getComputedStyle(unstyled.shadowRoot.querySelector('.manual')).color).toEqual(
+            'rgb(0, 0, 0)'
+        );
+        expect(getComputedStyle(styled.shadowRoot.querySelector('.manual')).color).toEqual(
+            'rgb(255, 0, 0)'
+        );
+        unstyled.insertManualNode(styled.getManualNode());
+        await new Promise((resolve_1) => requestAnimationFrame(() => resolve_1()));
+        expect(getComputedStyle(unstyled.shadowRoot.querySelector('.manual')).color).toEqual(
+            'rgb(0, 0, 0)'
+        );
     });
 });

--- a/packages/@lwc/integration-not-karma/test/synthetic-shadow/global-styles/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/synthetic-shadow/global-styles/index.spec.js
@@ -5,13 +5,12 @@ import Component from 'x/component';
 // Currently we can't, due to backwards compat.
 
 describe.skipIf(process.env.NATIVE_SHADOW)('global styles', () => {
-    it('injects global styles in document.head in synthetic shadow', () => {
+    it('injects global styles in document.head in synthetic shadow', async () => {
         const numStyleSheetsBefore = document.styleSheets.length;
         const elm = createElement('x-component', { is: Component });
         document.body.appendChild(elm);
-        return Promise.resolve().then(() => {
-            const numStyleSheetsAfter = document.styleSheets.length;
-            expect(numStyleSheetsBefore + 1).toEqual(numStyleSheetsAfter);
-        });
+        await Promise.resolve();
+        const numStyleSheetsAfter = document.styleSheets.length;
+        expect(numStyleSheetsBefore + 1).toEqual(numStyleSheetsAfter);
     });
 });

--- a/packages/@lwc/integration-not-karma/test/template/attribute-boolean-global/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/attribute-boolean-global/index.spec.js
@@ -27,27 +27,23 @@ describe('boolean attribute', () => {
         }
     });
 
-    it('should be added/removed when used with computed value in html element', () => {
+    it('should be added/removed when used with computed value in html element', async () => {
         const elm = createElement('x-computed', { is: Computed });
         document.body.appendChild(elm);
 
-        return Promise.resolve()
-            .then(() => {
-                const elmWithHidden = elm.shadowRoot.querySelector('.hidden-value');
-                expect(elmWithHidden.hidden).toBe(false);
-                expect(elmWithHidden.getAttribute('hidden')).toBeNull();
-                elm.toggleHiddenValue();
-            })
-            .then(() => {
-                const elmWithHidden = elm.shadowRoot.querySelector('.hidden-value');
-                expect(elmWithHidden.hidden).toBe(true);
-                expect(elmWithHidden.getAttribute('hidden')).toBe('');
-                elm.toggleHiddenValue();
-            })
-            .then(() => {
-                const elmWithHidden = elm.shadowRoot.querySelector('.hidden-value');
-                expect(elmWithHidden.hidden).toBe(false);
-                expect(elmWithHidden.getAttribute('hidden')).toBeNull();
-            });
+        await Promise.resolve();
+        const elmWithHidden = elm.shadowRoot.querySelector('.hidden-value');
+        expect(elmWithHidden.hidden).toBe(false);
+        expect(elmWithHidden.getAttribute('hidden')).toBeNull();
+        elm.toggleHiddenValue();
+        await Promise.resolve();
+        const elmWithHidden_1 = elm.shadowRoot.querySelector('.hidden-value');
+        expect(elmWithHidden_1.hidden).toBe(true);
+        expect(elmWithHidden_1.getAttribute('hidden')).toBe('');
+        elm.toggleHiddenValue();
+        await Promise.resolve();
+        const elmWithHidden_2 = elm.shadowRoot.querySelector('.hidden-value');
+        expect(elmWithHidden_2.hidden).toBe(false);
+        expect(elmWithHidden_2.getAttribute('hidden')).toBeNull();
     });
 });

--- a/packages/@lwc/integration-not-karma/test/template/attribute-class/object-values.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/attribute-class/object-values.spec.js
@@ -23,7 +23,7 @@ function testClassNameValue(name, value, expected, test = it) {
 }
 
 function testReactiveClassNameValue(name, setupFn, updateFn, expected) {
-    it(name, () => {
+    it(name, async () => {
         const elm = createElement('x-reactive', { is: Reactive });
         elm.updateDynamicClass(setupFn);
         document.body.appendChild(elm);
@@ -31,9 +31,8 @@ function testReactiveClassNameValue(name, setupFn, updateFn, expected) {
         const target = elm.shadowRoot.querySelector('div');
 
         elm.updateDynamicClass(updateFn);
-        return Promise.resolve().then(() => {
-            expect(target.className).toBe(expected);
-        });
+        await Promise.resolve();
+        expect(target.className).toBe(expected);
     });
 }
 

--- a/packages/@lwc/integration-not-karma/test/template/attribute-class/string-values.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/attribute-class/string-values.spec.js
@@ -39,43 +39,39 @@ describe('dynamic class attribute', () => {
         expect(target.className).toBe('foo bar baz');
     });
 
-    it('empty', () => {
+    it('empty', async () => {
         const { host, target } = createDynamicClass('foo');
 
         host.dynamicClass = '';
-        return Promise.resolve().then(() => {
-            expect(target.className).toBe('');
-        });
+        await Promise.resolve();
+        expect(target.className).toBe('');
     });
 
-    it('partial replacement', () => {
+    it('partial replacement', async () => {
         const { host, target } = createDynamicClass('foo bar');
 
         host.dynamicClass = 'bar baz';
-        return Promise.resolve().then(() => {
-            expect(target.className).toBe('bar baz');
-        });
+        await Promise.resolve();
+        expect(target.className).toBe('bar baz');
     });
 
-    it('full replacement', () => {
+    it('full replacement', async () => {
         const { host, target } = createDynamicClass('foo bar');
         expect(target.className).toBe('foo bar');
 
         host.dynamicClass = 'baz buz';
-        return Promise.resolve().then(() => {
-            expect(target.className).toBe('baz buz');
-        });
+        await Promise.resolve();
+        expect(target.className).toBe('baz buz');
     });
 
-    it('preserves manually added classes', () => {
+    it('preserves manually added classes', async () => {
         const { host, target } = createDynamicClass('foo');
         target.classList.add('bar');
         expect(target.className).toBe('foo bar');
 
         host.dynamicClass = 'baz';
-        return Promise.resolve().then(() => {
-            expect(target.className).toBe('bar baz');
-        });
+        await Promise.resolve();
+        expect(target.className).toBe('bar baz');
     });
 
     describe('updating with null/undefined/empty string', () => {

--- a/packages/@lwc/integration-not-karma/test/template/attribute-style/valid/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/attribute-style/valid/index.spec.js
@@ -38,7 +38,7 @@ describe('dynamic style attribute', () => {
     );
 
     function testUpdateStyleAttribute(type, value, expectedValue) {
-        it(`updates the style attribute for ${type}`, () => {
+        it(`updates the style attribute for ${type}`, async () => {
             const elm = createElement('x-dynamic', { is: Dynamic });
             elm.dynamicStyle = 'position: relative;';
             document.body.appendChild(elm);
@@ -48,11 +48,8 @@ describe('dynamic style attribute', () => {
             );
 
             elm.dynamicStyle = value;
-            return Promise.resolve().then(() => {
-                expect(elm.shadowRoot.querySelector('div').getAttribute('style')).toBe(
-                    expectedValue
-                );
-            });
+            await Promise.resolve();
+            expect(elm.shadowRoot.querySelector('div').getAttribute('style')).toBe(expectedValue);
         });
     }
 

--- a/packages/@lwc/integration-not-karma/test/template/attributes/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/attributes/index.spec.js
@@ -17,7 +17,7 @@ testRenderedAttribute('undefined', undefined, null);
 testRenderedAttribute('number', 1, '1');
 testRenderedAttribute('string', 'foo', 'foo');
 
-it(`should remove the existing attribute if set to null`, () => {
+it(`should remove the existing attribute if set to null`, async () => {
     const elm = createElement('x-test', { is: Test });
     elm.attr = 'initial value';
     document.body.appendChild(elm);
@@ -25,13 +25,12 @@ it(`should remove the existing attribute if set to null`, () => {
     expect(elm.shadowRoot.querySelector('div').getAttribute('title')).toBe('initial value');
 
     elm.attr = null;
-    return Promise.resolve().then(() => {
-        expect(elm.shadowRoot.querySelector('div').hasAttribute('title')).toBe(false);
-        expect(elm.shadowRoot.querySelector('div').getAttribute('title')).toBe(null);
-    });
+    await Promise.resolve();
+    expect(elm.shadowRoot.querySelector('div').hasAttribute('title')).toBe(false);
+    expect(elm.shadowRoot.querySelector('div').getAttribute('title')).toBe(null);
 });
 
-it(`should remove the existing attribute if set to undefined`, () => {
+it(`should remove the existing attribute if set to undefined`, async () => {
     const elm = createElement('x-test', { is: Test });
     elm.attr = 'initial value';
     document.body.appendChild(elm);
@@ -39,8 +38,7 @@ it(`should remove the existing attribute if set to undefined`, () => {
     expect(elm.shadowRoot.querySelector('div').getAttribute('title')).toBe('initial value');
 
     elm.attr = undefined;
-    return Promise.resolve().then(() => {
-        expect(elm.shadowRoot.querySelector('div').hasAttribute('title')).toBe(false);
-        expect(elm.shadowRoot.querySelector('div').getAttribute('title')).toBe(null);
-    });
+    await Promise.resolve();
+    expect(elm.shadowRoot.querySelector('div').hasAttribute('title')).toBe(false);
+    expect(elm.shadowRoot.querySelector('div').getAttribute('title')).toBe(null);
 });

--- a/packages/@lwc/integration-not-karma/test/template/directive-external/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/directive-external/index.spec.js
@@ -43,7 +43,7 @@ describe('lwc:external directive basic tests', () => {
         expect(slotContent[0].textContent).toBe('slot content');
     });
 
-    it('should render a Custom Element and handle hiding and showing the element', () => {
+    it('should render a Custom Element and handle hiding and showing the element', async () => {
         const elm = createElement('x-with-different-views', { is: XWithDifferentViews });
         document.body.appendChild(elm);
 
@@ -51,13 +51,12 @@ describe('lwc:external directive basic tests', () => {
         expect(ce).toBeNull();
 
         elm.showWC = true;
-        return Promise.resolve().then(() => {
-            ce = elm.shadowRoot.querySelector('ce-with-children');
-            expect(ce).not.toBeNull();
-        });
+        await Promise.resolve();
+        ce = elm.shadowRoot.querySelector('ce-with-children');
+        expect(ce).not.toBeNull();
     });
 
-    it('should imperatively listen to a DOM event dispatched by a Custom Element', () => {
+    it('should imperatively listen to a DOM event dispatched by a Custom Element', async () => {
         const elm = createElement('x-with-imperative-event', { is: XWithImperativeEvent });
         document.body.appendChild(elm);
 
@@ -66,12 +65,11 @@ describe('lwc:external directive basic tests', () => {
 
         const ce = elm.shadowRoot.querySelector('ce-with-event');
         ce.click();
-        return Promise.resolve().then(() => {
-            expect(handled.textContent).toBe('true');
-        });
+        await Promise.resolve();
+        expect(handled.textContent).toBe('true');
     });
 
-    it('should declaratively listen to a DOM event dispatched by a Custom Element', () => {
+    it('should declaratively listen to a DOM event dispatched by a Custom Element', async () => {
         const elm = createElement('x-with-declarative-event', { is: XWithDeclarativeEvent });
         document.body.appendChild(elm);
 
@@ -80,9 +78,8 @@ describe('lwc:external directive basic tests', () => {
 
         const ce = elm.shadowRoot.querySelector('ce-with-event');
         ce.click();
-        return Promise.resolve().then(() => {
-            expect(handled.textContent).toBe('true');
-        });
+        await Promise.resolve();
+        expect(handled.textContent).toBe('true');
     });
 
     it('should use unresolved HTMLElement if Custom Element is not registered', () => {
@@ -117,38 +114,35 @@ describe('lwc:external directive basic tests', () => {
             }).toLogWarningDev(unknownPropTokyo);
         });
 
-        it('should be stringified when set as an attribute', () => {
+        it('should be stringified when set as an attribute', async () => {
             elm.data = {};
 
-            return Promise.resolve().then(() => {
-                const ce = elm.shadowRoot.querySelector('ce-with-property');
-                expect(ce.getAttribute('attr')).toBe('[object Object]');
-            });
+            await Promise.resolve();
+            const ce = elm.shadowRoot.querySelector('ce-with-property');
+            expect(ce.getAttribute('attr')).toBe('[object Object]');
         });
 
-        it('should pass object without stringifying', () => {
+        it('should pass object without stringifying', async () => {
             const obj = {};
             elm.data = obj;
 
-            return Promise.resolve().then(() => {
-                const ce = elm.shadowRoot.querySelector('ce-with-property');
-                expect(ce.prop).toEqual(obj);
-            });
+            await Promise.resolve();
+            const ce = elm.shadowRoot.querySelector('ce-with-property');
+            expect(ce.prop).toEqual(obj);
         });
     });
 
-    it('should work with lwc:spread', () => {
+    it('should work with lwc:spread', async () => {
         const elm = createElement('x-with-property', { is: XWithProperty });
         expect(() => {
             document.body.appendChild(elm);
         }).toLogWarningDev(unknownPropTokyo);
 
-        return Promise.resolve().then(() => {
-            const ce = elm.shadowRoot.querySelector('ce-with-property');
-            expect(ce.kyoto).toBe('kamogawa river');
-            expect(ce.osaka).toBe('yodogawa river');
-            expect(ce.tokyo).toBe('tamagawa');
-        });
+        await Promise.resolve();
+        const ce = elm.shadowRoot.querySelector('ce-with-property');
+        expect(ce.kyoto).toBe('kamogawa river');
+        expect(ce.osaka).toBe('yodogawa river');
+        expect(ce.tokyo).toBe('tamagawa');
     });
 
     it('should work with camel case properties', async () => {
@@ -178,21 +172,19 @@ describe('lwc:external directive basic tests', () => {
             document.body.appendChild(elm);
         });
 
-        it('should set only attributes on mount', () => {
-            return Promise.resolve().then(() => {
-                const ce = elm.shadowRoot.querySelector('ce-not-registered');
-                expect(ce.getAttribute('attr')).toBe('default');
-                expect(elm.attr).toBeUndefined();
-            });
+        it('should set only attributes on mount', async () => {
+            await Promise.resolve();
+            const ce = elm.shadowRoot.querySelector('ce-not-registered');
+            expect(ce.getAttribute('attr')).toBe('default');
+            expect(elm.attr).toBeUndefined();
         });
 
-        it('should set only attributes on update', () => {
+        it('should set only attributes on update', async () => {
             elm.data = 'apple';
-            return Promise.resolve().then(() => {
-                const ce = elm.shadowRoot.querySelector('ce-not-registered');
-                expect(ce.getAttribute('attr')).toBe('apple');
-                expect(ce.attr).toBeUndefined();
-            });
+            await Promise.resolve();
+            const ce = elm.shadowRoot.querySelector('ce-not-registered');
+            expect(ce.getAttribute('attr')).toBe('apple');
+            expect(ce.attr).toBeUndefined();
         });
     });
 

--- a/packages/@lwc/integration-not-karma/test/template/directive-for-each/arrayMutation.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/directive-for-each/arrayMutation.spec.js
@@ -14,16 +14,14 @@ describe('Testing array primitives', () => {
     });
 
     function testReactivity(testCase, expectedItems, fn) {
-        it(`check ${testCase} reactivity`, function () {
+        it(`check ${testCase} reactivity`, async () => {
             fn(elm);
-            return Promise.resolve().then(function () {
-                var list = Array.prototype.slice.call(elm.shadowRoot.querySelectorAll('li'));
-
-                var textList = list.map(function (li) {
-                    return li.textContent;
-                });
-                expect(textList).toEqual(expectedItems);
+            await Promise.resolve();
+            var list = Array.prototype.slice.call(elm.shadowRoot.querySelectorAll('li'));
+            var textList = list.map(function (li) {
+                return li.textContent;
             });
+            expect(textList).toEqual(expectedItems);
         });
     }
 

--- a/packages/@lwc/integration-not-karma/test/template/directive-for-each/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/directive-for-each/index.spec.js
@@ -6,26 +6,22 @@ import ArrayNullPrototype from 'x/arrayNullPrototype';
 import { spyOn } from '@vitest/spy';
 
 function testForEach(type, obj) {
-    it(`should render ${type}`, () => {
+    it(`should render ${type}`, async () => {
         const elm = createElement('x-test', { is: XTest });
         document.body.appendChild(elm);
 
         expect(elm.shadowRoot.querySelector('ul').childElementCount).toBe(0);
         elm.items = obj;
 
-        return Promise.resolve()
-            .then(() => {
-                const ul = elm.shadowRoot.querySelector('ul');
-                expect(ul.childElementCount).toBe(3);
-                expect(ul.children[0].textContent).toBe('one');
-                expect(ul.children[1].textContent).toBe('two');
-                expect(ul.children[2].textContent).toBe('three');
-
-                elm.items = [];
-            })
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('ul').childElementCount).toBe(0);
-            });
+        await Promise.resolve();
+        const ul = elm.shadowRoot.querySelector('ul');
+        expect(ul.childElementCount).toBe(3);
+        expect(ul.children[0].textContent).toBe('one');
+        expect(ul.children[1].textContent).toBe('two');
+        expect(ul.children[2].textContent).toBe('three');
+        elm.items = [];
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('ul').childElementCount).toBe(0);
     });
 }
 

--- a/packages/@lwc/integration-not-karma/test/template/directive-if-elseif-else/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/directive-if-elseif-else/index.spec.js
@@ -30,7 +30,7 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
         expect(elm.shadowRoot.querySelector('.else')).not.toBeNull();
     });
 
-    it('should update which branch is rendered if the value changes', () => {
+    it('should update which branch is rendered if the value changes', async () => {
         const elm = createElement('x-test', { is: XTest });
         elm.showIf = true;
         document.body.appendChild(elm);
@@ -38,18 +38,14 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
         expect(elm.shadowRoot.querySelector('.if')).not.toBeNull();
 
         elm.showIf = false;
-        return Promise.resolve()
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.else')).not.toBeNull();
-                elm.showElseif = true;
-            })
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.elseif')).not.toBeNull();
-                elm.showIf = true;
-            })
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.if')).not.toBeNull();
-            });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.else')).not.toBeNull();
+        elm.showElseif = true;
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.elseif')).not.toBeNull();
+        elm.showIf = true;
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.if')).not.toBeNull();
     });
 
     it('should render content when nested inside another if branch', () => {
@@ -61,7 +57,7 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
         expect(element.shadowRoot.querySelector('.nestedContent')).not.toBeNull();
     });
 
-    it('should rerender content when nested inside another if branch', () => {
+    it('should rerender content when nested inside another if branch', async () => {
         const element = createElement('x-nested', { is: XNested });
         element.showContent = true;
         document.body.appendChild(element);
@@ -69,9 +65,8 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
         expect(element.shadowRoot.querySelector('.nestedElse')).not.toBeNull();
 
         element.showNestedContent = true;
-        return Promise.resolve().then(() => {
-            expect(element.shadowRoot.querySelector('.nestedContent')).not.toBeNull();
-        });
+        await Promise.resolve();
+        expect(element.shadowRoot.querySelector('.nestedContent')).not.toBeNull();
     });
 
     describe('foreach', () => {
@@ -83,7 +78,7 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
             expect(element.shadowRoot.querySelector('.if').textContent).toBe('h123f');
         });
 
-        it('should rerender list content when updated', () => {
+        it('should rerender list content when updated', async () => {
             const element = createElement('x-for-each', { is: XForEach });
             element.showList = true;
             document.body.appendChild(element);
@@ -95,31 +90,25 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
                 show: true,
             });
 
-            return Promise.resolve()
-                .then(() => {
-                    expect(element.shadowRoot.querySelector('.if').textContent).toBe('h1234f');
-
-                    element.showList = false;
-                    element.appendToList({
-                        value: 5,
-                        show: true,
-                    });
-                    element.prependToList({
-                        value: 0,
-                        show: true,
-                    });
-                })
-                .then(() => {
-                    expect(element.shadowRoot.querySelector('.if')).toBeNull();
-
-                    element.showList = true;
-                })
-                .then(() => {
-                    expect(element.shadowRoot.querySelector('.if').textContent).toBe('h012345f');
-                });
+            await Promise.resolve();
+            expect(element.shadowRoot.querySelector('.if').textContent).toBe('h1234f');
+            element.showList = false;
+            element.appendToList({
+                value: 5,
+                show: true,
+            });
+            element.prependToList({
+                value: 0,
+                show: true,
+            });
+            await Promise.resolve();
+            expect(element.shadowRoot.querySelector('.if')).toBeNull();
+            element.showList = true;
+            await Promise.resolve();
+            expect(element.shadowRoot.querySelector('.if').textContent).toBe('h012345f');
         });
 
-        it('should rerender list items when conditional expressions change', () => {
+        it('should rerender list items when conditional expressions change', async () => {
             const element = createElement('x-for-each', { is: XForEach });
             element.showList = true;
             document.body.appendChild(element);
@@ -131,25 +120,19 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
                 show: false,
             });
 
-            return Promise.resolve()
-                .then(() => {
-                    expect(element.shadowRoot.querySelector('.if').textContent).toBe('h123f');
-
-                    element.show(4);
-                })
-                .then(() => {
-                    expect(element.shadowRoot.querySelector('.if').textContent).toBe('h1234f');
-
-                    element.hide(1);
-                    element.hide(3);
-                    element.prependToList({
-                        value: 0,
-                        show: true,
-                    });
-                })
-                .then(() => {
-                    expect(element.shadowRoot.querySelector('.if').textContent).toBe('h024f');
-                });
+            await Promise.resolve();
+            expect(element.shadowRoot.querySelector('.if').textContent).toBe('h123f');
+            element.show(4);
+            await Promise.resolve();
+            expect(element.shadowRoot.querySelector('.if').textContent).toBe('h1234f');
+            element.hide(1);
+            element.hide(3);
+            element.prependToList({
+                value: 0,
+                show: true,
+            });
+            await Promise.resolve();
+            expect(element.shadowRoot.querySelector('.if').textContent).toBe('h024f');
         });
     });
 
@@ -171,7 +154,7 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
             }
         }
 
-        it('should properly assign content for slots', () => {
+        it('should properly assign content for slots', async () => {
             const element = createElement('x-parent', { is: XparentWithSlot });
             document.body.appendChild(element);
 
@@ -180,13 +163,12 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
             // When if condition is false, no slot content is provided by parent
             verifyExpectedSlotContent(child, false);
             element.condition = true;
-            return Promise.resolve().then(() => {
-                // Slot content should be provided when condition is true
-                verifyExpectedSlotContent(child, true);
-            });
+            await Promise.resolve();
+            // Slot content should be provided when condition is true
+            verifyExpectedSlotContent(child, true);
         });
 
-        it('should properly rerender content for slots', () => {
+        it('should properly rerender content for slots', async () => {
             const element = createElement('x-parent', { is: XparentWithSlot });
             element.condition = true;
             document.body.appendChild(element);
@@ -196,18 +178,14 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
             verifyExpectedSlotContent(child, true);
 
             element.condition = false;
-            return Promise.resolve()
-                .then(() => {
-                    verifyExpectedSlotContent(child, false);
-
-                    element.condition = true;
-                })
-                .then(() => {
-                    verifyExpectedSlotContent(child, true);
-                });
+            await Promise.resolve();
+            verifyExpectedSlotContent(child, false);
+            element.condition = true;
+            await Promise.resolve();
+            verifyExpectedSlotContent(child, true);
         });
 
-        it('should properly rerender list content nested inside slots', () => {
+        it('should properly rerender list content nested inside slots', async () => {
             const element = createElement('x-slotted-for-each', { is: XSlottedForEach });
             element.showList = true;
             document.body.appendChild(element);
@@ -221,28 +199,21 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
                 show: false,
             });
 
-            return Promise.resolve()
-                .then(() => {
-                    expect(child.textContent).toBe('Hh123fF');
-
-                    element.show(4);
-                })
-                .then(() => {
-                    expect(child.textContent).toBe('Hh1234fF');
-                    element.hide(1);
-                })
-                .then(() => {
-                    expect(child.textContent).toBe('Hh234fF');
-
-                    element.hide(3);
-                    element.prependToList({
-                        value: 0,
-                        show: true,
-                    });
-                })
-                .then(() => {
-                    expect(child.textContent).toBe('Hh024fF');
-                });
+            await Promise.resolve();
+            expect(child.textContent).toBe('Hh123fF');
+            element.show(4);
+            await Promise.resolve();
+            expect(child.textContent).toBe('Hh1234fF');
+            element.hide(1);
+            await Promise.resolve();
+            expect(child.textContent).toBe('Hh234fF');
+            element.hide(3);
+            element.prependToList({
+                value: 0,
+                show: true,
+            });
+            await Promise.resolve();
+            expect(child.textContent).toBe('Hh024fF');
         });
 
         describe('named slots', () => {
@@ -276,7 +247,7 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
                 expect(child.shadowRoot.querySelector('.defaultSlot')).not.toBeNull();
             }
 
-            it('should properly assign content for named slots', () => {
+            it('should properly assign content for named slots', async () => {
                 const element = createElement('x-parent', { is: XparentWithNamedSlot });
                 document.body.appendChild(element);
 
@@ -285,12 +256,11 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
                 // When if condition is false, no slot content is provided by parent
                 verifyExpectedNamedSlotContent(child, false);
                 element.condition = true;
-                return Promise.resolve().then(() => {
-                    verifyExpectedNamedSlotContent(child, true);
-                });
+                await Promise.resolve();
+                verifyExpectedNamedSlotContent(child, true);
             });
 
-            it('should properly rerender content for named slots', () => {
+            it('should properly rerender content for named slots', async () => {
                 const element = createElement('x-parent', { is: XparentWithNamedSlot });
                 element.condition = true;
 
@@ -301,19 +271,16 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
                 verifyDefaultSlotContent(child);
 
                 element.condition = false;
-                return Promise.resolve()
-                    .then(() => {
-                        verifyExpectedNamedSlotContent(child, false);
-                        verifyDefaultSlotContent(child);
-                        element.condition = true;
-                    })
-                    .then(() => {
-                        verifyExpectedNamedSlotContent(child, true);
-                        verifyDefaultSlotContent(child);
-                    });
+                await Promise.resolve();
+                verifyExpectedNamedSlotContent(child, false);
+                verifyDefaultSlotContent(child);
+                element.condition = true;
+                await Promise.resolve();
+                verifyExpectedNamedSlotContent(child, true);
+                verifyDefaultSlotContent(child);
             });
 
-            it('should not override default slot content when no elements are explicitly passed to the default slot', () => {
+            it('should not override default slot content when no elements are explicitly passed to the default slot', async () => {
                 const element = createElement('x-parent', { is: XparentWithNamedSlot });
                 element.condition = true;
                 document.body.appendChild(element);
@@ -322,9 +289,8 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
                 verifyDefaultSlotContent(child);
 
                 element.nestedNamedSlot = true;
-                return Promise.resolve().then(() => {
-                    verifyDefaultSlotContent(child);
-                });
+                await Promise.resolve();
+                verifyDefaultSlotContent(child);
             });
 
             it('should override default slot content when nested conditional elements are passed to the default slot', () => {
@@ -341,7 +307,7 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
                 expect(assignedNodes[1].innerHTML).toBe('additional default slot content');
             });
 
-            it('should properly rerender nested conditional slot content', () => {
+            it('should properly rerender nested conditional slot content', async () => {
                 const element = createElement('x-parent', { is: XparentWithNamedSlot });
                 element.condition = true;
                 element.nestedDefaultSlot = true;
@@ -354,11 +320,10 @@ describe('lwc:if, lwc:elseif, lwc:else directives', () => {
 
                 element.nestedNamedSlot = true;
                 element.nestedDefaultSlot = false;
-                return Promise.resolve().then(() => {
-                    const assignedNodes = child.shadowRoot.querySelector('slot').assignedNodes();
-                    expect(assignedNodes.length).toBe(4);
-                    expect(assignedNodes[2].innerHTML).toBe('nested slot content');
-                });
+                await Promise.resolve();
+                const assignedNodes_1 = child.shadowRoot.querySelector('slot').assignedNodes();
+                expect(assignedNodes_1.length).toBe(4);
+                expect(assignedNodes_1[2].innerHTML).toBe('nested slot content');
             });
         });
     });

--- a/packages/@lwc/integration-not-karma/test/template/directive-if/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/directive-if/index.spec.js
@@ -21,7 +21,7 @@ describe('if:true directive', () => {
         expect(elm.shadowRoot.querySelector('.true')).toBeNull();
     });
 
-    it('should remove element within a nested conditional', () => {
+    it('should remove element within a nested conditional', async () => {
         const elm = createElement('x-nested-render-conditional', { is: NestedRenderConditional });
         document.body.appendChild(elm);
 
@@ -29,14 +29,12 @@ describe('if:true directive', () => {
 
         elementToggler.click();
 
-        return Promise.resolve().then(() => {
-            const elementInsideNestedCondition = elm.shadowRoot.querySelector('.toggle');
-
-            expect(elementInsideNestedCondition).toBeNull();
-        });
+        await Promise.resolve();
+        const elementInsideNestedCondition = elm.shadowRoot.querySelector('.toggle');
+        expect(elementInsideNestedCondition).toBeNull();
     });
 
-    it('should update if the value change', () => {
+    it('should update if the value change', async () => {
         const elm = createElement('x-test', { is: XTest });
         elm.isVisible = true;
         document.body.appendChild(elm);
@@ -44,36 +42,29 @@ describe('if:true directive', () => {
         expect(elm.shadowRoot.querySelector('.true')).not.toBeNull();
 
         elm.isVisible = false;
-        return Promise.resolve()
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.true')).toBeNull();
-                elm.isVisible = {};
-            })
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.true')).not.toBeNull();
-                elm.isVisible = 0;
-            })
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.true')).toBeNull();
-                elm.isVisible = 1;
-            })
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.true')).not.toBeNull();
-                elm.isVisible = null;
-            })
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.true')).toBeNull();
-                elm.isVisible = [];
-            })
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.true')).not.toBeNull();
-            });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.true')).toBeNull();
+        elm.isVisible = {};
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.true')).not.toBeNull();
+        elm.isVisible = 0;
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.true')).toBeNull();
+        elm.isVisible = 1;
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.true')).not.toBeNull();
+        elm.isVisible = null;
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.true')).toBeNull();
+        elm.isVisible = [];
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.true')).not.toBeNull();
     });
     // In native shadow, the slotted content from parent is always queriable, its only the
     // child's <slot> that is rendered/unrendered based on the directive
     it.runIf(process.env.NATIVE_SHADOW)(
         'should update child with slot content if value changes',
-        () => {
+        async () => {
             const elm = createElement('x-test', { is: XSlotted });
             document.body.appendChild(elm);
             const assignedSlotContent = elm.shadowRoot.querySelector('div.content');
@@ -83,31 +74,27 @@ describe('if:true directive', () => {
 
             child.show = true;
 
-            return Promise.resolve()
-                .then(() => {
-                    const slot = child.shadowRoot.querySelector('slot');
-                    expect(slot).not.toBeNull();
-                    const assignedNodes = slot.assignedNodes({ flatten: true });
-                    expect(assignedNodes.length).toBe(1);
-                    expect(assignedNodes[0]).toBe(assignedSlotContent);
-                    child.show = false;
-                })
-                .then(() => {
-                    expect(child.shadowRoot.querySelector('slot')).toBeNull();
-                    child.show = true;
-                })
-                .then(() => {
-                    const slot = child.shadowRoot.querySelector('slot');
-                    expect(slot).not.toBeNull();
-                    const assignedNodes = slot.assignedNodes({ flatten: true });
-                    expect(assignedNodes.length).toBe(1);
-                    expect(assignedNodes[0]).toBe(assignedSlotContent);
-                });
+            await Promise.resolve();
+            const slot = child.shadowRoot.querySelector('slot');
+            expect(slot).not.toBeNull();
+            const assignedNodes = slot.assignedNodes({ flatten: true });
+            expect(assignedNodes.length).toBe(1);
+            expect(assignedNodes[0]).toBe(assignedSlotContent);
+            child.show = false;
+            await Promise.resolve();
+            expect(child.shadowRoot.querySelector('slot')).toBeNull();
+            child.show = true;
+            await Promise.resolve();
+            const slot_1 = child.shadowRoot.querySelector('slot');
+            expect(slot_1).not.toBeNull();
+            const assignedNodes_1 = slot_1.assignedNodes({ flatten: true });
+            expect(assignedNodes_1.length).toBe(1);
+            expect(assignedNodes_1[0]).toBe(assignedSlotContent);
         }
     );
     it.skipIf(process.env.NATIVE_SHADOW)(
         'should update child with slot content if value changes',
-        () => {
+        async () => {
             const elm = createElement('x-test', { is: XSlotted });
             document.body.appendChild(elm);
             const child = elm.shadowRoot.querySelector('x-child');
@@ -116,22 +103,18 @@ describe('if:true directive', () => {
 
             child.show = true;
 
-            return Promise.resolve()
-                .then(() => {
-                    expect(child.querySelector('.content')).not.toBeNull();
-                    child.show = false;
-                })
-                .then(() => {
-                    expect(child.querySelector('.content')).toBeNull();
-                    child.show = true;
-                })
-                .then(() => {
-                    expect(child.querySelector('.content')).not.toBeNull();
-                });
+            await Promise.resolve();
+            expect(child.querySelector('.content')).not.toBeNull();
+            child.show = false;
+            await Promise.resolve();
+            expect(child.querySelector('.content')).toBeNull();
+            child.show = true;
+            await Promise.resolve();
+            expect(child.querySelector('.content')).not.toBeNull();
         }
     );
 
-    it('should continue rendering content for nested slots after multiple rehydrations', () => {
+    it('should continue rendering content for nested slots after multiple rehydrations', async () => {
         const elm = createElement('x-multiple-slot', { is: MultipleSlot });
         document.body.appendChild(elm);
         const multipleSlotLevel1 = elm.shadowRoot.querySelector('x-multiple-slot-level1');
@@ -139,30 +122,23 @@ describe('if:true directive', () => {
 
         textToggleButton.click();
 
-        return Promise.resolve()
-            .then(() => {
-                const multipleSlotLevel2 = multipleSlotLevel1.shadowRoot
-                    .querySelector('slot')
-                    .assignedElements()[0];
-
-                expect(multipleSlotLevel2.textContent).toContain('text in multiple level slot');
-                // hide the slot
-                textToggleButton.click();
-            })
-            .then(() => {
-                const slotLevel1 = multipleSlotLevel1.shadowRoot.querySelector('slot');
-
-                expect(slotLevel1).toBe(null);
-                // show the slot
-                textToggleButton.click();
-            })
-            .then(() => {
-                const multipleSlotLevel2 = multipleSlotLevel1.shadowRoot
-                    .querySelector('slot')
-                    .assignedElements()[0];
-
-                expect(multipleSlotLevel2.textContent).toContain('text in multiple level slot');
-            });
+        await Promise.resolve();
+        const multipleSlotLevel2 = multipleSlotLevel1.shadowRoot
+            .querySelector('slot')
+            .assignedElements()[0];
+        expect(multipleSlotLevel2.textContent).toContain('text in multiple level slot');
+        // hide the slot
+        textToggleButton.click();
+        await Promise.resolve();
+        const slotLevel1 = multipleSlotLevel1.shadowRoot.querySelector('slot');
+        expect(slotLevel1).toBe(null);
+        // show the slot
+        textToggleButton.click();
+        await Promise.resolve();
+        const multipleSlotLevel2_1 = multipleSlotLevel1.shadowRoot
+            .querySelector('slot')
+            .assignedElements()[0];
+        expect(multipleSlotLevel2_1.textContent).toContain('text in multiple level slot');
     });
 });
 
@@ -183,7 +159,7 @@ describe('if:false directive', () => {
         expect(elm.shadowRoot.querySelector('.false')).not.toBeNull();
     });
 
-    it('should update if the value change', () => {
+    it('should update if the value change', async () => {
         const elm = createElement('x-test', { is: XTest });
         elm.isVisible = true;
         document.body.appendChild(elm);
@@ -191,29 +167,22 @@ describe('if:false directive', () => {
         expect(elm.shadowRoot.querySelector('.false')).toBeNull();
 
         elm.isVisible = false;
-        return Promise.resolve()
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.false')).not.toBeNull();
-                elm.isVisible = {};
-            })
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.false')).toBeNull();
-                elm.isVisible = 0;
-            })
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.false')).not.toBeNull();
-                elm.isVisible = 1;
-            })
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.false')).toBeNull();
-                elm.isVisible = null;
-            })
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.false')).not.toBeNull();
-                elm.isVisible = [];
-            })
-            .then(() => {
-                expect(elm.shadowRoot.querySelector('.false')).toBeNull();
-            });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.false')).not.toBeNull();
+        elm.isVisible = {};
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.false')).toBeNull();
+        elm.isVisible = 0;
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.false')).not.toBeNull();
+        elm.isVisible = 1;
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.false')).toBeNull();
+        elm.isVisible = null;
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.false')).not.toBeNull();
+        elm.isVisible = [];
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('.false')).toBeNull();
     });
 });

--- a/packages/@lwc/integration-not-karma/test/template/directive-lwc-dom-manual/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/directive-lwc-dom-manual/index.spec.js
@@ -134,29 +134,27 @@ describe('adopt node in the shadow', () => {
         expect(inner.parentElement.parentElement).toBe(elm);
     });
 
-    it('should apply the component styles to inserted elements', () => {
+    it('should apply the component styles to inserted elements', async () => {
         const root = createElement('x-test', { is: withLwcDomManual });
         document.body.appendChild(root);
 
         const elm = root.shadowRoot.querySelector('div');
         elm.innerHTML = '<div class="foo"></div>';
 
-        return waitForStyleToBeApplied().then(() => {
-            expect(window.getComputedStyle(elm.firstElementChild).fontSize).toBe('10px');
-        });
+        await waitForStyleToBeApplied();
+        expect(window.getComputedStyle(elm.firstElementChild).fontSize).toBe('10px');
     });
 
-    it('#871 - should apply style to inserted SVG elements', () => {
+    it('#871 - should apply style to inserted SVG elements', async () => {
         const root = createElement('x-test', { is: SvgWithLwcDomManual });
         document.body.appendChild(root);
 
         const svgElm = root.shadowRoot.querySelector('svg');
         svgElm.innerHTML = '<rect></rect>';
 
-        return waitForStyleToBeApplied().then(() => {
-            // Use firstChild instead of firstElementChild since accessing firstElementChild in an SVG element on
-            // IE11 throws an error.
-            expect(window.getComputedStyle(svgElm.firstChild).fill).toBe('rgb(0, 255, 0)');
-        });
+        await waitForStyleToBeApplied();
+        // Use firstChild instead of firstElementChild since accessing firstElementChild in an SVG element on
+        // IE11 throws an error.
+        expect(window.getComputedStyle(svgElm.firstChild).fill).toBe('rgb(0, 255, 0)');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/template/directive-lwc-inner-html/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/directive-lwc-inner-html/index.spec.js
@@ -31,7 +31,7 @@ it('renders the content as HTML', async () => {
     expect(div.childNodes[1].textContent).toBe('World');
 });
 
-it('re-renders the content on update', () => {
+it('re-renders the content on update', async () => {
     const elm = createElement('x-inner-html', { is: XInnerHtml });
     elm.content = 'Hello <b>World</b>';
     document.body.appendChild(elm);
@@ -40,10 +40,9 @@ it('re-renders the content on update', () => {
     expect(b.textContent).toBe('World');
 
     elm.content = 'Hello <b>LWC</b>';
-    return Promise.resolve().then(() => {
-        const b = elm.shadowRoot.querySelector('b');
-        expect(b.textContent).toBe('LWC');
-    });
+    await Promise.resolve();
+    const b_1 = elm.shadowRoot.querySelector('b');
+    expect(b_1.textContent).toBe('LWC');
 });
 
 describe('type conversion', () => {

--- a/packages/@lwc/integration-not-karma/test/template/html-comments/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/html-comments/index.spec.js
@@ -12,7 +12,7 @@ function getChildrenComments(node) {
 }
 
 describe('html comments', () => {
-    it('should be rendered within if', () => {
+    it('should be rendered within if', async () => {
         const elm = createElement('x-test', { is: Test });
         elm.count = 1;
         document.body.appendChild(elm);
@@ -23,14 +23,13 @@ describe('html comments', () => {
 
         elm.count = 2;
 
-        return Promise.resolve().then(() => {
-            comments = getChildrenComments(elm.shadowRoot);
-            expect(comments).toContain('Comment for even number');
-            expect(comments).not.toContain('Comment for odd number');
-        });
+        await Promise.resolve();
+        comments = getChildrenComments(elm.shadowRoot);
+        expect(comments).toContain('Comment for even number');
+        expect(comments).not.toContain('Comment for odd number');
     });
 
-    it('should be rendered within for:each', () => {
+    it('should be rendered within for:each', async () => {
         const elm = createElement('x-test', { is: Test });
         elm.count = 1;
         document.body.appendChild(elm);
@@ -40,13 +39,12 @@ describe('html comments', () => {
 
         elm.count = 2;
 
-        return Promise.resolve().then(() => {
-            comments = getChildrenComments(elm.shadowRoot);
-            expect(comments.filter((c) => c === 'Comment inside for:each')).toHaveSize(2);
-        });
+        await Promise.resolve();
+        comments = getChildrenComments(elm.shadowRoot);
+        expect(comments.filter((c_1) => c_1 === 'Comment inside for:each')).toHaveSize(2);
     });
 
-    it('should be rendered within slots', () => {
+    it('should be rendered within slots', async () => {
         const elm = createElement('x-test', { is: Test });
         elm.count = 1;
         document.body.appendChild(elm);
@@ -58,13 +56,12 @@ describe('html comments', () => {
 
         elm.count = 2;
 
-        return Promise.resolve().then(() => {
-            comments = getChildrenComments(child);
-            expect(comments).not.toContain('slotted:odd comment');
-        });
+        await Promise.resolve();
+        comments = getChildrenComments(child);
+        expect(comments).not.toContain('slotted:odd comment');
     });
 
-    it('should not confuse comments with text nodes', () => {
+    it('should not confuse comments with text nodes', async () => {
         const elm = createElement('x-confused-with-text', { is: ConfusedWithText });
         document.body.appendChild(elm);
 
@@ -72,10 +69,9 @@ describe('html comments', () => {
 
         elm.comments = ['comment'];
 
-        return Promise.resolve().then(() => {
-            const comments = getChildrenComments(elm.shadowRoot);
-            expect(comments).toContain('Comment inside for:each');
-            expect(elm.shadowRoot.textContent).toBe('hellocommentworld');
-        });
+        await Promise.resolve();
+        const comments = getChildrenComments(elm.shadowRoot);
+        expect(comments).toContain('Comment inside for:each');
+        expect(elm.shadowRoot.textContent).toBe('hellocommentworld');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/template/properties/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/template/properties/index.spec.js
@@ -16,7 +16,7 @@ describe('live properties', () => {
             expect(elm.shadowRoot.querySelector('input').checked).toBe(true);
         });
 
-        it('should use the DOM value for diffing', () => {
+        it('should use the DOM value for diffing', async () => {
             const elm = createElement('live-input-checked', { is: InputChecked });
             elm.checkedValue = true;
             document.body.appendChild(elm);
@@ -25,9 +25,8 @@ describe('live properties', () => {
             elm.shadowRoot.querySelector('input').checked = false;
             elm.checkedValue = true;
 
-            return Promise.resolve().then(() => {
-                expect(elm.shadowRoot.querySelector('input').checked).toBe(true);
-            });
+            await Promise.resolve();
+            expect(elm.shadowRoot.querySelector('input').checked).toBe(true);
         });
     });
 
@@ -40,7 +39,7 @@ describe('live properties', () => {
             expect(elm.shadowRoot.querySelector('input').value).toBe('foo bar');
         });
 
-        it('should use the DOM value for diffing', () => {
+        it('should use the DOM value for diffing', async () => {
             const elm = createElement('live-input-value', { is: InputValue });
             elm.checkedValue = 'foo bar';
             document.body.appendChild(elm);
@@ -49,38 +48,35 @@ describe('live properties', () => {
             elm.shadowRoot.querySelector('input').value = 'bar baz';
             elm.valueValue = 'foo bar';
 
-            return Promise.resolve().then(() => {
-                expect(elm.shadowRoot.querySelector('input').value).toBe('foo bar');
-            });
+            await Promise.resolve();
+            expect(elm.shadowRoot.querySelector('input').value).toBe('foo bar');
         });
     });
 });
 
 describe('custom properties', () => {
-    it('should allow attribute value with underscore', () => {
+    it('should allow attribute value with underscore', async () => {
         const elm = createElement('attrs-special-character', { is: SpecialCharacterPublicProp });
         document.body.appendChild(elm);
 
         expect(elm.public_prop).toBe('underscore property');
 
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('attrs-underscore-child').under_score).toEqual(
-                'underscore property'
-            );
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('attrs-underscore-child').under_score).toEqual(
+            'underscore property'
+        );
     });
 
-    it('should allow attribute name with a leading uppercase character', () => {
+    it('should allow attribute name with a leading uppercase character', async () => {
         const elm = createElement('attrs-uppercase-parent', {
             is: UppercaseCharacterPublicPropParent,
         });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            expect(elm.shadowRoot.querySelector('attrs-uppercase-child').Upper).toEqual(
-                'uppercase value from parent component'
-            );
-        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('attrs-uppercase-child').Upper).toEqual(
+            'uppercase value from parent component'
+        );
     });
 });
 

--- a/packages/@lwc/integration-not-karma/test/wire/property-trap/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/wire/property-trap/index.spec.js
@@ -4,28 +4,26 @@ import EchoAdapterConsumer from 'x/echoAdapterConsumer';
 import { EchoWireAdapter } from 'x/echoAdapter';
 
 describe('wire adapter update', () => {
-    it('should invoke listener with reactive parameter default value', () => {
+    it('should invoke listener with reactive parameter default value', async () => {
         const elm = createElement('x-echo-adapter-consumer', { is: EchoAdapterConsumer });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const actualWiredValues = elm.getWiredProp();
-            expect(actualWiredValues.data.recordId).toBe('default value');
-        });
+        await Promise.resolve();
+        const actualWiredValues = elm.getWiredProp();
+        expect(actualWiredValues.data.recordId).toBe('default value');
     });
 
-    xit('should invoke listener with reactive parameter is an expando and change', () => {
+    xit('should invoke listener with reactive parameter is an expando and change', async () => {
         const elm = createElement('x-echo-adapter-consumer', { is: EchoAdapterConsumer });
         document.body.appendChild(elm);
 
         elm.setExpandoValue('expando modified value');
-        return Promise.resolve().then(() => {
-            const actualWiredValues = elm.getWiredProp();
-            expect(actualWiredValues.data.expando).toBe('expando modified value');
-        });
+        await Promise.resolve();
+        const actualWiredValues = elm.getWiredProp();
+        expect(actualWiredValues.data.expando).toBe('expando modified value');
     });
 
-    it('should not invoke update when parameter value is unchanged', () => {
+    it('should not invoke update when parameter value is unchanged', async () => {
         const spy = [];
         EchoWireAdapter.setSpy(spy);
         const wireKey = { b: { c: { d: 'a.b.c.d value' } } };
@@ -34,141 +32,128 @@ describe('wire adapter update', () => {
         elm.setWireKeyParameter(wireKey);
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const actualWiredValues = elm.getWiredProp();
-            expect(spy).toHaveSize(1);
-            expect(actualWiredValues.data.recordId).toBe('default value');
-            elm.setWireKeyParameter(wireKey);
-
-            return Promise.resolve().then(() => {
-                expect(spy).toHaveSize(1);
-            });
-        });
+        await Promise.resolve();
+        const actualWiredValues = elm.getWiredProp();
+        expect(spy).toHaveSize(1);
+        expect(actualWiredValues.data.recordId).toBe('default value');
+        elm.setWireKeyParameter(wireKey);
+        await Promise.resolve();
+        expect(spy).toHaveSize(1);
     });
 
-    it('should invoke listener with getter value', () => {
+    it('should invoke listener with getter value', async () => {
         const elm = createElement('x-echo-adapter-consumer', { is: EchoAdapterConsumer });
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const actualWiredValues = elm.getWiredProp();
-            expect(actualWiredValues.data.getterValue).toBe('getterValue');
-        });
+        await Promise.resolve();
+        const actualWiredValues = elm.getWiredProp();
+        expect(actualWiredValues.data.getterValue).toBe('getterValue');
     });
 
-    it('should react invoke listener with getter value when dependant value is updated', () => {
+    it('should react invoke listener with getter value when dependant value is updated', async () => {
         const elm = createElement('x-echo-adapter-consumer', { is: EchoAdapterConsumer });
         document.body.appendChild(elm);
 
         elm.setMutatedGetterValue(' mutated');
 
-        return Promise.resolve().then(() => {
-            const actualWiredValues = elm.getWiredProp();
-            expect(actualWiredValues.data.getterValue).toBe('getterValue mutated');
-        });
+        await Promise.resolve();
+        const actualWiredValues = elm.getWiredProp();
+        expect(actualWiredValues.data.getterValue).toBe('getterValue mutated');
     });
 
     describe('reactivity when vm.isDirty === true', () => {
-        it('should call update with value set before connected (using observed fields)', () => {
+        it('should call update with value set before connected (using observed fields)', async () => {
             const wireKey = { b: { c: { d: 'expected' } } };
             const elm = createElement('x-echo-adapter-consumer', { is: EchoAdapterConsumer });
             elm.setWireKeyParameter(wireKey);
 
             document.body.appendChild(elm);
 
-            return Promise.resolve().then(() => {
-                const actualWiredValues = elm.getWiredProp();
-                expect(actualWiredValues.data.keyVal).toBe('expected');
-            });
+            await Promise.resolve();
+            const actualWiredValues = elm.getWiredProp();
+            expect(actualWiredValues.data.keyVal).toBe('expected');
         });
 
-        it('should call update when value set in setter (using @track) that makes dirty the vm', () => {
+        it('should call update when value set in setter (using @track) that makes dirty the vm', async () => {
             const wireKey = { b: { c: { d: 'a.b.c.d value' } } };
             const elm = createElement('x-echo-adapter-consumer', { is: EchoAdapterConsumer });
 
             document.body.appendChild(elm);
             elm.setTrackedPropAndWireKeyParameter(wireKey);
 
-            return Promise.resolve().then(() => {
-                const actualWiredValues = elm.getWiredProp();
-                expect(actualWiredValues.data.keyVal).toBe('a.b.c.d value');
-            });
+            await Promise.resolve();
+            const actualWiredValues = elm.getWiredProp();
+            expect(actualWiredValues.data.keyVal).toBe('a.b.c.d value');
         });
 
-        it('should call update when value set in setter (using @api) that makes dirty the vm', () => {
+        it('should call update when value set in setter (using @api) that makes dirty the vm', async () => {
             const elm = createElement('x-echo-adapter-consumer', { is: EchoAdapterConsumer });
             // done before connected, so we ensure the component is dirty.
             elm.recordId = 'modified Value';
 
             document.body.appendChild(elm);
 
-            return Promise.resolve().then(() => {
-                const actualWiredValues = elm.getWiredProp();
-                expect(actualWiredValues.data.recordId).toBe('modified Value');
-            });
+            await Promise.resolve();
+            const actualWiredValues = elm.getWiredProp();
+            expect(actualWiredValues.data.recordId).toBe('modified Value');
         });
     });
 });
 
 describe('reactive parameter', () => {
-    it('should return value when multiple levels deep', () => {
+    it('should return value when multiple levels deep', async () => {
         const elm = createElement('x-echo-adapter-consumer', { is: EchoAdapterConsumer });
         document.body.appendChild(elm);
 
         elm.setWireKeyParameter({ b: { c: { d: 'a.b.c.d value' } } });
 
-        return Promise.resolve().then(() => {
-            const actualWiredValues = elm.getWiredProp();
-            expect(actualWiredValues.data.keyVal).toBe('a.b.c.d value');
-        });
+        await Promise.resolve();
+        const actualWiredValues = elm.getWiredProp();
+        expect(actualWiredValues.data.keyVal).toBe('a.b.c.d value');
     });
 
-    it('should return object value', () => {
+    it('should return object value', async () => {
         const elm = createElement('x-echo-adapter-consumer', { is: EchoAdapterConsumer });
         document.body.appendChild(elm);
 
         const expected = { e: { f: 'expected' } };
         elm.setWireKeyParameter({ b: { c: { d: expected } } });
 
-        return Promise.resolve().then(() => {
-            const actualWiredValues = elm.getWiredProp();
-            expect(actualWiredValues.data.keyVal).toBe(expected);
-        });
+        await Promise.resolve();
+        const actualWiredValues = elm.getWiredProp();
+        expect(actualWiredValues.data.keyVal).toBe(expected);
     });
 
-    it('should return undefined when root is undefined', () => {
+    it('should return undefined when root is undefined', async () => {
         const elm = createElement('x-echo-adapter-consumer', { is: EchoAdapterConsumer });
         document.body.appendChild(elm);
 
         elm.setWireKeyParameter(undefined);
 
-        return Promise.resolve().then(() => {
-            const actualWiredValues = elm.getWiredProp();
-            expect(actualWiredValues.data.keyVal).toBe(undefined);
-        });
+        await Promise.resolve();
+        const actualWiredValues = elm.getWiredProp();
+        expect(actualWiredValues.data.keyVal).toBe(undefined);
     });
 
-    it('should return undefined when part of the value is not defined', () => {
+    it('should return undefined when part of the value is not defined', async () => {
         const elm = createElement('x-echo-adapter-consumer', { is: EchoAdapterConsumer });
         document.body.appendChild(elm);
 
         elm.setWireKeyParameter({ b: undefined });
 
-        return Promise.resolve().then(() => {
-            const actualWiredValues = elm.getWiredProp();
-            expect(actualWiredValues.data.keyVal).toBe(undefined);
-        });
+        await Promise.resolve();
+        const actualWiredValues = elm.getWiredProp();
+        expect(actualWiredValues.data.keyVal).toBe(undefined);
     });
 
-    it('should return undefined when a segment is not found', () => {
+    it('should return undefined when a segment is not found', async () => {
         const elm = createElement('x-echo-adapter-consumer', { is: EchoAdapterConsumer });
         document.body.appendChild(elm);
 
         elm.setWireKeyParameter({ b: { fooNotC: 'a.b.c.d value' } });
 
-        return Promise.resolve().then(() => {
-            const actualWiredValues = elm.getWiredProp();
-            expect(actualWiredValues.data.keyVal).toBe(undefined);
-        });
+        await Promise.resolve();
+        const actualWiredValues = elm.getWiredProp();
+        expect(actualWiredValues.data.keyVal).toBe(undefined);
     });
 });

--- a/packages/@lwc/integration-not-karma/test/wire/wirecontextevent-legacy/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/wire/wirecontextevent-legacy/index.spec.js
@@ -3,16 +3,14 @@ import { createElement } from 'lwc';
 import WireContextProvider from 'x/wireContextProvider';
 
 describe('wirecontextevent', () => {
-    it('should dispatchEvent on custom element when adapter dispatch an event of type wirecontextevent on the wireEventTarget', () => {
+    it('should dispatchEvent on custom element when adapter dispatch an event of type wirecontextevent on the wireEventTarget', async () => {
         const elm = createElement('x-wirecontext-provider', { is: WireContextProvider });
         elm.context = 'test value';
 
         document.body.appendChild(elm);
 
-        return Promise.resolve().then(() => {
-            const consumer = elm.shadowRoot.querySelector('.consumer');
-
-            expect(consumer.shadowRoot.textContent).toBe('test value');
-        });
+        await Promise.resolve();
+        const consumer = elm.shadowRoot.querySelector('.consumer');
+        expect(consumer.shadowRoot.textContent).toBe('test value');
     });
 });

--- a/packages/@lwc/integration-not-karma/test/wire/wiring/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/wire/wiring/index.spec.js
@@ -123,11 +123,10 @@ describe('wiring', () => {
             expect(spy).toHaveSize(1);
             expect(spy[0].method).toBe('connect');
 
-            return Promise.resolve().then(() => {
-                expect(spy).toHaveSize(2);
-                expect(spy[0].method).toBe('connect');
-                expect(spy[1].method).toBe('update');
-            });
+            await Promise.resolve();
+            expect(spy).toHaveSize(2);
+            expect(spy[0].method).toBe('connect');
+            expect(spy[1].method).toBe('update');
         });
 
         it('should call update only once when the component is created and a wire dynamic param is modified in the same tick', async () => {
@@ -139,12 +138,11 @@ describe('wiring', () => {
             elm.setDynamicParamSource(1);
             document.body.appendChild(elm);
 
-            return Promise.resolve().then(() => {
-                // in the old wire protocol, there is only one call because
-                // on the same tick the config was modified
-                const updateCalls = filterCalls(spy, 'update');
-                expect(updateCalls).toHaveSize(1);
-            });
+            await Promise.resolve();
+            // in the old wire protocol, there is only one call because
+            // on the same tick the config was modified
+            const updateCalls = filterCalls(spy, 'update');
+            expect(updateCalls).toHaveSize(1);
         });
 
         it('should be called only once during multiple renders when the wire config does not change', async () => {
@@ -153,16 +151,11 @@ describe('wiring', () => {
             const elm = createElement('x-echo-adapter-consumer', { is: ComponentClass });
             document.body.appendChild(elm);
 
-            return Promise.resolve()
-                .then(() => {
-                    expect(filterCalls(spy, 'update')).toHaveSize(1);
-                    elm.forceRerender();
-
-                    return Promise.resolve();
-                })
-                .then(() => {
-                    expect(filterCalls(spy, 'update')).toHaveSize(1);
-                });
+            await Promise.resolve();
+            expect(filterCalls(spy, 'update')).toHaveSize(1);
+            elm.forceRerender();
+            await Promise.resolve();
+            expect(filterCalls(spy, 'update')).toHaveSize(1);
         });
 
         it('should be called when the wire parameters change its value.', async () => {
@@ -171,19 +164,13 @@ describe('wiring', () => {
             const elm = createElement('x-echo-adapter-consumer', { is: ComponentClass });
             document.body.appendChild(elm);
 
-            return Promise.resolve()
-                .then(() => {
-                    expect(filterCalls(spy, 'update')).toHaveSize(1);
-                    elm.setDynamicParamSource('simpleParam modified');
-
-                    return Promise.resolve();
-                })
-                .then(() => {
-                    expect(filterCalls(spy, 'update')).toHaveSize(2);
-                    const wireResult = elm.getWiredProp();
-
-                    expect(wireResult.simpleParam).toBe('simpleParam modified');
-                });
+            await Promise.resolve();
+            expect(filterCalls(spy, 'update')).toHaveSize(1);
+            elm.setDynamicParamSource('simpleParam modified');
+            await Promise.resolve();
+            expect(filterCalls(spy, 'update')).toHaveSize(2);
+            const wireResult = elm.getWiredProp();
+            expect(wireResult.simpleParam).toBe('simpleParam modified');
         });
 
         it('should be called for common parameter when shared among wires', async () => {
@@ -192,21 +179,17 @@ describe('wiring', () => {
             const elm = createElement('x-bc-consumer', { is: BroadcastConsumer });
             document.body.appendChild(elm);
 
-            return Promise.resolve().then(() => {
-                expect(filterCalls(spy, 'update')).toHaveSize(2);
-                elm.setCommonParameter('modified');
-
-                return Promise.resolve().then(() => {
-                    expect(filterCalls(spy, 'update')).toHaveSize(4);
-                    const wireResult1 = elm.getEchoWiredProp1();
-                    const wireResult2 = elm.getEchoWiredProp2();
-
-                    expect(wireResult1.id).toBe('echoWire1');
-                    expect(wireResult1.common).toBe('modified');
-                    expect(wireResult2.id).toBe('echoWire2');
-                    expect(wireResult2.common).toBe('modified');
-                });
-            });
+            await Promise.resolve();
+            expect(filterCalls(spy, 'update')).toHaveSize(2);
+            elm.setCommonParameter('modified');
+            await Promise.resolve();
+            expect(filterCalls(spy, 'update')).toHaveSize(4);
+            const wireResult1 = elm.getEchoWiredProp1();
+            const wireResult2 = elm.getEchoWiredProp2();
+            expect(wireResult1.id).toBe('echoWire1');
+            expect(wireResult1.common).toBe('modified');
+            expect(wireResult2.id).toBe('echoWire2');
+            expect(wireResult2.common).toBe('modified');
         });
 
         it('should not update when setting parameter with same value', async () => {
@@ -218,19 +201,15 @@ describe('wiring', () => {
             const expected = 'expected value';
             elm.setDynamicParamSource(expected);
 
-            return Promise.resolve()
-                .then(() => {
-                    expect(spy.length).toBe(1); // update,connected
-                    const wireResult = elm.getWiredProp();
-                    expect(wireResult.simpleParam).toBe(expected);
+            await Promise.resolve();
+            expect(spy.length).toBe(1); // update,connected
+            const wireResult = elm.getWiredProp();
+            expect(wireResult.simpleParam).toBe(expected);
 
-                    elm.setDynamicParamSource(expected);
+            elm.setDynamicParamSource(expected);
 
-                    return Promise.resolve();
-                })
-                .then(() => {
-                    expect(spy.length).toBe(1); // update,connected
-                });
+            await Promise.resolve();
+            expect(spy.length).toBe(1); // update,connected
         });
 
         it('should trigger component rerender when field is updated', async () => {
@@ -261,15 +240,12 @@ describe('wiring', () => {
             const elm = createElement('x-echo-adapter-consumer', { is: ComponentClass });
             document.body.appendChild(elm);
 
-            return Promise.resolve()
-                .then(() => {
-                    expect(filterCalls(spy, 'update')).toHaveSize(1);
-                    document.body.removeChild(elm);
-                    elm.setDynamicParamSource('simpleParam modified');
-                })
-                .then(() => {
-                    expect(filterCalls(spy, 'update')).toHaveSize(1);
-                });
+            await Promise.resolve();
+            expect(filterCalls(spy, 'update')).toHaveSize(1);
+            document.body.removeChild(elm);
+            elm.setDynamicParamSource('simpleParam modified');
+            await Promise.resolve();
+            expect(filterCalls(spy, 'update')).toHaveSize(1);
         });
 
         it('should call update when component is re-connected.', async () => {
@@ -277,26 +253,24 @@ describe('wiring', () => {
             AdapterId.setSpy(spy);
             const elm = createElement('x-echo-adapter-consumer', { is: ComponentClass });
             document.body.appendChild(elm);
+            await Promise.resolve();
 
-            return Promise.resolve()
-                .then(() => {
-                    expect(filterCalls(spy, 'update')).toHaveSize(1);
-                    document.body.removeChild(elm);
-                    elm.setDynamicParamSource('simpleParam modified');
-                })
-                .then(() => {
-                    expect(filterCalls(spy, 'update')).toHaveSize(1);
-                    const wireResult = elm.getWiredProp();
+            expect(filterCalls(spy, 'update')).toHaveSize(1);
 
-                    expect(wireResult.simpleParam).not.toBeDefined();
-                    document.body.appendChild(elm);
-                })
-                .then(() => {
-                    expect(filterCalls(spy, 'update')).toHaveSize(2);
-                    const wireResult = elm.getWiredProp();
+            document.body.removeChild(elm);
+            elm.setDynamicParamSource('simpleParam modified');
+            await Promise.resolve();
 
-                    expect(wireResult.simpleParam).toBe('simpleParam modified');
-                });
+            expect(filterCalls(spy, 'update')).toHaveSize(1);
+            const wireResult1 = elm.getWiredProp();
+            expect(wireResult1.simpleParam).not.toBeDefined();
+
+            document.body.appendChild(elm);
+            await Promise.resolve();
+
+            expect(filterCalls(spy, 'update')).toHaveSize(2);
+            const wireResult2 = elm.getWiredProp();
+            expect(wireResult2.simpleParam).toBe('simpleParam modified');
         });
     });
 });
@@ -308,18 +282,13 @@ describe('wired fields', () => {
         document.body.appendChild(elm);
         BroadcastAdapter.broadcastData('expected value');
 
-        return Promise.resolve()
-            .then(() => {
-                const staticValue = elm.shadowRoot.querySelector('span');
-                expect(staticValue.textContent).toBe('expected value');
-                BroadcastAdapter.broadcastData('modified value');
-
-                return Promise.resolve();
-            })
-            .then(() => {
-                const staticValue = elm.shadowRoot.querySelector('span');
-                expect(staticValue.textContent).toBe('modified value');
-            });
+        await Promise.resolve();
+        const staticValue1 = elm.shadowRoot.querySelector('span');
+        expect(staticValue1.textContent).toBe('expected value');
+        BroadcastAdapter.broadcastData('modified value');
+        await Promise.resolve();
+        const staticValue2 = elm.shadowRoot.querySelector('span');
+        expect(staticValue2.textContent).toBe('modified value');
     });
 
     it('should rerender component when wired field is mutated from within the component', async () => {
@@ -328,17 +297,14 @@ describe('wired fields', () => {
         document.body.appendChild(elm);
         BroadcastAdapter.broadcastData('expected value');
 
-        return Promise.resolve()
-            .then(() => {
-                const staticValue = elm.shadowRoot.querySelector('span');
-                expect(staticValue.textContent).toBe('expected value');
+        await Promise.resolve();
+        const staticValue1 = elm.shadowRoot.querySelector('span');
+        expect(staticValue1.textContent).toBe('expected value');
 
-                elm.setWiredPropToValue('modified value');
-            })
-            .then(() => {
-                const staticValue = elm.shadowRoot.querySelector('span');
-                expect(staticValue.textContent).toBe('modified value');
-            });
+        elm.setWiredPropToValue('modified value');
+        await Promise.resolve();
+        const staticValue2 = elm.shadowRoot.querySelector('span');
+        expect(staticValue2.textContent).toBe('modified value');
     });
 });
 
@@ -349,10 +315,9 @@ describe('wired methods', () => {
         document.body.appendChild(elm);
         BroadcastAdapter.broadcastData('expected value');
 
-        return Promise.resolve().then(() => {
-            const actual = elm.getWiredMethodArgument();
-            expect(actual).toBe('expected value');
-        });
+        await Promise.resolve();
+        const actual = elm.getWiredMethodArgument();
+        expect(actual).toBe('expected value');
     });
 
     it('should support method override', async () => {


### PR DESCRIPTION
## Details

I discovered a tool that does this automatically. It makes everything much nicer to read!

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
