### PR TITLE
test(wtr): document and generalize !WTR directive

### DIFF
--- a/packages/@lwc/integration-not-karma/README.md
+++ b/packages/@lwc/integration-not-karma/README.md
@@ -24,6 +24,10 @@ Environment variables are used as controls to run tests in different modes (e.g 
 
 Integration tests are simply `.spec.js` files that run in the browser. LWC components are transformed by a plugin defined in `serve-integration.js`.
 
+## Custom Compiler Config
+
+To specify custom compiler config on a per test or per component basis, use a custom comment directive, `/* !WTR { ... } */`. This can be applied for an entire test directory by including it in the `.spec.js` file, or on a per-file basis by including it in individual files. Note that individual configs must be included per _file_, not per _component_. You must include the directive in _every_ JS/CSS/HTML file that needs to use a different config. HTML files should use HTML comments, e.g. `<!-- !WTR { "apiVersion": 60 } -->`.
+
 ### Hydration Tests
 
 Hydration tests test the SSR packages, and are therefore more complex than the integration tests. While the files are named `index.spec.js`, they are actually _config_ files. The actual test executed is defined in `test-hydration.js`, which also contains the interface definition for the config. Each hydration test is also expected to define an entrypoint component named `x/main`. The hydration tests are transformed by a plugin defined in `serve-hydration.js`.

--- a/packages/@lwc/integration-not-karma/test/rendering/native-only-css/x/light/chic.native-only.css
+++ b/packages/@lwc/integration-not-karma/test/rendering/native-only-css/x/light/chic.native-only.css
@@ -1,5 +1,5 @@
 /* Per-file compiler config, used in configs/plugins/serve-integration.js */
-/*!WTR {"nativeOnly": true}*/
+/*!WTR {"disableSyntheticShadowSupport": true}*/
 div {
     --chic: 'native';
 }

--- a/packages/@lwc/integration-not-karma/test/rendering/native-only-css/x/light/snazzy.native-only.scoped.css
+++ b/packages/@lwc/integration-not-karma/test/rendering/native-only-css/x/light/snazzy.native-only.scoped.css
@@ -1,5 +1,5 @@
 /* Per-file compiler config, used in configs/plugins/serve-integration.js */
-/*!WTR {"nativeOnly": true}*/
+/*!WTR {"disableSyntheticShadowSupport": true}*/
 div {
     --snazzy: 'native';
 }

--- a/packages/@lwc/integration-not-karma/test/rendering/native-only-css/x/shadow/chic.native-only.css
+++ b/packages/@lwc/integration-not-karma/test/rendering/native-only-css/x/shadow/chic.native-only.css
@@ -1,5 +1,5 @@
 /* Per-file compiler config, used in configs/plugins/serve-integration.js */
-/*!WTR {"nativeOnly": true}*/
+/*!WTR {"disableSyntheticShadowSupport": true}*/
 div {
     --chic: 'native';
 }

--- a/packages/@lwc/integration-not-karma/test/rendering/native-only-css/x/shadow/snazzy.native-only.scoped.css
+++ b/packages/@lwc/integration-not-karma/test/rendering/native-only-css/x/shadow/snazzy.native-only.scoped.css
@@ -1,5 +1,5 @@
 /* Per-file compiler config, used in configs/plugins/serve-integration.js */
-/*!WTR {"nativeOnly": true}*/
+/*!WTR {"disableSyntheticShadowSupport": true}*/
 div {
     --snazzy: 'native';
 }

--- a/packages/@lwc/integration-not-karma/test/rendering/native-only-css/x/styleLibrary/foo.native-only.css
+++ b/packages/@lwc/integration-not-karma/test/rendering/native-only-css/x/styleLibrary/foo.native-only.css
@@ -1,5 +1,5 @@
 /* Per-file compiler config, used in configs/plugins/serve-integration.js */
-/*!WTR {"nativeOnly": true}*/
+/*!WTR {"disableSyntheticShadowSupport": true}*/
 div {
     --foo: 'native';
 }


### PR DESCRIPTION
The `!WTR` directive is used in integration tests to specify a custom compiler config on a per-test or per-file basis. It was previously undocumented, and the config options were specific hard-coded things that were looked for.

This PR documents the feature and generalizes it to allow any compiler options to be passed through.

and it's added to the readme

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
