### PR TITLE
fix(release): publish via npm OIDC instead of yarn + token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,21 +121,16 @@ jobs:
             - name: Publish to npm (v${{ steps.update_version.outputs.new_version }})
               env:
                   NEW_VERSION: ${{ steps.update_version.outputs.new_version }}
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-                  NPM_CONFIG_ALWAYS_AUTH: 'true'
                   TAG: ${{ steps.resolve_input.outputs.tag }}
               run: |
-                  # Force both npm and yarn to use npmjs and pick up the token
-                  yarn config set registry https://registry.npmjs.org
-                  npm config set registry https://registry.npmjs.org
-                  printf "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}\nalways-auth=true\n" > ~/.npmrc
-
-                  # Sanity checks
-                  echo "yarn registry: $(yarn config get registry)"
-                  echo "npm registry:  $(npm config get registry)"
+                  # Trusted publishing via OIDC: must NOT ship an _authToken or
+                  # npm skips the OIDC exchange. Override setup-node's temp
+                  # .npmrc (which embeds NODE_AUTH_TOKEN) with a clean one.
+                  echo 'registry=https://registry.npmjs.org/' > ~/.npmrc
+                  export NPM_CONFIG_USERCONFIG="$HOME/.npmrc"
 
                   echo "Publishing $GITHUB_REF_NAME as v$NEW_VERSION using tag $TAG."
-                  yarn nx release publish --yes --tag "$TAG"
+                  npm publish --workspaces --provenance --tag "$TAG"
 
             - name: Tag and create GitHub release
               if: ${{ steps.resolve_input.outputs.resolved != 'prerelease' }}


### PR DESCRIPTION
## Summary

The release workflow has been failing at the publish step (e.g. [run 26772628633](https://github.com/salesforce/lwc/actions/runs/26772628633/job/78915829626)) with:

```
Not Found - PUT https://registry.npmjs.org/@lwc%2fmodule-resolver - Not found
The requested resource '@lwc/module-resolver@9.3.0' could not be found
or you do not have permission to access it.
```

npm returns 404 on unauthorized PUTs, so this is an auth failure — and it surfaced because the project moved to **trusted publishing** on npmjs.org. Two things in the existing workflow defeat OIDC:

1. `~/.npmrc` is written with `_authToken=$NPM_TOKEN`. When npm sees an `_authToken`, it skips the OIDC token exchange entirely.
2. `yarn nx release publish` shells out to `yarn publish` (because a `yarn.lock` is present, nx's publish executor picks yarn). **Yarn classic does not support OIDC trusted publishing at all** — only `npm publish` (≥ 11.5.1) performs the OIDC exchange.

The workflow already declares `id-token: write`; nothing was actually using it.

## Fix

- Drop `NPM_TOKEN` / `NODE_AUTH_TOKEN` / `NPM_CONFIG_ALWAYS_AUTH` from the publish step's env.
- Overwrite `~/.npmrc` (which `setup-node` populated with `_authToken=${NODE_AUTH_TOKEN}`) with a clean `registry=`-only file so OIDC can run.
- Replace `yarn nx release publish` with `npm publish --workspaces --provenance --tag "$TAG"`.
  - `--workspaces` publishes every non-`private` workspace package; the 6 private packages (`integration-*`, `perf-benchmarks*`, `playground`) are skipped automatically — same set nx was already excluding.
  - `--provenance` is the trusted-publishing flag; it's the call that triggers the OIDC exchange.

The version bump, build, commit, and tag steps are untouched.

## Test plan

- [ ] Trigger the workflow on a non-master branch with `prerelease` to confirm OIDC publishes a canary without the token.
- [ ] Verify all 21 publishable packages publish at version 9.3.0 (or the next version) with provenance attestations on npmjs.org.
- [ ] Confirm trusted publisher entry on npmjs.org points at `salesforce/lwc`, workflow `.github/workflows/release.yml`, environment `release`.

## Cleanup note

`chore: release v9.3.0` (16832a62c) is on master but 9.3.0 was never published. Once this lands, the next release run will publish 9.3.0 cleanly (no version bump needed since the on-disk version already matches), or you can revert that commit and let the workflow re-bump.