### PR TITLE
chore(ci): only install chrome when needed in unit test workflow

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -8,7 +8,6 @@ on:
             - 'spring*'
             - 'summer*'
             - 'winter*'
-            - 'wjh/*'
     pull_request:
         branches:
             - master


### PR DESCRIPTION
## Details

In the unit test workflow, the performance benchmark smoke tests are the last step executed. They require chrome and chromedriver, which are installed as one of the first steps in the workflow. The installation take ~1 minute, which is just wasted time if an earlier check fails (e.g. linting, unit tests). This PR moves the installation step to later in the workflow, so that it is only executed when it is truly needed.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
