### PR TITLE
revert(nucleus): add config back

### DIFF
--- a/.nucleus.yaml
+++ b/.nucleus.yaml
@@ -1,0 +1,46 @@
+core-deploy:
+    enabled: true
+    project-modules:
+        lwc: lwc.version
+branches:
+    ~DEFAULT~:
+        pull-request: &branch-definition
+            workflow: build-and-test
+            auto-start: true
+            auto-start-from-forks: false
+            merge-method: disabled # do not auto-merge; we'll do it ourselves
+            required-downstream-deps:
+                # none
+    release:
+        pull-request:
+            <<: *branch-definition
+    # Only active branches need to be included in this config
+    winter26:
+        pull-request:
+            <<: *branch-definition
+    spring25:
+        pull-request:
+            <<: *branch-definition
+    summer25:
+        pull-request:
+            <<: *branch-definition
+jobs:
+    build-and-test:
+        memory-limit: 16
+    create-canary-release:
+        memory-limit: 16
+    build-dependency:
+        memory-limit: 16
+    release:
+        memory-limit: 16
+steps:
+    node-conformance:
+        run:
+            command: yarn run lint
+        after: node-build
+    node-unit-tests:
+        run:
+            command: yarn test
+    # this project runs yarn build after yarn install so skip explicit build step
+    node-build: &node-build
+        skip: true


### PR DESCRIPTION
#5671 removed the nucleus config, but that made it fall back to defaults instead of shutting it up. This PR restores the config, but removes all required downstreams so maybe that'll work.

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
