### PR TITLE
docs: add deprecation notice to engine-server

### DIFF
--- a/packages/@lwc/engine-server/README.md
+++ b/packages/@lwc/engine-server/README.md
@@ -1,26 +1,7 @@
 # @lwc/engine-server
 
-WARNING: This is an experimental package. It is subject to change, may be removed at any time,
-and should be used at your own risk!
+⚠️ This package is deprecated and has been replaced by [`@lwc/ssr-compiler`](https://www.npmjs.com/package/@lwc/ssr-compiler) and [`@lwc/ssr-runtime`](https://www.npmjs.com/package/@lwc/ssr-compiler).
 
-This package can be used to render LWC components as strings in a server environment.
+## Links
 
-## Supported APIs
-
-This package supports the following APIs.
-
-### renderComponent()
-
-This function renders a string-representation of a serialized component tree, given a tag name
-and an LWC constructor. The output format itself is aligned with the [current leading
-proposal][explainer], but is subject to change.
-
-```js
-import { renderComponent } from '@lwc/engine-server';
-import LightningHello from 'lightning/hello';
-
-const componentProps = {};
-const serialized = renderComponent('lightning-hello', LightningHello, componentProps);
-```
-
-[explainer]: https://github.com/mfreed7/declarative-shadow-dom/blob/master/README.md
+- [Server-Side Rendering guide](https://lwc.dev/guide/ssr)


### PR DESCRIPTION
## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
