### PR TITLE
fix(release): force npmjs.org registry on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,11 @@ jobs:
                   export NPM_CONFIG_USERCONFIG="$HOME/.npmrc"
 
                   echo "Publishing $GITHUB_REF_NAME as v$NEW_VERSION using tag $TAG."
-                  npm publish --workspaces --provenance --tag "$TAG"
+                  # --registry overrides the project-level .npmrc which points
+                  # at registry.yarnpkg.com (a read-only mirror that rejects
+                  # publishes); CLI flags beat project .npmrc in npm config
+                  # precedence, so OIDC trusted publishing targets npmjs.org.
+                  npm publish --workspaces --provenance --tag "$TAG" --registry=https://registry.npmjs.org/
 
             - name: Tag and create GitHub release
               if: ${{ steps.resolve_input.outputs.resolved != 'prerelease' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,17 +123,17 @@ jobs:
                   NEW_VERSION: ${{ steps.update_version.outputs.new_version }}
                   TAG: ${{ steps.resolve_input.outputs.tag }}
               run: |
-                  # Trusted publishing via OIDC: must NOT ship an _authToken or
-                  # npm skips the OIDC exchange. Override setup-node's temp
-                  # .npmrc (which embeds NODE_AUTH_TOKEN) with a clean one.
-                  echo 'registry=https://registry.npmjs.org/' > ~/.npmrc
+                  # Clobber setup-node's temp ~/.npmrc, which embeds an
+                  # _authToken line — any _authToken (even empty) suppresses
+                  # the OIDC trusted-publishing exchange. The registry itself
+                  # is set via --registry on the publish CLI below, since
+                  # the project .npmrc points at registry.yarnpkg.com (a
+                  # read-only mirror that rejects publishes) and project
+                  # config beats user config in npm's precedence order.
+                  : > ~/.npmrc
                   export NPM_CONFIG_USERCONFIG="$HOME/.npmrc"
 
                   echo "Publishing $GITHUB_REF_NAME as v$NEW_VERSION using tag $TAG."
-                  # --registry overrides the project-level .npmrc which points
-                  # at registry.yarnpkg.com (a read-only mirror that rejects
-                  # publishes); CLI flags beat project .npmrc in npm config
-                  # precedence, so OIDC trusted publishing targets npmjs.org.
                   npm publish --workspaces --provenance --tag "$TAG" --registry=https://registry.npmjs.org/
 
             - name: Tag and create GitHub release


### PR DESCRIPTION
## Summary

Follow-up to #5821. The v9.3.1 release attempt failed at the publish step:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.yarnpkg.com/
```

### Root cause

The repo's project-level `.npmrc` contains:

```
registry=https://registry.yarnpkg.com/
```

npm's config precedence (highest → lowest) is **CLI > env > project `.npmrc` > user `.npmrc` > global**. The previous fix wrote `registry=https://registry.npmjs.org/` to `~/.npmrc` (user-level), but the project-level `.npmrc` in the workspace root sits one tier higher and wins. So `npm publish` resolved the registry to `registry.yarnpkg.com` (a read-only mirror that rejects publishes) and never even attempted the OIDC token exchange with npmjs.org.

### Fix

Add `--registry=https://registry.npmjs.org/` to the `npm publish` invocation. CLI flags beat project `.npmrc`, so OIDC trusted publishing now targets npmjs.org. This is the minimal, contained fix — it doesn't touch the repo `.npmrc` that local dev and other tooling rely on.

## Test plan

- [ ] Re-run the Manual Release workflow on a prerelease bump (canary tag) and confirm the publish step succeeds.
- [ ] Verify the published canary appears on npmjs.org with provenance attached.