### PR TITLE
chore(ci): fix parsing branch to commit

### DIFF
--- a/.github/workflows/benchmark-release.yml
+++ b/.github/workflows/benchmark-release.yml
@@ -25,8 +25,19 @@ jobs:
             - name: Set old version (manual)
               if: github.event_name == 'workflow_dispatch'
               run: |
-                  COMMIT="$(git rev-parse "${{ inputs.old_version }}")"
-                  echo "Parsed ${{ inputs.old_version }} to commit $COMMIT."
+                  INPUT='${{ inputs.old_version }}'
+                  # Convert branch/tag into commit
+                  COMMIT="$(git ls-remote origin "$INPUT" | cut -f 1)"
+                  if [ -z "$COMMIT" ]; then
+                    # Input is not a branch/tag; check if it's actually a commit
+                    if git cat-file -e "$INPUT^{commit}" >/dev/null; then
+                      COMMIT="$INPUT"
+                    else
+                      echo 'Could not resolve "${{ inputs.old_version }}" to a commit ID'
+                      exit 1
+                    fi
+                  fi
+                  echo "Parsed '$INPUT' to commit $COMMIT."
                   echo "BENCHMARK_REF=$COMMIT" >> "$GITHUB_ENV"
 
             - name: Set old version (release)


### PR DESCRIPTION
need to check remote, not just local git

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
