### PR TITLE
test(wtr): add option to only run in one browser

### DIFF
--- a/packages/@lwc/integration-wtr/README.md
+++ b/packages/@lwc/integration-wtr/README.md
@@ -12,6 +12,8 @@ To run individual test files, provide them as CLI arguments. If using relative p
 
 Environment variables are used as controls to run tests in different modes (e.g native vs synthetic shadow, different API versions). The full list of controls is defined in [`helpers/options.js`](./helpers/options.js).
 
+To run tests only for a specific browser, set the `BROWSERS` environment variable. For example, `BROWSERS=chromium yarn test:wtr`.
+
 ## Architecture
 
 - `configs`: WTR configuration files. The main entrypoints are `integration.js` and `hydration.js`.

--- a/packages/@lwc/integration-wtr/configs/shared/browsers.js
+++ b/packages/@lwc/integration-wtr/configs/shared/browsers.js
@@ -45,10 +45,7 @@ export function getBrowsers(options) {
                   }),
               ];
     } else {
-        return [
-            playwrightLauncher({ product: 'chromium' }),
-            playwrightLauncher({ product: 'firefox' }),
-            playwrightLauncher({ product: 'webkit' }),
-        ];
+        const browsers = options.BROWSERS?.split(',') ?? ['chromium', 'firefox', 'webkit'];
+        return browsers.map((product) => playwrightLauncher({ product }));
     }
 }

--- a/packages/@lwc/integration-wtr/helpers/options.js
+++ b/packages/@lwc/integration-wtr/helpers/options.js
@@ -75,6 +75,12 @@ export const COVERAGE_DIR_FOR_OPTIONS =
         .map(([key, val]) => `${key}=${val}`)
         .join('/') || 'no-options';
 
+/**
+ * Comma-delimited list of browsers to use. Can be any of `chromium`, `firefox`, or `webkit`.
+ * Does not apply when using SauceLabs.
+ */
+export const BROWSERS = process.env.BROWSERS?.replace(/\W+/g, ',');
+
 // --- CI config --- //
 
 /** Whether or not to report coverage. Currently unused. */


### PR DESCRIPTION
sometimes you just want to be quick about it

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
