### PR TITLE
chore(script): ignore empty directories

### DIFF
--- a/scripts/shared/packages.mjs
+++ b/scripts/shared/packages.mjs
@@ -1,22 +1,13 @@
-import { readdirSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { globSync } from 'glob';
 
-const readJsonSync = (filepath) => JSON.parse(readFileSync(filepath, 'utf8'));
+const allPackages = globSync(['packages/lwc/package.json', 'packages/@lwc/*/package.json']);
 
-const root = join(dirname(fileURLToPath(import.meta.url)), '../..');
-const lwcPackageDir = 'packages/lwc';
-const relativeNamespaceDir = 'packages/@lwc';
-const namespacedPackageDirs = readdirSync(join(root, 'packages/@lwc'), {
-    withFileTypes: true,
-})
-    .filter((fd) => fd.isDirectory() && !fd.name.startsWith('.'))
-    .map((fd) => join(relativeNamespaceDir, fd.name));
-const allPackageDirs = [lwcPackageDir, ...namespacedPackageDirs];
-
-export const ALL_PACKAGES = allPackageDirs.map((path) => ({
-    path,
-    package: readJsonSync(join(path, 'package.json')),
+export const ALL_PACKAGES = allPackages.map((pkg) => ({
+    path: dirname(pkg),
+    package: JSON.parse(readFileSync(pkg, 'utf8')),
 }));
 export const PRIVATE_PACKAGES = ALL_PACKAGES.filter((data) => data.package.private);
 export const PUBLIC_PACKAGES = ALL_PACKAGES.filter((data) => !data.package.private);
+export const SCOPED_PACKAGES = ALL_PACKAGES.filter((data) => data.package.name.startsWith('@lwc/'));

--- a/scripts/tasks/check-and-rewrite-package-json.js
+++ b/scripts/tasks/check-and-rewrite-package-json.js
@@ -17,7 +17,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { globSync } = require('glob');
+const { SCOPED_PACKAGES } = require('../shared/packages.mjs');
 
 // This is the same list as in @lwc/rollup-plugin/src/index.ts
 const LWC_EXPOSED_MODULES = {
@@ -38,10 +38,7 @@ const STATIC_PACKAGES = ['@lwc/types'];
 
 const expectedPkgJsons = [];
 
-for (const dir of globSync('./packages/@lwc/*')) {
-    const filename = path.join('./', dir, 'package.json');
-    const actual = fs.readFileSync(filename, 'utf-8').replace(/\r\n/g, '\n'); // Windows compat
-    const pkg = JSON.parse(actual);
+for (const { package: pkg, path: dir } of SCOPED_PACKAGES) {
     // Skip private packages
     if (pkg.private) {
         continue;
@@ -131,12 +128,11 @@ for (const dir of globSync('./packages/@lwc/*')) {
         };
     }
 
-    const expected = JSON.stringify(expectedJson, null, 4) + '\n';
-
     expectedPkgJsons.push({
-        filename,
-        expected,
-        actual,
+        filename: path.join(dir, 'package.json'),
+        // Including \n because that's how prettier formats files
+        expected: JSON.stringify(expectedJson, null, 4) + '\n',
+        actual: JSON.stringify(pkg, null, 4) + '\n',
     });
 }
 


### PR DESCRIPTION
## Details

In git, if you switch from a branch with a directory to a branch without it, only the files are removed. The directory remains. Some of our scripts assume that if a package directory exists, then it must have a `package.json`. This is not always the case, such as when I deleted `integration-karma` (#5590).

This PR updates the scripts to check for `package.json` files, rather than directories. It also updates the scripts so that they all use the shared utility.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
