### PR TITLE
fix: warn on document-structure tags inside LWC template (#3681)

### DIFF
--- a/packages/@lwc/errors/src/compiler/error-info/index.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/index.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 /**
- * Next error code: 1214
+ * Next error code: 1215
  */
 
 export * from './compiler';

--- a/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
+++ b/packages/@lwc/errors/src/compiler/error-info/template-transform.ts
@@ -445,6 +445,16 @@ export const ParserDiagnostics = {
         url: '',
     },
 
+    DOCUMENT_STRUCTURE_TAG_NOT_ALLOWED_IN_TEMPLATE: {
+        code: 1214,
+        message:
+            "The '<0>' tag is not allowed inside an LWC template and will not be rendered. " +
+            "'<html>', '<head>', '<body>', and doctype declarations are document-level constructs " +
+            'and have no meaning inside a component template.',
+        level: DiagnosticLevel.Warning,
+        url: '',
+    },
+
     UNKNOWN_HTML_TAG_IN_TEMPLATE: {
         code: 1123,
         message:

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/disallowed-document-structure-tags/actual.html
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/disallowed-document-structure-tags/actual.html
@@ -1,0 +1,6 @@
+<template>
+    <!doctype html>
+    <html></html>
+    <head></head>
+    <body></body>
+</template>

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/disallowed-document-structure-tags/ast.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/disallowed-document-structure-tags/ast.json
@@ -1,0 +1,31 @@
+{
+    "root": {
+        "type": "Root",
+        "location": {
+            "startLine": 1,
+            "startColumn": 1,
+            "endLine": 6,
+            "endColumn": 12,
+            "start": 0,
+            "end": 96,
+            "startTag": {
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 1,
+                "endColumn": 11,
+                "start": 0,
+                "end": 10
+            },
+            "endTag": {
+                "startLine": 6,
+                "startColumn": 1,
+                "endLine": 6,
+                "endColumn": 12,
+                "start": 85,
+                "end": 96
+            }
+        },
+        "directives": [],
+        "children": []
+    }
+}

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/disallowed-document-structure-tags/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/disallowed-document-structure-tags/expected.js
@@ -1,0 +1,20 @@
+import _implicitStylesheets from "./disallowed-document-structure-tags.css";
+import _implicitScopedStylesheets from "./disallowed-document-structure-tags.scoped.css?scoped=true";
+import { freezeTemplate, registerTemplate } from "lwc";
+const stc0 = [];
+function tmpl($api, $cmp, $slotset, $ctx) {
+  return stc0;
+  /*LWC compiler vX.X.X*/
+}
+export default registerTemplate(tmpl);
+tmpl.stylesheets = [];
+tmpl.stylesheetToken = "lwc-5d17n7c3a3p";
+tmpl.legacyStylesheetToken =
+  "x-disallowed-document-structure-tags_disallowed-document-structure-tags";
+if (_implicitStylesheets) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
+}
+if (_implicitScopedStylesheets) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitScopedStylesheets);
+}
+freezeTemplate(tmpl);

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/disallowed-document-structure-tags/metadata.json
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/disallowed-document-structure-tags/metadata.json
@@ -1,0 +1,88 @@
+{
+    "warnings": [
+        {
+            "code": 1214,
+            "message": "LWC1214: The '<0>' tag is not allowed inside an LWC template and will not be rendered. '<html>', '<head>', '<body>', and doctype declarations are document-level constructs and have no meaning inside a component template.",
+            "level": 2,
+            "url": "",
+            "location": {
+                "line": 1,
+                "column": 11,
+                "start": 10,
+                "length": 75
+            }
+        },
+        {
+            "code": 1214,
+            "message": "LWC1214: The '<0>' tag is not allowed inside an LWC template and will not be rendered. '<html>', '<head>', '<body>', and doctype declarations are document-level constructs and have no meaning inside a component template.",
+            "level": 2,
+            "url": "",
+            "location": {
+                "line": 1,
+                "column": 11,
+                "start": 10,
+                "length": 75
+            }
+        },
+        {
+            "code": 1214,
+            "message": "LWC1214: The '<0>' tag is not allowed inside an LWC template and will not be rendered. '<html>', '<head>', '<body>', and doctype declarations are document-level constructs and have no meaning inside a component template.",
+            "level": 2,
+            "url": "",
+            "location": {
+                "line": 1,
+                "column": 11,
+                "start": 10,
+                "length": 75
+            }
+        },
+        {
+            "code": 1214,
+            "message": "LWC1214: The '<0>' tag is not allowed inside an LWC template and will not be rendered. '<html>', '<head>', '<body>', and doctype declarations are document-level constructs and have no meaning inside a component template.",
+            "level": 2,
+            "url": "",
+            "location": {
+                "line": 1,
+                "column": 11,
+                "start": 10,
+                "length": 75
+            }
+        },
+        {
+            "code": 1214,
+            "message": "LWC1214: The '<0>' tag is not allowed inside an LWC template and will not be rendered. '<html>', '<head>', '<body>', and doctype declarations are document-level constructs and have no meaning inside a component template.",
+            "level": 2,
+            "url": "",
+            "location": {
+                "line": 1,
+                "column": 11,
+                "start": 10,
+                "length": 75
+            }
+        },
+        {
+            "code": 1214,
+            "message": "LWC1214: The '<0>' tag is not allowed inside an LWC template and will not be rendered. '<html>', '<head>', '<body>', and doctype declarations are document-level constructs and have no meaning inside a component template.",
+            "level": 2,
+            "url": "",
+            "location": {
+                "line": 1,
+                "column": 11,
+                "start": 10,
+                "length": 75
+            }
+        },
+        {
+            "code": 1214,
+            "message": "LWC1214: The '<0>' tag is not allowed inside an LWC template and will not be rendered. '<html>', '<head>', '<body>', and doctype declarations are document-level constructs and have no meaning inside a component template.",
+            "level": 2,
+            "url": "",
+            "location": {
+                "line": 1,
+                "column": 11,
+                "start": 10,
+                "length": 75
+            }
+        }
+    ]
+}

--- a/packages/@lwc/template-compiler/src/parser/constants.ts
+++ b/packages/@lwc/template-compiler/src/parser/constants.ts
@@ -117,6 +117,8 @@ export const ATTRS_PROPS_TRANFORMS: { [attr: string]: string } = {
 
 export const DISALLOWED_HTML_TAGS = new Set(['base', 'link', 'meta', 'script', 'title']);
 
+export const DOCUMENT_STRUCTURE_TAGS_RE = /<!doctype[^>]*>|<\/?(?:html|head|body)(?:\s[^>]*)?>/gi;
+
 export const KNOWN_HTML_AND_SVG_ELEMENTS = new Set([...HTML_ELEMENTS, ...SVG_ELEMENTS]);
 
 export const HTML_TAG = {

--- a/packages/@lwc/template-compiler/src/parser/index.ts
+++ b/packages/@lwc/template-compiler/src/parser/index.ts
@@ -50,6 +50,7 @@ import {
 import {
     DISALLOWED_HTML_TAGS,
     DISALLOWED_MATHML_TAGS,
+    DOCUMENT_STRUCTURE_TAGS_RE,
     EVENT_HANDLER_NAME_RE,
     EVENT_HANDLER_RE,
     EXPRESSION_RE,
@@ -568,8 +569,24 @@ function parseTextNode(ctx: ParserCtx, parse5Text: parse5Tools.TextNode): Text[]
         );
     }
 
-    // Extract the raw source to avoid HTML entity decoding done by parse5
-    const rawText = cleanTextNode(ctx.getSource(location.startOffset, location.endOffset));
+    // parse5 collapses <html>/<head>/<body>/doctype into a text node when parsing
+    // a fragment. We re-read raw source here, so their literal markup leaks through
+    // as rendered text without this check. Strip and warn instead.
+    // https://github.com/salesforce/lwc/issues/3681
+    let rawText = cleanTextNode(ctx.getSource(location.startOffset, location.endOffset));
+
+    const documentStructureMatches = rawText.match(DOCUMENT_STRUCTURE_TAGS_RE);
+    if (documentStructureMatches) {
+        for (const match of documentStructureMatches) {
+            const tagName = match.replace(/[<>/]/g, '').split(/\s/)[0];
+            ctx.warnAtLocation(
+                ParserDiagnostics.DOCUMENT_STRUCTURE_TAG_NOT_ALLOWED_IN_TEMPLATE,
+                ast.sourceLocation(location),
+                [tagName]
+            );
+        }
+        rawText = rawText.replace(DOCUMENT_STRUCTURE_TAGS_RE, '');
+    }
 
     if (!rawText.trim().length) {
         return [];


### PR DESCRIPTION
Hi Team,

Fixes #3681

## Details
When `<!doctype>`, `<html>`, `<head>`, or `<body>` appear inside an LWC template, `parse5` collapses them into a text node. LWC's `parseTextNode` re-reads the raw source (to avoid HTML entity decoding), which accidentally causes the literal tag markup to leak through and render as visible text on the screen.

This PR updates `parseTextNode` to intercept these document-structure tags, strip them from the output so they don't render, and emit a specific warning diagnostic (`LWC1214`) per tag to notify the developer.

**Summary of Changes:**
* **`@lwc/errors`**: Added `DOCUMENT_STRUCTURE_TAG_NOT_ALLOWED_IN_TEMPLATE` (Warning code `1214`) to `template-transform.ts` and bumped the next error code marker to `1215` in `index.ts`.
* **`@lwc/template-compiler`**: Added matching regex rules in `constants.ts` and wired them into `parseTextNode` inside `parser/index.ts`.
* **Tests**: Created a new test fixture (`disallowed-document-structure-tags`) verifying that the compiler cleanly strips out the invalid markup and emits four individual `LWC1214` warnings.

---

## Does this pull request introduce a breaking change?
🗿 No, it does not introduce a breaking change.

---

## Does this pull request introduce an observable change?
✅  Yes, it does include an observable change.

**Anticipated Observable Changes:**
* Developers will now see an explicit `LWC1214` compiler warning in the console if they include document-level tags inside an LWC template.
* The literal tag strings (e.g., `<html>`) will no longer render onto the viewport at runtime.

---

## GUS work item
[W-18040860](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002B5WBwYAN/view)

Thanks!