### PR TITLE
feat(engine): add static dynamicProps to opt out of unknown-prop warning

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-lightning-element.ts
@@ -143,6 +143,21 @@ export interface LightningElementConstructor {
     renderMode?: 'light' | 'shadow';
     formAssociated?: boolean;
     shadowSupportMode?: ShadowSupportMode;
+    /**
+     * Declares that this component accepts arbitrary (non-`@api`) properties
+     * from its parent's template bindings. When `true`, the dev-mode
+     * "Unknown public property" warning is suppressed for this component.
+     *
+     * Intended for generic wrapper / "shape-shifter" components that cannot
+     * statically enumerate the props they will receive (for example, a single
+     * component that substitutes for many different authored components and
+     * forwards their props through a postMessage bridge).
+     *
+     * The runtime behavior of prop assignment is otherwise unchanged: writes
+     * still land as plain own properties on the host element just as they do
+     * today for any undeclared prop.
+     */
+    dynamicProps?: boolean;
     stylesheets: Stylesheets;
 }
 

--- a/packages/@lwc/engine-core/src/framework/def.ts
+++ b/packages/@lwc/engine-core/src/framework/def.ts
@@ -119,6 +119,7 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
         shadowSupportMode: ctorShadowSupportMode,
         renderMode: ctorRenderMode,
         formAssociated: ctorFormAssociated,
+        dynamicProps: ctorDynamicProps,
     } = Ctor;
 
     if (process.env.NODE_ENV !== 'production') {
@@ -159,6 +160,12 @@ function createComponentDef(Ctor: LightningElementConstructor): ComponentDef {
         ) {
             logError(
                 `Invalid value for static property renderMode: '${ctorRenderMode}'. renderMode must be either 'light' or 'shadow'.`
+            );
+        }
+
+        if (!isUndefined(ctorDynamicProps) && ctorDynamicProps !== true) {
+            logError(
+                `Invalid value for static property dynamicProps: '${ctorDynamicProps}'. dynamicProps must be 'true' or left unset.`
             );
         }
     }

--- a/packages/@lwc/engine-core/src/framework/modules/props.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/props.ts
@@ -8,6 +8,7 @@ import { htmlPropertyToAttribute, isNull, isUndefined } from '@lwc/shared';
 import { logWarn } from '../../shared/logger';
 import { EmptyObject } from '../utils';
 import { safelySetProperty } from '../sanitized-html-content';
+import { isVCustomElement } from '../vnodes';
 import type { RendererAPI } from '../renderer';
 import type { VBaseElement } from '../vnodes';
 
@@ -60,11 +61,18 @@ export function patchProps(
             // SSR has its own custom validation.
             if (process.env.IS_BROWSER && process.env.NODE_ENV !== 'production') {
                 if (!(key in elm!)) {
-                    logWarn(
-                        `Unknown public property "${key}" of element <${elm!.tagName.toLowerCase()}>. This is either a typo on the corresponding attribute "${htmlPropertyToAttribute(
-                            key
-                        )}", or the attribute does not exist in this browser or DOM implementation.`
-                    );
+                    // Components that legitimately accept arbitrary props (e.g., generic
+                    // wrapper/shape-shifter components) can opt out of this warning by
+                    // declaring `static dynamicProps = true` on the class.
+                    const acceptsAnyProp =
+                        isVCustomElement(vnode) && vnode.ctor?.dynamicProps === true;
+                    if (!acceptsAnyProp) {
+                        logWarn(
+                            `Unknown public property "${key}" of element <${elm!.tagName.toLowerCase()}>. This is either a typo on the corresponding attribute "${htmlPropertyToAttribute(
+                                key
+                            )}", or the attribute does not exist in this browser or DOM implementation.`
+                        );
+                    }
                 }
             }
             safelySetProperty(setProperty, elm!, key, cur);

--- a/packages/@lwc/integration-wtr/test/component/dynamic-props/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/component/dynamic-props/index.spec.js
@@ -1,0 +1,24 @@
+import { createElement } from 'lwc';
+import Parent from 'x/parent';
+
+describe('static dynamicProps', () => {
+    it('suppresses "Unknown public property" warning for components with static dynamicProps = true', () => {
+        const elm = createElement('x-parent', { is: Parent });
+        elm.showShapeShifter = true;
+        expect(() => {
+            document.body.appendChild(elm);
+        }).not.toLogWarningDev();
+    });
+
+    it('still warns for components that have not opted in', () => {
+        const elm = createElement('x-parent', { is: Parent });
+        elm.showPlainChild = true;
+        expect(() => {
+            document.body.appendChild(elm);
+        }).toLogWarningDev(
+            'Error: [LWC warn]: Unknown public property "undeclaredProp" of element <x-plain-child>. ' +
+                'This is either a typo on the corresponding attribute "undeclared-prop", or ' +
+                'the attribute does not exist in this browser or DOM implementation.'
+        );
+    });
+});

--- a/packages/@lwc/integration-wtr/test/component/dynamic-props/x/parent/parent.html
+++ b/packages/@lwc/integration-wtr/test/component/dynamic-props/x/parent/parent.html
@@ -1,0 +1,8 @@
+<template>
+    <template lwc:if={showShapeShifter}>
+        <x-shape-shifter undeclared-prop={arbitraryValue}></x-shape-shifter>
+    </template>
+    <template lwc:if={showPlainChild}>
+        <x-plain-child undeclared-prop={arbitraryValue}></x-plain-child>
+    </template>
+</template>

--- a/packages/@lwc/integration-wtr/test/component/dynamic-props/x/parent/parent.js
+++ b/packages/@lwc/integration-wtr/test/component/dynamic-props/x/parent/parent.js
@@ -1,0 +1,7 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Parent extends LightningElement {
+    @api showShapeShifter = false;
+    @api showPlainChild = false;
+    @api arbitraryValue = 'anything';
+}

--- a/packages/@lwc/integration-wtr/test/component/dynamic-props/x/plainChild/plainChild.html
+++ b/packages/@lwc/integration-wtr/test/component/dynamic-props/x/plainChild/plainChild.html
@@ -1,0 +1,3 @@
+<template>
+    <span>plain</span>
+</template>

--- a/packages/@lwc/integration-wtr/test/component/dynamic-props/x/plainChild/plainChild.js
+++ b/packages/@lwc/integration-wtr/test/component/dynamic-props/x/plainChild/plainChild.js
@@ -1,0 +1,6 @@
+import { LightningElement } from 'lwc';
+
+// A component without the dynamicProps opt-in. Setting undeclared props
+// on this component should still produce the "Unknown public property"
+// warning.
+export default class PlainChild extends LightningElement {}

--- a/packages/@lwc/integration-wtr/test/component/dynamic-props/x/shapeShifter/shapeShifter.html
+++ b/packages/@lwc/integration-wtr/test/component/dynamic-props/x/shapeShifter/shapeShifter.html
@@ -1,0 +1,3 @@
+<template>
+    <span>shape-shifter</span>
+</template>

--- a/packages/@lwc/integration-wtr/test/component/dynamic-props/x/shapeShifter/shapeShifter.js
+++ b/packages/@lwc/integration-wtr/test/component/dynamic-props/x/shapeShifter/shapeShifter.js
@@ -1,0 +1,9 @@
+import { LightningElement } from 'lwc';
+
+// A "shape-shifter" component that accepts any prop. It declares no @api
+// fields because the set of props it receives is not known at authoring time
+// (for example, in a generic wrapper that proxies many different authored
+// components behind a single registered element).
+export default class ShapeShifter extends LightningElement {
+    static dynamicProps = true;
+}


### PR DESCRIPTION
Introduce an opt-in `static dynamicProps = true` declaration on component classes that suppresses the dev-mode "Unknown public property" warning in `patchProps`. Prop assignment behavior is otherwise unchanged — writes still land as plain own properties on the host element, matching today's behavior for any undeclared prop.

Motivation

Generic wrapper / "shape-shifter" components cannot statically enumerate the props they will receive. A single component may substitute for many authored components and forward their props across a postMessage bridge, a runtime registry, or similar mechanisms. Today such components trigger a warning per unique prop on first assignment, which in practice is noise rather than a useful signal, and there is no way to quiet it.

This change gives those components a narrow, explicit way to declare "I know what I'm doing" without touching the warning globally.

Changes:
- framework/modules/props.ts: in dev mode, skip the `logWarn` when the receiving element is a custom element whose `Ctor.dynamicProps === true`
- framework/base-lightning-element.ts: add `dynamicProps?: boolean` to the `LightningElementConstructor` type, with jsdoc explaining the intended use
- framework/def.ts: dev-mode validation logs an error for any non-`true` value, matching the pattern of the existing `shadowSupportMode` / `renderMode` validations
- integration-wtr: spec covering both the suppression (with opt-in) and the control case (without opt-in, warning still fires)

Non-goals

This flag controls only the dev-mode warning. It does not change the runtime prop-assignment path and does not bypass the `@api` bridge — undeclared props still land on the host element as own data properties, which is the documented runtime behavior.

## Details

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change. Even if you have that same static value today for some other reason, it will just show or not the warn in the logs for that component when undeclared props are used.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.
