### PR TITLE
fix: remove word boundaries from decorator check regex

### DIFF
--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -91,7 +91,8 @@ export default function scriptTransform(
         if (
             (e as any).code === 'BABEL_TRANSFORM_ERROR' &&
             (e as any).message?.includes('Decorators are not enabled.') &&
-            /(track|api|wire)/.test((e as any).message) // sniff for track/api/wire
+            // eslint-disable-next-line no-control-regex
+            /(?:\b|\x1b\S*?)(api|wire|track)\b/.test((e as any).message) // sniff for track/api/wire
         ) {
             transformerError = TransformerErrors.JS_TRANSFORMER_DECORATOR_ERROR;
         }


### PR DESCRIPTION
## Details
`/\b(track|api|wire)\b/` tests false if `track` is with ANSI escape codes for color output in terminals e.g. `\033[31;1;4mtrack\033[0m`
## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🔬 Yes, it does include an observable change.
- The user will now get `LWC1198` error instead of `LWC1007` for Babel decorator error consistently.
