### PR TITLE
chore: update dependabot rollup group to cover all update types and add caution note

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,12 +45,13 @@ updates:
                   - '@nx/*'
               update-types:
                   - 'major'
-          rollup:
+          # Changes to rollup can sometimes introduce subtle changes that break our users.
+          # If bumping rollup, make sure it's in a release with no code changes
+          # (other dep bumps are okay).
+          ROLLUP-BE-CAREFUL:
               patterns:
                   - 'rollup'
                   - '@rollup/*'
-              update-types:
-                  - 'major'
           webdriverio:
               patterns:
                   - 'webdriverio'


### PR DESCRIPTION
## Summary

- Renames the `rollup` dependabot group to `ROLLUP-BE-CAREFUL` so the group name surfaces in PR titles and branch names as a reminder to reviewers
- Removes the `update-types: [major]` restriction so all rollup/`@rollup/*` updates (major, minor, patch) are bundled into their own dedicated PR instead of being swept into `theoretically-non-breaking`
- Adds a comment explaining why rollup bumps deserve extra care

## Test plan

- [ ] Verify next dependabot run produces a PR with `ROLLUP-BE-CAREFUL` in the branch/title for any rollup updates
- [ ] Confirm rollup minor/patch bumps no longer appear in the `theoretically-non-breaking` grouped PR