### PR TITLE
feat(compiler): rename `experimentalDynamicComponent` to `dynamicImports`

### DIFF
--- a/packages/@lwc/compiler/README.md
+++ b/packages/@lwc/compiler/README.md
@@ -42,7 +42,7 @@ const { code } = transformSync(source, filename, options);
     - `name` (type: `string`, required) - name of the component, e.g. `foo` in `x/foo`.
     - `namespace` (type: `string`, required) - namespace of the component, e.g. `x` in `x/foo`.
     - `stylesheetConfig` (type: `object`, default: `{}`) - Deprecated. Ignored by compiler.
-    - `experimentalDynamicComponent` (type: `DynamicImportConfig`, default: `null`) - The configuration to pass to `@lwc/compiler`.
+    - `dynamicImports` (type: `DynamicImportConfig`, default: `null`) - The configuration to pass to `@lwc/compiler`.
     - `experimentalDynamicDirective` (type: `boolean`, default: `false`) - The configuration to pass to `@lwc/template-compiler` to enable deprecated dynamic components.
     - `enableDynamicComponents` (type: `boolean`, default: `false`) - The configuration to pass to `@lwc/template-compiler` to enable dynamic components.
     - `outputConfig` (type: `object`, optional) - see below:

--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -102,9 +102,8 @@ export interface TransformOptions {
     namespace: string;
     /** @deprecated Ignored by compiler. */
     stylesheetConfig?: StylesheetConfig;
-    // TODO [#5031]: Unify dynamicImports and experimentalDynamicComponent options
     /** Config applied in usage of dynamic import statements in javascript */
-    experimentalDynamicComponent?: DynamicImportConfig;
+    dynamicImports?: DynamicImportConfig;
     // TODO [#3331]: deprecate and remove lwc:dynamic
     /** Flag to enable usage of dynamic component(lwc:dynamic) directive in HTML template */
     experimentalDynamicDirective?: boolean;
@@ -163,7 +162,7 @@ type OptionalTransformKeys =
     | 'enableDynamicComponents'
     | 'enableSyntheticElementInternals'
     | 'experimentalDynamicDirective'
-    | 'experimentalDynamicComponent'
+    | 'dynamicImports'
     | 'componentFeatureFlagModulePath'
     | 'instrumentation';
 
@@ -246,9 +245,9 @@ function normalizeOptions(options: TransformOptions): NormalizedTransformOptions
         },
     };
 
-    const experimentalDynamicComponent: Required<DynamicImportConfig> = {
+    const dynamicImports: Required<DynamicImportConfig> = {
         ...DEFAULT_DYNAMIC_IMPORT_CONFIG,
-        ...options.experimentalDynamicComponent,
+        ...options.dynamicImports,
     };
 
     const apiVersion = getAPIVersionFromNumber(options.apiVersion);
@@ -258,7 +257,7 @@ function normalizeOptions(options: TransformOptions): NormalizedTransformOptions
         ...options,
         stylesheetConfig,
         outputConfig,
-        experimentalDynamicComponent,
+        dynamicImports,
         apiVersion,
     };
 }

--- a/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
+++ b/packages/@lwc/compiler/src/transformers/__tests__/transform-javascript.spec.ts
@@ -131,7 +131,7 @@ describe('instrumentation', () => {
         `;
         await transform(actual, 'foo.js', {
             ...BASE_TRANSFORM_OPTIONS,
-            experimentalDynamicComponent: {
+            dynamicImports: {
                 loader: '@custom/loader',
                 strictSpecifier: true,
             },

--- a/packages/@lwc/compiler/src/transformers/javascript.ts
+++ b/packages/@lwc/compiler/src/transformers/javascript.ts
@@ -41,8 +41,7 @@ export default function scriptTransform(
     const {
         isExplicitImport,
         enableSyntheticElementInternals,
-        // TODO [#5031]: Unify dynamicImports and experimentalDynamicComponent options
-        experimentalDynamicComponent: dynamicImports,
+        dynamicImports,
         outputConfig: { sourcemap },
         enableLightningWebSecurityTransforms,
         namespace,

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -33,7 +33,7 @@ export default function templateTransform(
     options: NormalizedTransformOptions
 ): TransformResult {
     const {
-        experimentalDynamicComponent,
+        dynamicImports,
         // TODO [#3370]: remove experimental template expression flag
         experimentalComplexExpressions,
         preserveHtmlComments,
@@ -49,8 +49,7 @@ export default function templateTransform(
         disableSyntheticShadowSupport,
         experimentalErrorRecoveryMode,
     } = options;
-    const experimentalDynamicDirective =
-        deprecatedDynamicDirective ?? Boolean(experimentalDynamicComponent);
+    const experimentalDynamicDirective = deprecatedDynamicDirective ?? Boolean(dynamicImports);
 
     let result;
     try {

--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -80,7 +80,7 @@ async function compileFixture({
             lwcRollupPlugin({
                 enableDynamicComponents: true,
                 enableLwcOn: true,
-                experimentalDynamicComponent: {
+                dynamicImports: {
                     loader: path.join(import.meta.dirname, './utils/custom-loader.js'),
                     strictSpecifier: false,
                 },

--- a/packages/@lwc/integration-wtr/configs/plugins/serve-hydration.js
+++ b/packages/@lwc/integration-wtr/configs/plugins/serve-hydration.js
@@ -27,7 +27,7 @@ async function compileModule(input, targetSSR, format) {
             lwcRollupPlugin({
                 targetSSR,
                 modules: [{ dir: modulesDir }],
-                experimentalDynamicComponent: {
+                dynamicImports: {
                     loader: fileURLToPath(
                         new URL('../../helpers/loader.js', import.meta.url)
                     ).replaceAll(path.sep, path.posix.sep),

--- a/packages/@lwc/integration-wtr/configs/plugins/serve-integration.js
+++ b/packages/@lwc/integration-wtr/configs/plugins/serve-integration.js
@@ -23,7 +23,7 @@ const createRollupPlugin = (input, options) => {
     return lwcRollupPlugin({
         // Sourcemaps don't work with Istanbul coverage
         sourcemap: !process.env.COVERAGE,
-        experimentalDynamicComponent: {
+        dynamicImports: {
             loader: fileURLToPath(new URL('../../helpers/dynamic-loader', import.meta.url)),
             strict: true,
         },

--- a/packages/@lwc/integration-wtr/helpers/dynamic-loader.js
+++ b/packages/@lwc/integration-wtr/helpers/dynamic-loader.js
@@ -2,7 +2,7 @@
 const register = new Map();
 /**
  * Called by compiled components to, well, load another component. The path to this file is
- * specified by the `experimentalDynamicComponent.loader` rollup plugin option.
+ * specified by the `dynamicImports.loader` rollup plugin option.
  */
 export const load = async (id) => await Promise.resolve(register.get(id));
 export const registerForLoad = (name, Ctor) => register.set(name, Ctor);

--- a/packages/@lwc/rollup-plugin/README.md
+++ b/packages/@lwc/rollup-plugin/README.md
@@ -29,7 +29,7 @@ export default {
 - `modules` (type: `ModuleRecord[]`, default: `[]`) - The [module resolution](https://lwc.dev/guide/es_modules#module-resolution) overrides passed to the `@lwc/module-resolver`.
 - `stylesheetConfig` (type: `object`, default: `{}`) - Deprecated. Ignored by compiler.
 - `preserveHtmlComments` (type: `boolean`, default: `false`) - The configuration to pass to the `@lwc/template-compiler`.
-- `experimentalDynamicComponent` (type: `DynamicImportConfig`, default: `null`) - The configuration to pass to `@lwc/compiler`.
+- `dynamicImports` (type: `DynamicImportConfig`, default: `null`) - The configuration to pass to `@lwc/compiler`.
 - `experimentalDynamicDirective` (type: `boolean`, default: `false`) - The configuration to pass to `@lwc/template-compiler` to enable deprecated dynamic components.
 - `enableDynamicComponents` (type: `boolean`, default: `false`) - The configuration to pass to `@lwc/template-compiler` to enable dynamic components.
 - `enableLightningWebSecurityTransforms` (type: `boolean`, default: `false`) - The configuration to pass to `@lwc/compiler`.

--- a/packages/@lwc/rollup-plugin/src/__tests__/compilerConfig/compilerConfig.spec.ts
+++ b/packages/@lwc/rollup-plugin/src/__tests__/compilerConfig/compilerConfig.spec.ts
@@ -89,12 +89,12 @@ describe('templateConfig', () => {
 });
 
 describe('javaScriptConfig', () => {
-    it('should accept experimentalDynamicComponent config flag', async () => {
+    it('should accept dynamicImports config flag', async () => {
         const CUSTOM_LOADER = '@salesforce/loader';
         const { bundle } = await runRollup(
             'dynamicImportConfig/dynamicImportConfig.js',
             {
-                experimentalDynamicComponent: { loader: CUSTOM_LOADER, strictSpecifier: true },
+                dynamicImports: { loader: CUSTOM_LOADER, strictSpecifier: true },
             },
             {
                 external: [CUSTOM_LOADER],

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -43,9 +43,8 @@ export interface RollupLwcOptions {
     stylesheetConfig?: StylesheetConfig;
     /** The configuration to pass to the `@lwc/template-compiler`. */
     preserveHtmlComments?: boolean;
-    // TODO [#5031]: Unify dynamicImports and experimentalDynamicComponent options
     /** The configuration to pass to `@lwc/compiler`. */
-    experimentalDynamicComponent?: DynamicImportConfig;
+    dynamicImports?: DynamicImportConfig;
     // TODO [#3331]: deprecate and remove lwc:dynamic
     /** The configuration to pass to `@lwc/template-compiler`. */
     experimentalDynamicDirective?: boolean;
@@ -187,7 +186,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
         stylesheetConfig,
         sourcemap = false,
         preserveHtmlComments,
-        experimentalDynamicComponent,
+        dynamicImports,
         experimentalDynamicDirective,
         enableDynamicComponents,
         enableSyntheticElementInternals,
@@ -375,7 +374,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
                 namespace,
                 outputConfig: { sourcemap },
                 stylesheetConfig,
-                experimentalDynamicComponent,
+                dynamicImports,
                 experimentalDynamicDirective,
                 enableDynamicComponents,
                 enableSyntheticElementInternals,

--- a/packages/@lwc/ssr-compiler/src/__tests__/dynamic-imports.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/dynamic-imports.spec.ts
@@ -42,7 +42,7 @@ describe('dynamic imports', () => {
 
             const callback = () => {
                 code = compileComponentForSSR(source, filename, {
-                    experimentalDynamicComponent: {
+                    dynamicImports: {
                         loader,
                         strictSpecifier,
                     },
@@ -87,7 +87,7 @@ describe('dynamic imports', () => {
             `;
         const filename = path.resolve('component.js');
         const { code } = compileComponentForSSR(source, filename, {
-            experimentalDynamicComponent: {
+            dynamicImports: {
                 loader: 'myLoader',
                 strictSpecifier: true,
             },

--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -80,7 +80,7 @@ async function compileFixture({
                 // TODO [#3331]: remove usage of lwc:dynamic in 246
                 experimentalDynamicDirective: true,
                 modules: [{ dir: modulesDir }],
-                experimentalDynamicComponent: {
+                dynamicImports: {
                     loader: path.join(import.meta.dirname, './utils/custom-loader.js'),
                     strictSpecifier: false,
                 },

--- a/packages/@lwc/ssr-compiler/src/compile-js/index.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/index.ts
@@ -53,12 +53,12 @@ const visitors: Visitors = {
         removeDecoratorImport(path);
     },
     ImportExpression(path, state) {
-        const { experimentalDynamicComponent, importManager } = state;
-        if (!experimentalDynamicComponent) {
-            // if no `experimentalDynamicComponent` config, then leave dynamic `import()`s as-is
+        const { dynamicImports, importManager } = state;
+        if (!dynamicImports) {
+            // if no `dynamicImports` config, then leave dynamic `import()`s as-is
             return;
         }
-        if (experimentalDynamicComponent.strictSpecifier) {
+        if (dynamicImports.strictSpecifier) {
             if (!is.literal(path.node?.source) || typeof path.node.source.value !== 'string') {
                 throw generateError(
                     path.node!,
@@ -67,7 +67,7 @@ const visitors: Visitors = {
                 );
             }
         }
-        const loader = experimentalDynamicComponent.loader;
+        const loader = dynamicImports.loader;
         if (!loader) {
             // if no `loader` defined, then leave dynamic `import()`s as-is
             return;
@@ -299,7 +299,7 @@ export default function compileJS(
         publicProperties: new Map(),
         privateProperties: new Set(),
         wireAdapters: [],
-        experimentalDynamicComponent: options.experimentalDynamicComponent,
+        dynamicImports: options.dynamicImports,
         importManager: new ImportManager(),
         trustedLwcIdentifiers: new WeakSet(),
     };

--- a/packages/@lwc/ssr-compiler/src/compile-js/types.ts
+++ b/packages/@lwc/ssr-compiler/src/compile-js/types.ts
@@ -56,7 +56,7 @@ export interface ComponentMetaState {
     /** indicates whether the LightningElement has any wired props */
     wireAdapters: WireAdapter[];
     /** dynamic imports configuration */
-    experimentalDynamicComponent: ComponentTransformOptions['experimentalDynamicComponent'];
+    dynamicImports: ComponentTransformOptions['dynamicImports'];
     /** imports to add to the top of the program after parsing */
     importManager: ImportManager;
     /** identifiers starting with __lwc that we added */

--- a/packages/@lwc/ssr-compiler/src/shared.ts
+++ b/packages/@lwc/ssr-compiler/src/shared.ts
@@ -11,8 +11,5 @@ export type Expression = string;
 
 export type TemplateTransformOptions = Pick<TemplateCompilerConfig, 'name' | 'namespace'>;
 export type ComponentTransformOptions = Partial<
-    Pick<LwcBabelPluginOptions, 'name' | 'namespace'>
-> & {
-    // TODO [#5031]: Unify dynamicImports and experimentalDynamicComponent options
-    experimentalDynamicComponent?: LwcBabelPluginOptions['dynamicImports'];
-};
+    Pick<LwcBabelPluginOptions, 'name' | 'namespace' | 'dynamicImports'>
+>;


### PR DESCRIPTION
## Details

The feature is no longer experimental; `dynamicImports` is the name used in `@lwc/babel-plugin-component`, so now all the packages use the same name. This is a breaking change for users of the compilers.

Closes #5031.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
