### PR TITLE
Revert "build(deps): bump meriyah from 5.0.0 to 7.0.0 (#5619)"

### DIFF
--- a/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-method/error-ssr.txt
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures/wire/errors/throws-on-computed-method/error-ssr.txt
@@ -1,1 +1,1 @@
-[7:12-7:13]: Unexpected token: '{'
+[7:13]: Unexpected token: '{'

--- a/packages/@lwc/ssr-compiler/package.json
+++ b/packages/@lwc/ssr-compiler/package.json
@@ -56,7 +56,7 @@
         "astring": "^1.9.0",
         "estree-toolkit": "^1.7.13",
         "immer": "^11.0.1",
-        "meriyah": "^7.0.0"
+        "meriyah": "^5.0.0"
     },
     "devDependencies": {
         "@lwc/babel-plugin-component": "8.26.0",

--- a/packages/@lwc/ssr-compiler/src/__tests__/compilation.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/compilation.spec.ts
@@ -127,9 +127,9 @@ export default class Test extends LightningElement {
                 "filename": "test.js",
                 "location": {
                   "column": 2,
-                  "length": 77,
-                  "line": 6,
-                  "start": 220,
+                  "length": 9,
+                  "line": 7,
+                  "start": 288,
                 },
                 "message": "LWC1200: Computed property in @wire config must be a constant or primitive literal.",
               }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8666,10 +8666,10 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-meriyah@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/meriyah/-/meriyah-7.0.0.tgz#a1b507c29ebb4157430fcc627215439044a28914"
-  integrity sha512-eM23BVAsVhOxLEKckm3DopvcEze2o1leYO11xIkYqeeJgaNbzfGS00y7BUp/KeQPcTzXx0cGJRD2V7BYEZnDcg==
+meriyah@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/meriyah/-/meriyah-5.0.0.tgz#9f5fd811ee6e7952dcb48cf6962f27a885f108b8"
+  integrity sha512-tNlPDP4AzkH/7cROw7PKJ7mCLe/ZLpa2ja23uqB35vt63+8dgZi2NKLJMrkjxLcxArnLJVvd3Y/7pRl3OLR7yg==
 
 methods@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This reverts commit 6a7c0ad33eee730a47dda1c167430b9f833b6d5d.

## Details

We need to wait for #4484 and release this as part of 9.0.0 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
