### PR TITLE
fix: correct typos in comments and docs

### DIFF
--- a/packages/@lwc/rollup-plugin/README.md
+++ b/packages/@lwc/rollup-plugin/README.md
@@ -36,7 +36,7 @@ export default {
 - `enableLwcSpread` (type: `boolean`, default: `false`) - The configuration to pass to the `@lwc/template-compiler`.
 - `enableLwcOn` (type: `boolean`, default: `false`) - The configuration to pass to the `@lwc/template-compiler`.
 - `disableSyntheticShadowSupport` (type: `boolean`, default: `false`) - Set to true if synthetic shadow DOM support is not needed, which can result in smaller output.
-- `apiVersion` (type: `number`, default: `undefined`) - Set to a valid API version such as 58, 59, etc. This will be overriden if the component itself overrides the version with a `*.js-meta.xml` file.
+- `apiVersion` (type: `number`, default: `undefined`) - Set to a valid API version such as 58, 59, etc. This will be overridden if the component itself overrides the version with a `*.js-meta.xml` file.
 - `enableStaticContentOptimization` (type: `boolean`, optional) - True if the static content optimization should be enabled. Passed to `@lwc/template-compiler`. True by default.
 - `targetSSR` (type: `boolean`) - Utilize the experimental SSR compilation mode. False by default. Do not use unless you know what you're doing.
 - `ssrMode` (type: `string`): The variety of SSR code that should be generated when using experimental SSR compilation mode. Should be one of `sync`, `async` or `asyncYield`.

--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures.spec.ts
@@ -25,7 +25,7 @@ interface FixtureConfig {
     /** Props to provide to the top-level component. */
     props?: Record<string, string | string[]>;
 
-    /** Output files used by ssr-compiler, when the output needs to differ fron engine-server */
+    /** Output files used by ssr-compiler, when the output needs to differ from engine-server */
     ssrFiles?: {
         error?: string;
         expected?: string;

--- a/packages/@lwc/ssr-compiler/src/__tests__/fixtures/read-only-props/function/modules/x/component/component.js
+++ b/packages/@lwc/ssr-compiler/src/__tests__/fixtures/read-only-props/function/modules/x/component/component.js
@@ -11,7 +11,7 @@ export default class extends LightningElement {
         this.foo.mutated = true;
 
         // Mutating the proxy should not work in V1 but will work in V2.
-        // The V2 implementation returns the original object as readonly invokation
+        // The V2 implementation returns the original object as readonly invocation
         // is deprecated and will be removed.
         try {
             this.readonlyFoo.readonlyMutated = true;

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/invalid-non-alphanumeric/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/invalid-non-alphanumeric/actual.html
@@ -1,5 +1,5 @@
 <template>
-    <!-- These are valid javascript propery names but their usage is restricted by template-compiler
+    <!-- These are valid javascript property names but their usage is restricted by template-compiler
         This test case is to just document the existing precedent-->
 
     <!-- leading latin characters-->

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/invalid-non-alphanumeric/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/invalid-non-alphanumeric/metadata.json
@@ -7,7 +7,7 @@
             "location": {
                 "line": 6,
                 "column": 15,
-                "start": 233,
+                "start": 234,
                 "length": 11
             },
             "url": ""
@@ -19,7 +19,7 @@
             "location": {
                 "line": 9,
                 "column": 15,
-                "start": 310,
+                "start": 311,
                 "length": 11
             },
             "url": ""

--- a/packages/@lwc/template-compiler/src/codegen/codegen.ts
+++ b/packages/@lwc/template-compiler/src/codegen/codegen.ts
@@ -341,7 +341,7 @@ export default class CodeGen {
     }
 
     /**
-     * Generates childs vnodes when slot content is static.
+     * Generates child vnodes when slot content is static.
      * @param slotName
      * @param data
      * @param children

--- a/packages/@lwc/template-compiler/src/codegen/static-element.ts
+++ b/packages/@lwc/template-compiler/src/codegen/static-element.ts
@@ -211,7 +211,7 @@ export function transformStaticChildren(elm: StaticElement, preserveComments: bo
     return result;
 }
 
-// Given a static child, determines wether the child is a contiguous text node.
+// Given a static child, determines whether the child is a contiguous text node.
 // Note this is intended to be used with children generated from transformStaticChildren
 export const isContiguousText = (staticChild: StaticChildNode | Text[]): staticChild is Text[] =>
     isArray(staticChild) && ArrayEvery.call(staticChild, isText);

--- a/packages/@lwc/template-compiler/src/parser/expression-complex/validate.ts
+++ b/packages/@lwc/template-compiler/src/parser/expression-complex/validate.ts
@@ -99,7 +99,7 @@ function validateLiteral(node: t.Literal) {
         ['BigInts']
     );
     // Regular expression literals are difficult to visually parse, and
-    // may be difficult to programatically parse with future parsing methods. For those
+    // may be difficult to programmatically parse with future parsing methods. For those
     // reasons, they are also disallowed.
     invariant(
         (node as t.RegExpLiteral).regex === undefined,

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -488,7 +488,7 @@ function parseText(
     const tokenizedContent = rawText.split(EXPRESSION_RE);
 
     for (const token of tokenizedContent) {
-        // Don't create nodes for emtpy strings
+        // Don't create nodes for empty strings
         if (!token.length) {
             continue;
         }
@@ -519,7 +519,7 @@ function parseTextComplex(
 
     while (index < rawText.length) {
         if (rawText[index] === EXPRESSION_SYMBOL_START) {
-            // Parse any literal that preceeded the expression
+            // Parse any literal that preceded the expression
             if (start < index) {
                 const literalToken = rawText.slice(start, index);
                 parsedTextNodes.push(

--- a/packages/@lwc/template-compiler/src/parser/parser.ts
+++ b/packages/@lwc/template-compiler/src/parser/parser.ts
@@ -187,7 +187,7 @@ export default class ParserCtx {
     }
 
     /**
-     * This method searchs the current scope and returns the value that satisfies the predicate.
+     * This method searches the current scope and returns the value that satisfies the predicate.
      * @param predicate This callback is called once for each sibling in the current scope
      * until it finds one where predicate returns true.
      */

--- a/scripts/release/version.js
+++ b/scripts/release/version.js
@@ -64,7 +64,7 @@ function updatePackages(newVersion) {
         }
     }
 
-    // Update package.json files and print updated packges
+    // Update package.json files and print updated packages
     for (const { originalVersion, packageJson, packageJsonPath } of packagesToUpdate) {
         fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 4) + '\n');
         console.log(


### PR DESCRIPTION
## Details

Fixes 10 typos in comments, JSDoc, and the README across 9 files in the `@lwc/template-compiler`, `@lwc/ssr-compiler`, `@lwc/rollup-plugin`, and `scripts/release` packages.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.

## GUS work item

N/A
