### PR TITLE
test(wtr): handle endpoint to make logs quieter @W-19098252

### DIFF
--- a/packages/@lwc/integration-not-karma/configs/plugins/serve-integration.js
+++ b/packages/@lwc/integration-not-karma/configs/plugins/serve-integration.js
@@ -118,6 +118,11 @@ export default {
     async serve(ctx) {
         if (ctx.path.endsWith('.spec.js')) {
             return await transform(ctx);
+        } else if (ctx.path === '/test_api_sanitizeAttribute') {
+            // The test in /test/api/sanitizeAttribute makes network requests
+            // The returned value doesn't matter; this is just to avoid
+            // unnecessary logging output
+            return '';
         }
     },
 };

--- a/packages/@lwc/integration-not-karma/test/api/sanitizeAttribute/index.spec.js
+++ b/packages/@lwc/integration-not-karma/test/api/sanitizeAttribute/index.spec.js
@@ -1,3 +1,7 @@
+/**
+ * The URLs used in test are handled by the `serve` method defined in `serve-integration.js`.
+ * What they serve doesn't matter, it's just to avoid a 404 warning logged to console
+ */
 import {
     createElement,
     // Spy is created in a mock file and injected with the import map plugin
@@ -49,7 +53,7 @@ scenarios.forEach(({ type, attrName, tagName, Ctor }) => {
             document.body.appendChild(elm);
 
             const use = elm.shadowRoot.querySelector('use');
-            expect(use.getAttribute(attrName)).toBe('/foo');
+            expect(use.getAttribute(attrName)).toBe('/test_api_sanitizeAttribute?foo');
         });
 
         it('receives the right parameters', () => {
@@ -60,18 +64,18 @@ scenarios.forEach(({ type, attrName, tagName, Ctor }) => {
                 'use',
                 'http://www.w3.org/2000/svg',
                 attrName,
-                '/foo'
+                '/test_api_sanitizeAttribute?foo'
             );
         });
 
         it('replace the original attribute value with a string', () => {
-            sanitizeAttributeSpy.mockReturnValue('/bar');
+            sanitizeAttributeSpy.mockReturnValue('/test_api_sanitizeAttribute?bar');
 
             const elm = createElement(tagName, { is: Ctor });
             document.body.appendChild(elm);
 
             const use = elm.shadowRoot.querySelector('use');
-            expect(use.getAttribute(attrName)).toBe('/bar');
+            expect(use.getAttribute(attrName)).toBe('/test_api_sanitizeAttribute?bar');
         });
 
         it('replace the original attribute value with undefined', () => {

--- a/packages/@lwc/integration-not-karma/test/api/sanitizeAttribute/x/hrefDynamic/hrefDynamic.js
+++ b/packages/@lwc/integration-not-karma/test/api/sanitizeAttribute/x/hrefDynamic/hrefDynamic.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
-    href = '/foo';
+    href = '/test_api_sanitizeAttribute?foo';
 }

--- a/packages/@lwc/integration-not-karma/test/api/sanitizeAttribute/x/hrefStatic/hrefStatic.html
+++ b/packages/@lwc/integration-not-karma/test/api/sanitizeAttribute/x/hrefStatic/hrefStatic.html
@@ -1,5 +1,5 @@
 <template>
     <svg>
-        <use href="/foo"></use>
+        <use href="/test_api_sanitizeAttribute?foo"></use>
     </svg>
 </template>

--- a/packages/@lwc/integration-not-karma/test/api/sanitizeAttribute/x/xlinkDynamic/xlinkDynamic.js
+++ b/packages/@lwc/integration-not-karma/test/api/sanitizeAttribute/x/xlinkDynamic/xlinkDynamic.js
@@ -1,5 +1,5 @@
 import { LightningElement } from 'lwc';
 
 export default class extends LightningElement {
-    href = '/foo';
+    href = '/test_api_sanitizeAttribute?foo';
 }

--- a/packages/@lwc/integration-not-karma/test/api/sanitizeAttribute/x/xlinkStatic/xlinkStatic.html
+++ b/packages/@lwc/integration-not-karma/test/api/sanitizeAttribute/x/xlinkStatic/xlinkStatic.html
@@ -1,5 +1,5 @@
 <template>
     <svg>
-        <use xlink:href="/foo"></use>
+        <use xlink:href="/test_api_sanitizeAttribute?foo"></use>
     </svg>
 </template>


### PR DESCRIPTION
## Details

Without this change, every test run includes this log output:

```
 test/api/sanitizeAttribute/index.spec.js:

 🚧 404 network requests:
    - foo
    - bar
```

We don't care about the network requests, so that's just noise. This PR adds handling to make that noise go away. The extra logic can't be encapsulated within the single test, and it's kind of indirect "magic", so I changed the name of the endpoint to try to make the connection between the two a bit more obvious.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
