### PR TITLE
chore: remove ENABLE_LEGACY_CONTEXT_CONNECTION

### DIFF
--- a/packages/@lwc/engine-core/src/framework/modules/context.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/context.ts
@@ -13,7 +13,6 @@ import {
     isTrustedContext,
     type ContextProvidedCallback,
     type ContextBinding as IContextBinding,
-    getPrototypeOf,
 } from '@lwc/shared';
 import { type VM } from '../vm';
 import { logWarnOnce } from '../../shared/logger';
@@ -81,35 +80,17 @@ class ContextBinding<C extends object> implements IContextBinding<C> {
 }
 
 export function connectContext(vm: VM) {
-    /**
-     * If ENABLE_LEGACY_CONTEXT_CONNECTION is true, enumerates directly on the component
-     * which can result in the component lifecycle observing properties that are not typically observed.
-     * See PR #5536 for more information.
-     */
-    if (lwcRuntimeFlags.ENABLE_LEGACY_CONTEXT_CONNECTION) {
-        connect(vm, keys(getPrototypeOf(vm.component)), vm.component);
-    } else {
-        // Non-decorated objects
-        connect(vm, keys(vm.cmpFields), vm.cmpFields);
-        // Decorated objects like @api context
-        connect(vm, keys(vm.cmpProps), vm.cmpProps);
-    }
+    // Non-decorated objects
+    connect(vm, keys(vm.cmpFields), vm.cmpFields);
+    // Decorated objects like @api context
+    connect(vm, keys(vm.cmpProps), vm.cmpProps);
 }
 
 export function disconnectContext(vm: VM) {
-    /**
-     * If ENABLE_LEGACY_CONTEXT_CONNECTION is true, enumerates directly on the component
-     * which can result in the component lifecycle observing properties that are not typically observed.
-     * See PR #5536 for more information.
-     */
-    if (lwcRuntimeFlags.ENABLE_LEGACY_CONTEXT_CONNECTION) {
-        connect(vm, keys(getPrototypeOf(vm.component)), vm.component);
-    } else {
-        // Non-decorated objects
-        disconnect(vm, keys(vm.cmpFields), vm.cmpFields);
-        // Decorated objects like @api context
-        disconnect(vm, keys(vm.cmpProps), vm.cmpProps);
-    }
+    // Non-decorated objects
+    disconnect(vm, keys(vm.cmpFields), vm.cmpFields);
+    // Decorated objects like @api context
+    disconnect(vm, keys(vm.cmpProps), vm.cmpProps);
 }
 
 function connect(vm: VM, enumerableKeys: string[], contextContainer: any) {

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -25,7 +25,6 @@ const features: FeatureFlagMap = {
     DISABLE_SCOPE_TOKEN_VALIDATION: null,
     DISABLE_STRICT_VALIDATION: null,
     DISABLE_DETACHED_REHYDRATION: null,
-    ENABLE_LEGACY_CONTEXT_CONNECTION: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -101,13 +101,6 @@ export interface FeatureFlagMap {
     DISABLE_DETACHED_REHYDRATION: FeatureFlagValue;
 
     /**
-     * If true, enables legacy context connection and disconnection which can result in the component lifecycle
-     * observing properties that are not typically observed. ENABLE_EXPERIMENTAL_SIGNALS must also be enabled for
-     * this flag to have an effect. See PR #5536 for more information.
-     */
-    ENABLE_LEGACY_CONTEXT_CONNECTION: FeatureFlagValue;
-
-    /**
      * If true, skips the guard that blocks native `attachShadow` on LWC component hosts that already use
      * synthetic shadow. When false or unset, the guard is active (default).
      */

--- a/packages/@lwc/integration-wtr/test/reactivity/delayed-render/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/reactivity/delayed-render/index.spec.js
@@ -5,78 +5,27 @@ import Test from 'x/test';
 // A bug (W-19830319) has shown that if child component properties are incorrectly marked for observation by the lifecycle, they can trigger the parent component to re-render
 // and this will cause undesired effects. This bug manifested due to context connection/disconnection erroneously accessing properties, but it could theoretically occur in any instance where
 // the "live" component property is accessed instead of via vm.cmpFields / vm.cmpProps.
-describe('Unobserved properties should trigger additional re-renders', () => {
-    it('when signals is enabled and legacy context connection is enabled', async () => {
-        // This is on by default, but enabled here to confirm the case
-        setFeatureFlagForTest('ENABLE_EXPERIMENTAL_SIGNALS', true);
-        setFeatureFlagForTest('ENABLE_LEGACY_CONTEXT_CONNECTION', true);
-
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
-        // Specific sequence (it is rather nuanced and requires 1. parent to switch templates and 2. child to mutate a property in a setTimeout function or similar):
-        // 1. The template change results in the parent component being marked as dirty.
-        // 1a. Marking the parent as dirty sets the currentReactiveObserver to the parent, here: https://github.com/salesforce/lwc/blob/master/packages/%40lwc/engine-core/src/libs/mutation-tracker/index.ts#L83
-        // 2. The new template doesn't contain the child so disconnectContext is called on the child component. The BUG: If the child properties are incorrectly observed then riggering disconnectContext marks all child properties
-        // for observation using the currentReactiveObserver of the parent set in 1a. here: https://github.com/salesforce/lwc/blob/master/packages/%40lwc/engine-core/src/libs/mutation-tracker/index.ts#L60
-        // 3. Next, a delayed property mutation inside the child component's renderedCallback occurs and this delayed (post disconnection) mutation triggers valueMutated, where all the parent properties are registered listeners.
-        // That happens here: https://github.com/salesforce/lwc/blob/master/packages/%40lwc/engine-core/src/libs/mutation-tracker/index.ts#L41
-        // 3b. This causes the parent component to re-render.
-        elm.switchToEmptyTemplate();
-
-        // Before the bugfix (W-19830319/PR-5536), expecting 2 renders when signals was enabled would fail.
-        // An erroneous 3rd render would occur when signals was enabled due to the behavior described above.
-        setTimeout(() => {
-            expect(elm.renderCount).toBe(3); // because ENABLE_LEGACY_SIGNAL_CONTEXT_VALIDATION = true this will render 3 times (incorrect)
-        });
-    });
-
-    it('when signals is enabled, legacy context connection is true and detached rehydration is enabled', async () => {
-        setFeatureFlagForTest('ENABLE_EXPERIMENTAL_SIGNALS', true);
-        setFeatureFlagForTest('ENABLE_LEGACY_CONTEXT_CONNECTION', true);
-        setFeatureFlagForTest('DISABLE_DETACHED_REHYDRATION', true);
-
-        const elm = createElement('x-test', { is: Test });
-        document.body.appendChild(elm);
-        elm.switchToEmptyTemplate();
-
-        // Enabling detached rehydration does not change the behavior (bug still exists and the third render occurs)
-        setTimeout(() => {
-            expect(elm.renderCount).toBe(3);
-        });
-    });
-
-    afterAll(() => {
-        setFeatureFlagForTest('ENABLE_EXPERIMENTAL_SIGNALS', true);
-        setFeatureFlagForTest('ENABLE_LEGACY_CONTEXT_CONNECTION', false);
-        setFeatureFlagForTest('DISABLE_DETACHED_REHYDRATION', false);
-    });
-});
-
 describe('Unobserved properties should NOT trigger additional re-renders', () => {
-    it('when signals is enabled, legacy context connection is disabled and detached rehydration is enabled', async () => {
+    it('when signals is enabled and detached rehydration is enabled', async () => {
         setFeatureFlagForTest('ENABLE_EXPERIMENTAL_SIGNALS', true);
-        setFeatureFlagForTest('ENABLE_LEGACY_CONTEXT_CONNECTION', false);
         setFeatureFlagForTest('DISABLE_DETACHED_REHYDRATION', true);
 
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
         elm.switchToEmptyTemplate();
 
-        // Enabling detached rehydration does not change the behavior
         setTimeout(() => {
             expect(elm.renderCount).toBe(2);
         });
     });
 
-    it('when signals is enabled and legacy context connection is disabled', async () => {
+    it('when signals is enabled', async () => {
         setFeatureFlagForTest('ENABLE_EXPERIMENTAL_SIGNALS', true);
-        setFeatureFlagForTest('ENABLE_LEGACY_CONTEXT_CONNECTION', false);
 
         const elm = createElement('x-test', { is: Test });
         document.body.appendChild(elm);
         elm.switchToEmptyTemplate();
 
-        // CORRECT: This component should render twice as the corrected context connection is in use.
         setTimeout(() => {
             expect(elm.renderCount).toBe(2);
         });
@@ -89,7 +38,6 @@ describe('Unobserved properties should NOT trigger additional re-renders', () =>
         document.body.appendChild(elm);
         elm.switchToEmptyTemplate();
 
-        // CORRECT: This component should render twice as signals is disabled and there should be no observation bugs elsewhere in the lifecycle.
         setTimeout(() => {
             expect(elm.renderCount).toBe(2);
         });


### PR DESCRIPTION
## Details

The ENABLE_LEGACY_CONTEXT_CONNECTION killswitch has remained unused for several releases.
Removing this.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.

## GUS work item

W-22216107