### PR TITLE
ci: declare workflow-level `contents: read` on 4 workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,6 +14,9 @@ env:
     PUPPETEER_SKIP_DOWNLOAD: 'true' # only needed for @best/runner-local, unused here
     NODE_VERSION: '24.11.1'
 
+permissions:
+  contents: read
+
 jobs:
     run-best-performance-tests:
         # It is important to use this image so that we have a consistent IP address that can be allowlisted by Best infra

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -21,6 +21,9 @@ env:
     CHROME_VERSION: 130
     NODE_VERSION: '24.11.1'
 
+permissions:
+  contents: read
+
 jobs:
     run-unit-tests:
         runs-on: ubuntu-22.04

--- a/.github/workflows/web-test-runner.yml
+++ b/.github/workflows/web-test-runner.yml
@@ -14,6 +14,9 @@ env:
     COVERAGE: '1'
     NODE_VERSION: '24.11.1'
 
+permissions:
+  contents: read
+
 jobs:
     # We run tests in parallel to speed up CI, with an arbitrary goal of ~20 minutes per job.
     integration-tests:

--- a/.github/workflows/webdriver.yml
+++ b/.github/workflows/webdriver.yml
@@ -21,6 +21,9 @@ env:
     CHROMEDRIVER_BINARY: '../../../node_modules/chromedriver/lib/chromedriver/chromedriver' # pin wdio to local chromedriver
     NODE_VERSION: '24.11.1'
 
+permissions:
+  contents: read
+
 jobs:
     run-integration-tests:
         runs-on: ubuntu-22.04


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 4 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.