### PR TITLE
feat(engine): expose static shadowRootMode on component constructors

### DIFF
--- a/packages/@lwc/engine-core/src/framework/api.ts
+++ b/packages/@lwc/engine-core/src/framework/api.ts
@@ -379,6 +379,10 @@ function c(
     }
 
     const { key, slotAssignment } = data;
+    // The component author can opt into a closed shadow root by declaring
+    // `static shadowRootMode = 'closed'` on the component class. Default is 'open'
+    // to preserve backwards-compatible behavior. Closes #1294.
+    const shadowRootMode = Ctor.shadowRootMode === 'closed' ? 'closed' : 'open';
     const vnode: VCustomElement = {
         type: VNodeType.CustomElement,
         sel,
@@ -390,7 +394,7 @@ function c(
 
         ctor: Ctor,
         owner: vmBeingRendered,
-        mode: 'open', // TODO [#1294]: this should be defined in Ctor
+        mode: shadowRootMode,
         aChildren: undefined,
         vm: undefined,
     };

--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -143,6 +143,19 @@ export interface LightningElementConstructor {
     renderMode?: 'light' | 'shadow';
     formAssociated?: boolean;
     shadowSupportMode?: ShadowSupportMode;
+    /**
+     * Controls the mode of the component's shadow root. Defaults to `'open'`.
+     * Set to `'closed'` to hide the shadow root from outside script access —
+     * `element.shadowRoot` will return `null` from outside the component.
+     *
+     * Works in both native and synthetic shadow: the synthetic shadow polyfill
+     * stores the mode internally and its patched `shadowRoot` getter only
+     * exposes the faux root when the mode is `'open'`.
+     *
+     * This setting has no effect when the component uses light DOM
+     * (`static renderMode = 'light'`).
+     */
+    shadowRootMode?: 'open' | 'closed';
     stylesheets: Stylesheets;
 }
 

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -119,6 +119,7 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
         shadowSupportMode: ctorShadowSupportMode,
         renderMode: ctorRenderMode,
         formAssociated: ctorFormAssociated,
+        shadowRootMode: ctorShadowRootMode,
     } = Ctor;
 
     if (process.env.NODE_ENV !== 'production') {
@@ -159,6 +160,16 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
         ) {
             logError(
                 `Invalid value for static property renderMode: '${ctorRenderMode}'. renderMode must be either 'light' or 'shadow'.`
+            );
+        }
+
+        if (
+            !isUndefined(ctorShadowRootMode) &&
+            ctorShadowRootMode !== 'open' &&
+            ctorShadowRootMode !== 'closed'
+        ) {
+            logError(
+                `Invalid value for static property shadowRootMode: '${ctorShadowRootMode}'. shadowRootMode must be either 'open' or 'closed'.`
             );
         }
     }

--- a/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/index.spec.js
@@ -1,0 +1,42 @@
+import { createElement } from 'lwc';
+import Parent from 'x/parent';
+
+// This spec is run under BOTH synthetic and native shadow DOM via the
+// integration-wtr infrastructure (see configs/integration.js — `SHADOW_MODE`
+// env toggles between 'synthetic' default and 'native'). The assertions below
+// hold identically in either mode:
+//   - native: `elm.attachShadow({ mode: 'closed' })` is a first-class browser
+//     API; `.shadowRoot` returns null from outside the component.
+//   - synthetic: the polyfill stores `mode` in its internal record and
+//     `shadowRootGetterPatched` only exposes the faux root when
+//     `shadow.mode === 'open'` (see @lwc/synthetic-shadow/src/faux-shadow/
+//     element.ts). Closed synthetic hosts also return null from `.shadowRoot`.
+
+describe('static shadowRootMode', () => {
+    it('renders a closed shadow root when child declares static shadowRootMode = "closed"', () => {
+        const elm = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elm);
+
+        const closed = elm.shadowRoot.querySelector('x-closed-child');
+        // `.shadowRoot` is null for a closed host in both native and synthetic shadow.
+        expect(closed.shadowRoot).toBe(null);
+    });
+
+    it('renders an open shadow root when child declares static shadowRootMode = "open"', () => {
+        const elm = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elm);
+
+        const open = elm.shadowRoot.querySelector('x-open-child');
+        expect(open.shadowRoot).not.toBe(null);
+        expect(open.shadowRoot.mode).toBe('open');
+    });
+
+    it('defaults to open when no static shadowRootMode is declared', () => {
+        const elm = createElement('x-parent', { is: Parent });
+        document.body.appendChild(elm);
+
+        const def = elm.shadowRoot.querySelector('x-default-child');
+        expect(def.shadowRoot).not.toBe(null);
+        expect(def.shadowRoot.mode).toBe('open');
+    });
+});

--- a/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/closedChild/closedChild.html
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/closedChild/closedChild.html
@@ -1,0 +1,3 @@
+<template>
+    <span>closed</span>
+</template>

--- a/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/closedChild/closedChild.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/closedChild/closedChild.js
@@ -1,0 +1,9 @@
+import { LightningElement } from 'lwc';
+
+export default class ClosedChild extends LightningElement {
+    static shadowRootMode = 'closed';
+
+    getShadowMode() {
+        return this.template.mode;
+    }
+}

--- a/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/defaultChild/defaultChild.html
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/defaultChild/defaultChild.html
@@ -1,0 +1,3 @@
+<template>
+    <span>default</span>
+</template>

--- a/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/defaultChild/defaultChild.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/defaultChild/defaultChild.js
@@ -1,0 +1,7 @@
+import { LightningElement } from 'lwc';
+
+export default class DefaultChild extends LightningElement {
+    getShadowMode() {
+        return this.template.mode;
+    }
+}

--- a/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/openChild/openChild.html
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/openChild/openChild.html
@@ -1,0 +1,3 @@
+<template>
+    <span>open</span>
+</template>

--- a/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/openChild/openChild.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/openChild/openChild.js
@@ -1,0 +1,9 @@
+import { LightningElement } from 'lwc';
+
+export default class OpenChild extends LightningElement {
+    static shadowRootMode = 'open';
+
+    getShadowMode() {
+        return this.template.mode;
+    }
+}

--- a/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/parent/parent.html
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/parent/parent.html
@@ -1,0 +1,5 @@
+<template>
+    <x-closed-child lwc:ref="closed"></x-closed-child>
+    <x-open-child lwc:ref="open"></x-open-child>
+    <x-default-child lwc:ref="default"></x-default-child>
+</template>

--- a/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/parent/parent.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/shadow-root-mode-static/x/parent/parent.js
@@ -1,0 +1,3 @@
+import { LightningElement } from 'lwc';
+
+export default class Parent extends LightningElement {}


### PR DESCRIPTION
Allow component authors to opt into a closed shadow root by declaring `static shadowRootMode = 'closed'`. The default remains `'open'`, so existing components are unaffected.

Previously, closed shadow was only reachable via
`createElement(tag, { is, mode: 'closed' })` — there was no way for a child component to request it when rendered through a parent template. The mode was hardcoded to `'open'` at the VNode creation site with a longstanding `TODO [#1294]` pointing at this gap.

Changes:
- framework/api.ts: honor `Ctor.shadowRootMode` when constructing the VNode
- framework/base-lightning-element.ts: add `shadowRootMode?: 'open' | 'closed'` to the `LightningElementConstructor` type, with jsdoc explicitly covering native/synthetic parity
- framework/def.ts: dev-mode validation with a clear error for invalid values
- integration-wtr: spec covering closed, open, and unset (default open)

Native vs synthetic shadow

The change is safe under both shadow modes because the synthetic-shadow polyfill already honors the `mode` option internally:

- Native (`shadowSupportMode: 'native'`): engine calls the browser-native `elm.attachShadow({ mode: 'closed' })`. `element.shadowRoot` returns `null` from outside, per standard DOM semantics.
- Synthetic (`shadowSupportMode: 'reset'`, the default): the polyfill stores `mode` in its internal record (`synthetic-shadow/src/faux-shadow/shadow- root.ts` attachShadow). `shadowRootGetterPatched` (`synthetic-shadow/src/ faux-shadow/element.ts`) only exposes the faux shadow root when `shadow.mode === 'open'` — otherwise it delegates to the native getter, which returns `null` for a synthetic host.

In both cases, the outside-observer semantics match (`element.shadowRoot === null` when closed) while internal LWC access via `this.template` continues to work. The integration-wtr test runs under both modes via the `SHADOW_MODE` env toggle in `configs/integration.js`, so CI validates parity automatically.

Closes #1294

## Details

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change. Maybe we should not throw when the value is not in range to avoid a very edge case that existing static values with this new name is used for some other reason. And instead, only focus on getting the shadow to closed when the value is closed, otherwise keep it as open.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change. Unless you had that static value in place for some other reason, and now your component runs with closed shadow, which is normally not a problem.
