### PR TITLE
[DO NOT MERGE] Trigger CI for #5534: fix: remove word boundaries from decorator check regex

### DIFF
--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -91,7 +91,8 @@ export default function scriptTransform(
         if (
             (e as any).code === 'BABEL_TRANSFORM_ERROR' &&
             (e as any).message?.includes('Decorators are not enabled.') &&
-            /(track|api|wire)/.test((e as any).message) // sniff for track/api/wire
+            // eslint-disable-next-line no-control-regex
+            /(?:\b|\x1b\S*?)(api|wire|track)\b/.test((e as any).message) // sniff for track/api/wire
         ) {
             transformerError = TransformerErrors.JS_TRANSFORMER_DECORATOR_ERROR;
         }


### PR DESCRIPTION
External contributors do not have access to CI secrets. This PR serves as a workaround to trigger CI with secrets for #5534.