### PR TITLE
chore(ci): configure perf benchmarks to be executed manually

### DIFF
--- a/.github/workflows/benchmark-release.yml
+++ b/.github/workflows/benchmark-release.yml
@@ -1,4 +1,4 @@
-name: Run Performance Benchmarks (Release)
+name: Run Performance Benchmarks
 
 on:
     push:


### PR DESCRIPTION
## Details

We currently [run performance benchmarks](https://github.com/salesforce/lwc/actions/workflows/benchmark-release.yml) whenever we push a commit to a release branch (e.g. `winter26). But sometimes we want to run them manually, too, without needing to lock up a laptop for half a day.

This PR adds a manual trigger to the perf benchmark workflow so that we can do ad hoc analysis.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
