### PR TITLE
chore(compiler): provide type for source maps

### DIFF
--- a/packages/@lwc/compiler/src/transformers/shared.ts
+++ b/packages/@lwc/compiler/src/transformers/shared.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import type { BabelFileResult } from '@babel/core';
 import type { CompilerDiagnostic } from '@lwc/errors';
 
 /** The object returned after transforming code. */
@@ -11,7 +12,7 @@ export interface TransformResult {
     /** The compiled source code. */
     code: string;
     /** The generated source map. */
-    map: unknown;
+    map: BabelFileResult['map'];
     /** Any diagnostic warnings that may have occurred. */
     warnings?: CompilerDiagnostic[];
     /**

--- a/packages/@lwc/compiler/src/transformers/style.ts
+++ b/packages/@lwc/compiler/src/transformers/style.ts
@@ -7,6 +7,7 @@
 import * as styleCompiler from '@lwc/style-compiler';
 import { normalizeToCompilerError, TransformerErrors, CompilerAggregateError } from '@lwc/errors';
 
+import type { BabelFileResult } from '@babel/core';
 import type { NormalizedTransformOptions } from '../options';
 import type { TransformResult } from './shared';
 
@@ -63,6 +64,6 @@ export default function styleTransform(
     // the styles doesn't make sense, the transform returns an empty mappings.
     return {
         code: res.code,
-        map: { mappings: '' },
+        map: { mappings: '' } as BabelFileResult['map'],
     };
 }

--- a/packages/@lwc/compiler/src/transformers/template.ts
+++ b/packages/@lwc/compiler/src/transformers/template.ts
@@ -13,6 +13,7 @@ import {
 } from '@lwc/errors';
 import { compile } from '@lwc/template-compiler';
 
+import type { BabelFileResult } from '@babel/core';
 import type { NormalizedTransformOptions } from '../options';
 import type { TransformResult } from './shared';
 
@@ -93,7 +94,7 @@ export default function templateTransform(
     // the template doesn't make sense, the transform returns an empty mappings.
     return {
         code: result.code,
-        map: { mappings: '' },
+        map: { mappings: '' } as BabelFileResult['map'],
         warnings,
         cssScopeTokens: result.cssScopeTokens,
     };

--- a/packages/@lwc/ssr-compiler/src/index.ts
+++ b/packages/@lwc/ssr-compiler/src/index.ts
@@ -12,7 +12,7 @@ import type { ComponentTransformOptions, TemplateTransformOptions } from './shar
 
 export interface CompilationResult {
     code: string;
-    map: unknown;
+    map: undefined;
 }
 
 export function compileComponentForSSR(


### PR DESCRIPTION
## Details

We know what the types are, so we might as well use them. 🤷 

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
