### PR TITLE
feat(synthetic-shadow): gate ShadowRoot undefined-methods behind a flag

### DIFF
--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -24,6 +24,7 @@ const features: FeatureFlagMap = {
     DISABLE_SCOPE_TOKEN_VALIDATION: null,
     DISABLE_STRICT_VALIDATION: null,
     DISABLE_DETACHED_REHYDRATION: null,
+    ENABLE_SHADOW_ROOT_UNDEFINED_METHODS: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -24,7 +24,7 @@ const features: FeatureFlagMap = {
     DISABLE_SCOPE_TOKEN_VALIDATION: null,
     DISABLE_STRICT_VALIDATION: null,
     DISABLE_DETACHED_REHYDRATION: null,
-    ENABLE_SHADOW_ROOT_UNDEFINED_METHODS: null,
+    ENABLE_SHADOW_ROOT_UNDEFINED_GET_ELEMENT_BY_ID: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -98,6 +98,23 @@ export interface FeatureFlagMap {
      * synthetic shadow. When false or unset, the guard is active (default).
      */
     DISABLE_HOST_ATTACH_SHADOW_GUARD: FeatureFlagValue;
+
+    /**
+     * Controls how synthetic shadow exposes `ShadowRoot` methods that have no correct shadow-scoped
+     * semantics and are therefore not emulated: `getElementById`, `getSelection`, and `cloneNode`.
+     *
+     * When false or unset (default), these are exposed as stubs that throw when invoked — preserving
+     * the long-standing behavior. Because a throwing stub is still a callable function, feature
+     * detection (`typeof root.getElementById === 'function'`) reports it as present, so callers
+     * invoke it and hit the throw.
+     *
+     * When true, the methods are exposed as `undefined` instead, so feature detection reveals their
+     * absence and callers can fall back to the supported, shadow-scoped `querySelector('#' + id)`
+     * (matching how native shadow behaves for well-behaved feature-detecting code). This is a
+     * visible change to a long-stable API used by every synthetic-shadow consumer, hence gated and
+     * off by default.
+     */
+    ENABLE_SHADOW_ROOT_UNDEFINED_METHODS: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -100,24 +100,28 @@ export interface FeatureFlagMap {
     DISABLE_HOST_ATTACH_SHADOW_GUARD: FeatureFlagValue;
 
     /**
-     * Controls how synthetic shadow exposes `ShadowRoot` methods that have no correct shadow-scoped
-     * semantics and are therefore not emulated: `getElementById`, `getSelection`, and `cloneNode`.
+     * Controls how synthetic shadow exposes `ShadowRoot.getElementById`, which has no correct
+     * shadow-scoped semantics and is therefore not emulated.
      *
-     * When false or unset (default), these are exposed as stubs that throw when invoked — preserving
+     * When false or unset (default), it is exposed as a stub that throws when invoked — preserving
      * the long-standing behavior. Because a throwing stub is still a callable function, *value-based*
      * feature detection (`typeof root.getElementById === 'function'`, `if (root.getElementById)`,
      * `root.getElementById?.(id)`) reports it as present, so callers invoke it and hit the throw.
      *
-     * When true, the methods are exposed as `undefined` instead, so value-based feature detection
-     * reveals their absence and callers can fall back to the supported, shadow-scoped
-     * `querySelector('#' + id)`. This closes a real native-vs-synthetic divergence for
-     * `getElementById` (native `ShadowRoot` inherits a working one from `DocumentFragment`);
-     * `getSelection`/`cloneNode` are swept in for a uniform surface, not native parity. This is a
-     * visible change to a long-stable API used by every synthetic-shadow consumer, hence gated and
-     * off by default.
+     * When true, `getElementById` is exposed as `undefined` instead, so value-based feature detection
+     * reveals its absence and callers can fall back to the supported, shadow-scoped
+     * `querySelector('#' + id)`. This closes a real native-vs-synthetic divergence: native
+     * `ShadowRoot` inherits a working `getElementById` from `DocumentFragment`, so feature-detecting
+     * RUM/analytics libraries succeed in native shadow but throw in synthetic. This is a visible
+     * change to a long-stable API used by every synthetic-shadow consumer, hence gated and off by
+     * default.
      *
-     * Note: `'methodName' in root` stays `true` in both states by design — the own property is what
-     * shadows the native `DocumentFragment.prototype` method (see @lwc/synthetic-shadow
+     * The flag is scoped to `getElementById` alone — the only unsupported `ShadowRoot` method with a
+     * genuine native-vs-synthetic feature-detection divergence and a working `querySelector` fallback.
+     * The other unsupported methods (`getSelection`, `cloneNode`) remain plain throwing stubs.
+     *
+     * Note: `'getElementById' in root` stays `true` in both states by design — the own property is
+     * what shadows the native `DocumentFragment.prototype.getElementById` (see @lwc/synthetic-shadow
      * shadow-root.ts). A caller that guards with `in` rather than a value check therefore still
      * enters the branch and, flag-on, throws a plain `TypeError` on the `undefined` value instead of
      * the descriptive `Disallowed method` error.

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -104,15 +104,23 @@ export interface FeatureFlagMap {
      * semantics and are therefore not emulated: `getElementById`, `getSelection`, and `cloneNode`.
      *
      * When false or unset (default), these are exposed as stubs that throw when invoked — preserving
-     * the long-standing behavior. Because a throwing stub is still a callable function, feature
-     * detection (`typeof root.getElementById === 'function'`) reports it as present, so callers
-     * invoke it and hit the throw.
+     * the long-standing behavior. Because a throwing stub is still a callable function, *value-based*
+     * feature detection (`typeof root.getElementById === 'function'`, `if (root.getElementById)`,
+     * `root.getElementById?.(id)`) reports it as present, so callers invoke it and hit the throw.
      *
-     * When true, the methods are exposed as `undefined` instead, so feature detection reveals their
-     * absence and callers can fall back to the supported, shadow-scoped `querySelector('#' + id)`
-     * (matching how native shadow behaves for well-behaved feature-detecting code). This is a
+     * When true, the methods are exposed as `undefined` instead, so value-based feature detection
+     * reveals their absence and callers can fall back to the supported, shadow-scoped
+     * `querySelector('#' + id)`. This closes a real native-vs-synthetic divergence for
+     * `getElementById` (native `ShadowRoot` inherits a working one from `DocumentFragment`);
+     * `getSelection`/`cloneNode` are swept in for a uniform surface, not native parity. This is a
      * visible change to a long-stable API used by every synthetic-shadow consumer, hence gated and
      * off by default.
+     *
+     * Note: `'methodName' in root` stays `true` in both states by design — the own property is what
+     * shadows the native `DocumentFragment.prototype` method (see @lwc/synthetic-shadow
+     * shadow-root.ts). A caller that guards with `in` rather than a value check therefore still
+     * enters the branch and, flag-on, throws a plain `TypeError` on the `undefined` value instead of
+     * the descriptive `Disallowed method` error.
      */
     ENABLE_SHADOW_ROOT_UNDEFINED_METHODS: FeatureFlagValue;
 }

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -116,9 +116,8 @@ export interface FeatureFlagMap {
      * change to a long-stable API used by every synthetic-shadow consumer, hence gated and off by
      * default.
      *
-     * The flag is scoped to `getElementById` alone — the only unsupported `ShadowRoot` method with a
-     * genuine native-vs-synthetic feature-detection divergence and a working `querySelector` fallback.
-     * The other unsupported methods (`getSelection`, `cloneNode`) remain plain throwing stubs.
+     * The flag affects `getElementById` only; the other unsupported `ShadowRoot` methods
+     * (`getSelection`, `cloneNode`) are unrelated to it and remain plain throwing stubs.
      *
      * Note: `'getElementById' in root` stays `true` in both states by design — the own property is
      * what shadows the native `DocumentFragment.prototype.getElementById` (see @lwc/synthetic-shadow

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -100,30 +100,18 @@ export interface FeatureFlagMap {
     DISABLE_HOST_ATTACH_SHADOW_GUARD: FeatureFlagValue;
 
     /**
-     * Controls how synthetic shadow exposes `ShadowRoot.getElementById`, which has no correct
-     * shadow-scoped semantics and is therefore not emulated.
+     * Controls how synthetic shadow exposes `ShadowRoot.getElementById`, which is not emulated.
      *
-     * When false or unset (default), it is exposed as a stub that throws when invoked — preserving
-     * the long-standing behavior. Because a throwing stub is still a callable function, *value-based*
-     * feature detection (`typeof root.getElementById === 'function'`, `if (root.getElementById)`,
-     * `root.getElementById?.(id)`) reports it as present, so callers invoke it and hit the throw.
+     * When false or unset (default), it is a stub that throws when invoked — the long-standing
+     * behavior. When true, it is exposed as `undefined` instead, so value-based feature detection
+     * (`typeof`, `if`, `?.`) reveals its absence and callers fall back to `querySelector('#' + id)`.
+     * This closes a native-vs-synthetic divergence: native `ShadowRoot` inherits a working
+     * `getElementById` from `DocumentFragment`, so feature-detecting RUM/analytics libraries succeed
+     * in native shadow but throw in synthetic. Off by default since it changes long-stable behavior.
      *
-     * When true, `getElementById` is exposed as `undefined` instead, so value-based feature detection
-     * reveals its absence and callers can fall back to the supported, shadow-scoped
-     * `querySelector('#' + id)`. This closes a real native-vs-synthetic divergence: native
-     * `ShadowRoot` inherits a working `getElementById` from `DocumentFragment`, so feature-detecting
-     * RUM/analytics libraries succeed in native shadow but throw in synthetic. This is a visible
-     * change to a long-stable API used by every synthetic-shadow consumer, hence gated and off by
-     * default.
-     *
-     * The flag affects `getElementById` only; the other unsupported `ShadowRoot` methods
-     * (`getSelection`, `cloneNode`) are unrelated to it and remain plain throwing stubs.
-     *
-     * Note: `'getElementById' in root` stays `true` in both states by design — the own property is
-     * what shadows the native `DocumentFragment.prototype.getElementById` (see @lwc/synthetic-shadow
-     * shadow-root.ts). A caller that guards with `in` rather than a value check therefore still
-     * enters the branch and, flag-on, throws a plain `TypeError` on the `undefined` value instead of
-     * the descriptive `Disallowed method` error.
+     * Affects `getElementById` only; `getSelection` / `cloneNode` remain plain throwing stubs. See
+     * @lwc/synthetic-shadow shadow-root.ts for why `'getElementById' in root` stays `true` in both
+     * states (and the `in`-guard `TypeError` caveat).
      */
     ENABLE_SHADOW_ROOT_UNDEFINED_METHODS: FeatureFlagValue;
 }

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -100,20 +100,11 @@ export interface FeatureFlagMap {
     DISABLE_HOST_ATTACH_SHADOW_GUARD: FeatureFlagValue;
 
     /**
-     * Controls how synthetic shadow exposes `ShadowRoot.getElementById`, which is not emulated.
-     *
-     * When false or unset (default), it is a stub that throws when invoked — the long-standing
-     * behavior. When true, it is exposed as `undefined` instead, so value-based feature detection
-     * (`typeof`, `if`, `?.`) reveals its absence and callers fall back to `querySelector('#' + id)`.
-     * This closes a native-vs-synthetic divergence: native `ShadowRoot` inherits a working
-     * `getElementById` from `DocumentFragment`, so feature-detecting RUM/analytics libraries succeed
-     * in native shadow but throw in synthetic. Off by default since it changes long-stable behavior.
-     *
-     * Affects `getElementById` only; `getSelection` / `cloneNode` remain plain throwing stubs. See
-     * @lwc/synthetic-shadow shadow-root.ts for why `'getElementById' in root` stays `true` in both
-     * states (and the `in`-guard `TypeError` caveat).
+     * If true, synthetic shadow exposes the unemulated `ShadowRoot.getElementById` as `undefined`
+     * so value-based feature detection falls back to `querySelector`. If false or unset (default),
+     * it stays a stub that throws when invoked.
      */
-    ENABLE_SHADOW_ROOT_UNDEFINED_METHODS: FeatureFlagValue;
+    ENABLE_SHADOW_ROOT_UNDEFINED_GET_ELEMENT_BY_ID: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
@@ -85,9 +85,19 @@ describe.skipIf(process.env.NATIVE_SHADOW)('synthetic-shadow restrictions', () =
         );
     });
 
-    it(`should throw when invoking ShadowRoot.getElementById`, () => {
-        expect(() => elm.shadowRoot.getElementById()).toThrowError(
-            `Disallowed method "getElementById" on ShadowRoot.`
-        );
+    // `getElementById` is not emulated on the synthetic ShadowRoot. Instead of a throwing stub
+    // (which is a callable function and therefore passes `typeof root.getElementById === 'function'`
+    // feature detection, only to throw when invoked), it is left `undefined` so callers can
+    // feature-detect its absence and fall back to the supported, shadow-scoped `querySelector`.
+    it(`should not expose ShadowRoot.getElementById as a callable method`, () => {
+        expect(elm.shadowRoot.getElementById).toBe(undefined);
+        expect(typeof elm.shadowRoot.getElementById).not.toBe('function');
+        expect('getElementById' in elm.shadowRoot).toBe(true);
+    });
+
+    it(`querySelector remains the supported shadow-scoped lookup`, () => {
+        // querySelector stays emulated and callable (the recommended fallback for id lookups
+        // via querySelector('#' + id)), unlike the absent getElementById.
+        expect(typeof elm.shadowRoot.querySelector).toBe('function');
     });
 });

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
@@ -94,6 +94,48 @@ describe.skipIf(process.env.NATIVE_SHADOW)('synthetic-shadow restrictions', () =
                 expect(typeof elm.shadowRoot[method]).toBe('function');
             });
         });
+
+        // Write semantics must match the pre-flag `writable: true` data property: some consumers
+        // monkey-patch these unsupported methods with a working implementation. The flag is exposed
+        // via an accessor (so the flag read stays dynamic), and a getter-only accessor would break
+        // that — throwing in strict mode, silently dropping the write in sloppy mode. The paired
+        // setter restores the original behavior by installing an own writable data property.
+        describe('preserves reassignment (writable) semantics', () => {
+            DISALLOWED_METHODS.forEach((method) => {
+                it(`allows replacing ShadowRoot.${method} on an instance (strict mode)`, () => {
+                    // This spec module is an ES module, so this assignment runs in strict mode —
+                    // the case that would throw against a getter-only accessor.
+                    const fresh = createElement('x-test', { is: Test });
+                    const replacement = () => 'replaced';
+                    expect(() => {
+                        fresh.shadowRoot[method] = replacement;
+                    }).not.toThrow();
+                    expect(fresh.shadowRoot[method]).toBe(replacement);
+                    expect(fresh.shadowRoot[method]()).toBe('replaced');
+                });
+
+                it(`records the replacement as an own writable data property for ShadowRoot.${method}`, () => {
+                    const fresh = createElement('x-test', { is: Test });
+                    fresh.shadowRoot[method] = () => 'replaced';
+                    const desc = Object.getOwnPropertyDescriptor(fresh.shadowRoot, method);
+                    expect(desc).toBeDefined();
+                    expect(desc.writable).toBe(true);
+                    expect(desc.enumerable).toBe(true);
+                    expect(desc.configurable).toBe(true);
+                    expect(typeof desc.value).toBe('function');
+                });
+
+                it(`isolates the replacement of ShadowRoot.${method} to the reassigned instance`, () => {
+                    const a = createElement('x-test', { is: Test });
+                    const b = createElement('x-test', { is: Test });
+                    a.shadowRoot[method] = () => 'replaced';
+                    // A sibling instance still sees the original throwing stub.
+                    expect(() => b.shadowRoot[method]()).toThrowError(
+                        `Disallowed method "${method}" on ShadowRoot.`
+                    );
+                });
+            });
+        });
     });
 
     // Opt-in behavior (flag on): the methods are `undefined`, so feature detection reveals their

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
@@ -67,9 +67,14 @@ describe('Properties overrides', () => {
 });
 
 // `getElementById`, `getSelection`, and `cloneNode` have no correct shadow-scoped semantics and are
-// not emulated on the synthetic ShadowRoot. How their absence is *exposed* is gated by the
-// ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag (see @lwc/synthetic-shadow shadow-root.ts).
+// not emulated on the synthetic ShadowRoot — invoking any of them throws. Only `getElementById` has
+// a genuine native-vs-synthetic feature-detection divergence (native `ShadowRoot` inherits a working
+// one from `DocumentFragment`) with a `querySelector` fallback, so only *its* exposure is gated by
+// the ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag (see @lwc/synthetic-shadow shadow-root.ts).
+// `getSelection`/`cloneNode` are plain throwing stubs the flag does not affect.
 const DISALLOWED_METHODS = ['getSelection', 'cloneNode', 'getElementById'];
+const FLAG_GATED_METHOD = 'getElementById';
+const UNGATED_METHODS = DISALLOWED_METHODS.filter((m) => m !== FLAG_GATED_METHOD);
 
 describe.skipIf(process.env.NATIVE_SHADOW)('synthetic-shadow restrictions', () => {
     let elm;
@@ -78,8 +83,8 @@ describe.skipIf(process.env.NATIVE_SHADOW)('synthetic-shadow restrictions', () =
         elm = createElement('x-test', { is: Test });
     });
 
-    // Default behavior (flag off): the methods are throwing stubs. This preserves the long-standing
-    // behavior shipped to every synthetic-shadow consumer.
+    // Default behavior (flag off): all three methods are throwing stubs. This preserves the
+    // long-standing behavior shipped to every synthetic-shadow consumer.
     describe('by default (ENABLE_SHADOW_ROOT_UNDEFINED_METHODS off)', () => {
         DISALLOWED_METHODS.forEach((method) => {
             it(`should throw when invoking ShadowRoot.${method}`, () => {
@@ -96,10 +101,12 @@ describe.skipIf(process.env.NATIVE_SHADOW)('synthetic-shadow restrictions', () =
         });
 
         // Write semantics must match the pre-flag `writable: true` data property: some consumers
-        // monkey-patch these unsupported methods with a working implementation. The flag is exposed
-        // via an accessor (so the flag read stays dynamic), and a getter-only accessor would break
-        // that — throwing in strict mode, silently dropping the write in sloppy mode. The paired
-        // setter restores the original behavior by installing an own writable data property.
+        // monkey-patch these unsupported methods with a working implementation. `getSelection` and
+        // `cloneNode` remain plain writable data properties, so this always held for them. The
+        // flag-gated `getElementById` is exposed via an accessor (so the flag read stays dynamic),
+        // and a getter-only accessor would break reassignment — throwing in strict mode, silently
+        // dropping the write in sloppy mode; its paired setter restores the writable-data-property
+        // behavior. This block asserts all three behave identically on reassignment.
         describe('preserves reassignment (writable) semantics', () => {
             DISALLOWED_METHODS.forEach((method) => {
                 it(`allows replacing ShadowRoot.${method} on an instance (strict mode)`, () => {
@@ -138,8 +145,9 @@ describe.skipIf(process.env.NATIVE_SHADOW)('synthetic-shadow restrictions', () =
         });
     });
 
-    // Opt-in behavior (flag on): the methods are `undefined`, so feature detection reveals their
-    // absence and callers fall back to the supported, shadow-scoped `querySelector('#' + id)`.
+    // Opt-in behavior (flag on): only `getElementById` becomes `undefined`, so feature detection
+    // reveals its absence and callers fall back to the supported, shadow-scoped
+    // `querySelector('#' + id)`. `getSelection`/`cloneNode` are unaffected by the flag.
     describe('with ENABLE_SHADOW_ROOT_UNDEFINED_METHODS enabled', () => {
         beforeAll(() => {
             setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', true);
@@ -149,16 +157,24 @@ describe.skipIf(process.env.NATIVE_SHADOW)('synthetic-shadow restrictions', () =
             setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', false);
         });
 
-        DISALLOWED_METHODS.forEach((method) => {
-            it(`exposes ShadowRoot.${method} as undefined`, () => {
-                expect(elm.shadowRoot[method]).toBe(undefined);
-                expect(typeof elm.shadowRoot[method]).not.toBe('function');
-            });
+        it(`exposes ShadowRoot.${FLAG_GATED_METHOD} as undefined`, () => {
+            expect(elm.shadowRoot[FLAG_GATED_METHOD]).toBe(undefined);
+            expect(typeof elm.shadowRoot[FLAG_GATED_METHOD]).not.toBe('function');
+        });
 
-            it(`keeps '${method}' as an own property so it shadows DocumentFragment.prototype`, () => {
-                // The property must still exist (as undefined) — deleting it would expose the
-                // native DocumentFragment method, which runs against the empty fragment.
-                expect(method in elm.shadowRoot).toBe(true);
+        it(`keeps '${FLAG_GATED_METHOD}' as an own property so it shadows DocumentFragment.prototype`, () => {
+            // The property must still exist (as undefined) — deleting it would expose the
+            // native DocumentFragment method, which runs against the empty fragment.
+            expect(FLAG_GATED_METHOD in elm.shadowRoot).toBe(true);
+        });
+
+        // The flag is scoped to getElementById; the other unsupported methods must be untouched.
+        UNGATED_METHODS.forEach((method) => {
+            it(`leaves ShadowRoot.${method} as a throwing stub regardless of the flag`, () => {
+                expect(typeof elm.shadowRoot[method]).toBe('function');
+                expect(() => elm.shadowRoot[method]()).toThrowError(
+                    `Disallowed method "${method}" on ShadowRoot.`
+                );
             });
         });
 

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
@@ -168,6 +168,21 @@ describe.skipIf(process.env.NATIVE_SHADOW)('synthetic-shadow restrictions', () =
             expect(FLAG_GATED_METHOD in elm.shadowRoot).toBe(true);
         });
 
+        it(`still allows replacing ShadowRoot.${FLAG_GATED_METHOD} with the flag on`, () => {
+            // The setter that preserves writable-data-property write semantics is
+            // flag-independent: reassignment must keep working even when the getter would
+            // otherwise return undefined. Guards against re-coupling the setter to the flag.
+            const fresh = createElement('x-test', { is: Test });
+            const replacement = () => 'replaced';
+            expect(() => {
+                fresh.shadowRoot[FLAG_GATED_METHOD] = replacement;
+            }).not.toThrow();
+            expect(fresh.shadowRoot[FLAG_GATED_METHOD]).toBe(replacement);
+            const desc = Object.getOwnPropertyDescriptor(fresh.shadowRoot, FLAG_GATED_METHOD);
+            expect(desc.writable).toBe(true);
+            expect(typeof desc.value).toBe('function');
+        });
+
         // The flag is scoped to getElementById; the other unsupported methods must be untouched.
         UNGATED_METHODS.forEach((method) => {
             it(`leaves ShadowRoot.${method} as a throwing stub regardless of the flag`, () => {

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement, setFeatureFlagForTest } from 'lwc';
 
 import Test from 'x/test';
 
@@ -66,6 +66,11 @@ describe('Properties overrides', () => {
     });
 });
 
+// `getElementById`, `getSelection`, and `cloneNode` have no correct shadow-scoped semantics and are
+// not emulated on the synthetic ShadowRoot. How their absence is *exposed* is gated by the
+// ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag (see @lwc/synthetic-shadow shadow-root.ts).
+const DISALLOWED_METHODS = ['getSelection', 'cloneNode', 'getElementById'];
+
 describe.skipIf(process.env.NATIVE_SHADOW)('synthetic-shadow restrictions', () => {
     let elm;
 
@@ -73,31 +78,52 @@ describe.skipIf(process.env.NATIVE_SHADOW)('synthetic-shadow restrictions', () =
         elm = createElement('x-test', { is: Test });
     });
 
-    it(`should throw when invoking ShadowRoot.getSelection`, () => {
-        expect(() => elm.shadowRoot.getSelection()).toThrowError(
-            `Disallowed method "getSelection" on ShadowRoot.`
-        );
+    // Default behavior (flag off): the methods are throwing stubs. This preserves the long-standing
+    // behavior shipped to every synthetic-shadow consumer.
+    describe('by default (ENABLE_SHADOW_ROOT_UNDEFINED_METHODS off)', () => {
+        DISALLOWED_METHODS.forEach((method) => {
+            it(`should throw when invoking ShadowRoot.${method}`, () => {
+                expect(() => elm.shadowRoot[method]()).toThrowError(
+                    `Disallowed method "${method}" on ShadowRoot.`
+                );
+            });
+
+            it(`exposes ShadowRoot.${method} as a callable function`, () => {
+                // The crux of the problem the flag addresses: a throwing stub still passes
+                // `typeof === 'function'` feature detection, so callers commit to invoking it.
+                expect(typeof elm.shadowRoot[method]).toBe('function');
+            });
+        });
     });
 
-    it(`should throw when invoking ShadowRoot.cloneNode`, () => {
-        expect(() => elm.shadowRoot.cloneNode()).toThrowError(
-            `Disallowed method "cloneNode" on ShadowRoot.`
-        );
-    });
+    // Opt-in behavior (flag on): the methods are `undefined`, so feature detection reveals their
+    // absence and callers fall back to the supported, shadow-scoped `querySelector('#' + id)`.
+    describe('with ENABLE_SHADOW_ROOT_UNDEFINED_METHODS enabled', () => {
+        beforeAll(() => {
+            setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', true);
+        });
 
-    // `getElementById` is not emulated on the synthetic ShadowRoot. Instead of a throwing stub
-    // (which is a callable function and therefore passes `typeof root.getElementById === 'function'`
-    // feature detection, only to throw when invoked), it is left `undefined` so callers can
-    // feature-detect its absence and fall back to the supported, shadow-scoped `querySelector`.
-    it(`should not expose ShadowRoot.getElementById as a callable method`, () => {
-        expect(elm.shadowRoot.getElementById).toBe(undefined);
-        expect(typeof elm.shadowRoot.getElementById).not.toBe('function');
-        expect('getElementById' in elm.shadowRoot).toBe(true);
-    });
+        afterAll(() => {
+            setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', false);
+        });
 
-    it(`querySelector remains the supported shadow-scoped lookup`, () => {
-        // querySelector stays emulated and callable (the recommended fallback for id lookups
-        // via querySelector('#' + id)), unlike the absent getElementById.
-        expect(typeof elm.shadowRoot.querySelector).toBe('function');
+        DISALLOWED_METHODS.forEach((method) => {
+            it(`exposes ShadowRoot.${method} as undefined`, () => {
+                expect(elm.shadowRoot[method]).toBe(undefined);
+                expect(typeof elm.shadowRoot[method]).not.toBe('function');
+            });
+
+            it(`keeps '${method}' as an own property so it shadows DocumentFragment.prototype`, () => {
+                // The property must still exist (as undefined) — deleting it would expose the
+                // native DocumentFragment method, which runs against the empty fragment.
+                expect(method in elm.shadowRoot).toBe(true);
+            });
+        });
+
+        it('querySelector remains the supported shadow-scoped lookup', () => {
+            // querySelector stays emulated and callable — the recommended fallback for id lookups
+            // via querySelector('#' + id), unlike the now-absent getElementById.
+            expect(typeof elm.shadowRoot.querySelector).toBe('function');
+        });
     });
 });

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/ShadowRoot.spec.js
@@ -1,4 +1,4 @@
-import { createElement, setFeatureFlagForTest } from 'lwc';
+import { createElement } from 'lwc';
 
 import Test from 'x/test';
 
@@ -66,16 +66,6 @@ describe('Properties overrides', () => {
     });
 });
 
-// `getElementById`, `getSelection`, and `cloneNode` have no correct shadow-scoped semantics and are
-// not emulated on the synthetic ShadowRoot — invoking any of them throws. Only `getElementById` has
-// a genuine native-vs-synthetic feature-detection divergence (native `ShadowRoot` inherits a working
-// one from `DocumentFragment`) with a `querySelector` fallback, so only *its* exposure is gated by
-// the ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag (see @lwc/synthetic-shadow shadow-root.ts).
-// `getSelection`/`cloneNode` are plain throwing stubs the flag does not affect.
-const DISALLOWED_METHODS = ['getSelection', 'cloneNode', 'getElementById'];
-const FLAG_GATED_METHOD = 'getElementById';
-const UNGATED_METHODS = DISALLOWED_METHODS.filter((m) => m !== FLAG_GATED_METHOD);
-
 describe.skipIf(process.env.NATIVE_SHADOW)('synthetic-shadow restrictions', () => {
     let elm;
 
@@ -83,120 +73,21 @@ describe.skipIf(process.env.NATIVE_SHADOW)('synthetic-shadow restrictions', () =
         elm = createElement('x-test', { is: Test });
     });
 
-    // Default behavior (flag off): all three methods are throwing stubs. This preserves the
-    // long-standing behavior shipped to every synthetic-shadow consumer.
-    describe('by default (ENABLE_SHADOW_ROOT_UNDEFINED_METHODS off)', () => {
-        DISALLOWED_METHODS.forEach((method) => {
-            it(`should throw when invoking ShadowRoot.${method}`, () => {
-                expect(() => elm.shadowRoot[method]()).toThrowError(
-                    `Disallowed method "${method}" on ShadowRoot.`
-                );
-            });
-
-            it(`exposes ShadowRoot.${method} as a callable function`, () => {
-                // The crux of the problem the flag addresses: a throwing stub still passes
-                // `typeof === 'function'` feature detection, so callers commit to invoking it.
-                expect(typeof elm.shadowRoot[method]).toBe('function');
-            });
-        });
-
-        // Write semantics must match the pre-flag `writable: true` data property: some consumers
-        // monkey-patch these unsupported methods with a working implementation. `getSelection` and
-        // `cloneNode` remain plain writable data properties, so this always held for them. The
-        // flag-gated `getElementById` is exposed via an accessor (so the flag read stays dynamic),
-        // and a getter-only accessor would break reassignment — throwing in strict mode, silently
-        // dropping the write in sloppy mode; its paired setter restores the writable-data-property
-        // behavior. This block asserts all three behave identically on reassignment.
-        describe('preserves reassignment (writable) semantics', () => {
-            DISALLOWED_METHODS.forEach((method) => {
-                it(`allows replacing ShadowRoot.${method} on an instance (strict mode)`, () => {
-                    // This spec module is an ES module, so this assignment runs in strict mode —
-                    // the case that would throw against a getter-only accessor.
-                    const fresh = createElement('x-test', { is: Test });
-                    const replacement = () => 'replaced';
-                    expect(() => {
-                        fresh.shadowRoot[method] = replacement;
-                    }).not.toThrow();
-                    expect(fresh.shadowRoot[method]).toBe(replacement);
-                    expect(fresh.shadowRoot[method]()).toBe('replaced');
-                });
-
-                it(`records the replacement as an own writable data property for ShadowRoot.${method}`, () => {
-                    const fresh = createElement('x-test', { is: Test });
-                    fresh.shadowRoot[method] = () => 'replaced';
-                    const desc = Object.getOwnPropertyDescriptor(fresh.shadowRoot, method);
-                    expect(desc).toBeDefined();
-                    expect(desc.writable).toBe(true);
-                    expect(desc.enumerable).toBe(true);
-                    expect(desc.configurable).toBe(true);
-                    expect(typeof desc.value).toBe('function');
-                });
-
-                it(`isolates the replacement of ShadowRoot.${method} to the reassigned instance`, () => {
-                    const a = createElement('x-test', { is: Test });
-                    const b = createElement('x-test', { is: Test });
-                    a.shadowRoot[method] = () => 'replaced';
-                    // A sibling instance still sees the original throwing stub.
-                    expect(() => b.shadowRoot[method]()).toThrowError(
-                        `Disallowed method "${method}" on ShadowRoot.`
-                    );
-                });
-            });
-        });
+    it(`should throw when invoking ShadowRoot.getSelection`, () => {
+        expect(() => elm.shadowRoot.getSelection()).toThrowError(
+            `Disallowed method "getSelection" on ShadowRoot.`
+        );
     });
 
-    // Opt-in behavior (flag on): only `getElementById` becomes `undefined`, so feature detection
-    // reveals its absence and callers fall back to the supported, shadow-scoped
-    // `querySelector('#' + id)`. `getSelection`/`cloneNode` are unaffected by the flag.
-    describe('with ENABLE_SHADOW_ROOT_UNDEFINED_METHODS enabled', () => {
-        beforeAll(() => {
-            setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', true);
-        });
+    it(`should throw when invoking ShadowRoot.cloneNode`, () => {
+        expect(() => elm.shadowRoot.cloneNode()).toThrowError(
+            `Disallowed method "cloneNode" on ShadowRoot.`
+        );
+    });
 
-        afterAll(() => {
-            setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', false);
-        });
-
-        it(`exposes ShadowRoot.${FLAG_GATED_METHOD} as undefined`, () => {
-            expect(elm.shadowRoot[FLAG_GATED_METHOD]).toBe(undefined);
-            expect(typeof elm.shadowRoot[FLAG_GATED_METHOD]).not.toBe('function');
-        });
-
-        it(`keeps '${FLAG_GATED_METHOD}' as an own property so it shadows DocumentFragment.prototype`, () => {
-            // The property must still exist (as undefined) — deleting it would expose the
-            // native DocumentFragment method, which runs against the empty fragment.
-            expect(FLAG_GATED_METHOD in elm.shadowRoot).toBe(true);
-        });
-
-        it(`still allows replacing ShadowRoot.${FLAG_GATED_METHOD} with the flag on`, () => {
-            // The setter that preserves writable-data-property write semantics is
-            // flag-independent: reassignment must keep working even when the getter would
-            // otherwise return undefined. Guards against re-coupling the setter to the flag.
-            const fresh = createElement('x-test', { is: Test });
-            const replacement = () => 'replaced';
-            expect(() => {
-                fresh.shadowRoot[FLAG_GATED_METHOD] = replacement;
-            }).not.toThrow();
-            expect(fresh.shadowRoot[FLAG_GATED_METHOD]).toBe(replacement);
-            const desc = Object.getOwnPropertyDescriptor(fresh.shadowRoot, FLAG_GATED_METHOD);
-            expect(desc.writable).toBe(true);
-            expect(typeof desc.value).toBe('function');
-        });
-
-        // The flag is scoped to getElementById; the other unsupported methods must be untouched.
-        UNGATED_METHODS.forEach((method) => {
-            it(`leaves ShadowRoot.${method} as a throwing stub regardless of the flag`, () => {
-                expect(typeof elm.shadowRoot[method]).toBe('function');
-                expect(() => elm.shadowRoot[method]()).toThrowError(
-                    `Disallowed method "${method}" on ShadowRoot.`
-                );
-            });
-        });
-
-        it('querySelector remains the supported shadow-scoped lookup', () => {
-            // querySelector stays emulated and callable — the recommended fallback for id lookups
-            // via querySelector('#' + id), unlike the now-absent getElementById.
-            expect(typeof elm.shadowRoot.querySelector).toBe('function');
-        });
+    it(`should throw when invoking ShadowRoot.getElementById`, () => {
+        expect(() => elm.shadowRoot.getElementById()).toThrowError(
+            `Disallowed method "getElementById" on ShadowRoot.`
+        );
     });
 });

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
@@ -1,0 +1,56 @@
+import { createElement } from 'lwc';
+
+import Lookup from 'x/lookup';
+
+// Some third-party libraries (e.g. RUM / analytics agents) resolve an element by id relative to a
+// node's root, obtained via `node.getRootNode()`. A well-behaved library feature-detects the method
+// before using it and falls back to `querySelector('#' + id)` when it is unavailable:
+//
+//     function resolveById(root, id) {
+//         if (typeof root.getElementById === 'function') {
+//             return root.getElementById(id);
+//         }
+//         return root.querySelector('#' + id);
+//     }
+//
+// On the synthetic ShadowRoot `getElementById` is intentionally not emulated. It must therefore be
+// feature-detectable as ABSENT: exposing it as a throwing stub is worse than not exposing it at all,
+// because a stub is still a callable function — `typeof root.getElementById === 'function'` is `true`
+// — so the guard passes and the caller invokes it, only for it to throw. Leaving it `undefined`
+// makes the guard fail, so the caller pivots to the supported, shadow-scoped `querySelector`.
+function resolveById(root, id) {
+    if (typeof root.getElementById === 'function') {
+        return root.getElementById(id);
+    }
+    return root.querySelector('#' + id);
+}
+
+describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature detection', () => {
+    let shadowRoot;
+
+    beforeAll(() => {
+        const elm = createElement('x-lookup', { is: Lookup });
+        // Must be connected so renderedCallback runs and injects the marker node.
+        document.body.appendChild(elm);
+        shadowRoot = elm.shadowRoot;
+    });
+
+    it('exposes getElementById as absent (not a callable stub) so feature detection reveals it', () => {
+        // The crux of the fix: detection must report the method as unavailable.
+        expect(typeof shadowRoot.getElementById === 'function').toBe(false);
+        expect(shadowRoot.getElementById).toBe(undefined);
+    });
+
+    it('lets a feature-detecting caller resolve an element without throwing', () => {
+        // Before the fix, `getElementById` was a throwing stub: the guard above passed (it IS a
+        // function), the caller invoked it, and it threw `Disallowed method "getElementById" ...`.
+        // After the fix the guard fails and the caller falls back to querySelector — no throw.
+        expect(() => resolveById(shadowRoot, 'injected-marker')).not.toThrow();
+    });
+
+    it('resolves the element end-to-end via the querySelector fallback', () => {
+        const el = resolveById(shadowRoot, 'injected-marker');
+        expect(el).not.toBeNull();
+        expect(el.textContent).toBe('Injected Marker');
+    });
+});

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
@@ -77,9 +77,11 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
             expect('getElementById' in shadowRoot).toBe(true);
         });
 
-        it('throws a plain TypeError when an `in`-guarded caller invokes the undefined value', () => {
+        it('throws a plain TypeError — not the descriptive error — when an `in`-guarded caller invokes the undefined value', () => {
             // A caller that guards with `in` rather than a value check still enters the branch and
-            // calls `undefined()`, which throws a native TypeError (not the descriptive stub error).
+            // calls `undefined()`, which throws a native TypeError. This is deliberately distinct
+            // from the flag-off throwing stub, whose descriptive `Disallowed method` Error is a
+            // plain Error (not a TypeError) — so the two assertions below pin the exact error kind.
             const callViaInGuard = () => {
                 if ('getElementById' in shadowRoot) {
                     return shadowRoot.getElementById('injected-marker');
@@ -87,9 +89,17 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
                 return null;
             };
             expect(callViaInGuard).toThrowError(TypeError);
+            expect(callViaInGuard).not.toThrowError(
+                'Disallowed method "getElementById" on ShadowRoot.'
+            );
         });
 
         it('silently no-ops for truthy-guard and optional-chaining callers', () => {
+            // Pin the precondition inline so this test is self-contained: with the flag on, the
+            // value is genuinely `undefined` (not a stub function), which is what makes the guards
+            // below short-circuit rather than invoke-and-return-undefined.
+            expect(shadowRoot.getElementById).toBe(undefined);
+
             // `if (root.getElementById)` skips the branch, and `root.getElementById?.(id)`
             // short-circuits — both yield undefined with no throw, rather than a resolved element.
             expect(shadowRoot.getElementById?.('injected-marker')).toBe(undefined);
@@ -98,6 +108,8 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
             if (shadowRoot.getElementById) {
                 result = shadowRoot.getElementById('injected-marker');
             }
+            // The sentinel survives only if the truthy branch was skipped; had it been entered and
+            // returned undefined, `result` would be undefined (≠ 'unset') and this would fail.
             expect(result).toBe('unset');
         });
 

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
@@ -2,23 +2,10 @@ import { createElement, setFeatureFlagForTest } from 'lwc';
 
 import Lookup from 'x/lookup';
 
-// Some third-party libraries (e.g. RUM / analytics agents) resolve an element by id relative to a
-// node's root, obtained via `node.getRootNode()`. A well-behaved library feature-detects the method
-// before using it and falls back to `querySelector('#' + id)` when it is unavailable:
-//
-//     function resolveById(root, id) {
-//         if (typeof root.getElementById === 'function') {
-//             return root.getElementById(id);
-//         }
-//         return root.querySelector('#' + id);
-//     }
-//
-// On the synthetic ShadowRoot `getElementById` is intentionally not emulated. By default it is a
-// throwing stub — which is worse than useless for these callers, because a stub is still a callable
-// function (`typeof root.getElementById === 'function'` is `true`), so the guard passes, the caller
-// invokes it, and it throws. The ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag makes the method
-// `undefined` instead, so the guard fails and the caller pivots to the supported, shadow-scoped
-// `querySelector`. These tests exercise both states through the exact feature-detecting caller.
+// Feature-detecting caller, as used by RUM/analytics libraries that resolve an id off
+// `node.getRootNode()`: use `getElementById` if present, else fall back to `querySelector`. On the
+// synthetic ShadowRoot the default throwing stub passes the guard and then throws; the
+// ENABLE_SHADOW_ROOT_UNDEFINED_METHODS flag makes it `undefined` so the caller falls back instead.
 function resolveById(root, id) {
     if (typeof root.getElementById === 'function') {
         return root.getElementById(id);
@@ -43,13 +30,12 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
         });
 
         it('reports getElementById as present via the `in` operator', () => {
-            // `in` is true here and stays true flag-on (the own property shadows the native
-            // DocumentFragment method), so it never distinguishes the two states.
+            // Stays true flag-on too (the own property shadows the native method), so `in` never
+            // distinguishes the two states.
             expect('getElementById' in shadowRoot).toBe(true);
         });
 
         it('makes a feature-detecting caller throw (the reported failure mode)', () => {
-            // The guard passes (it IS a function), the caller invokes it, and it throws.
             expect(() => resolveById(shadowRoot, 'injected-marker')).toThrowError(
                 `Disallowed method "getElementById" on ShadowRoot.`
             );
@@ -72,16 +58,15 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
         });
 
         it('still reports getElementById as present via the `in` operator (by design)', () => {
-            // The own property remains (as undefined) to shadow the native DocumentFragment
-            // method, so `in` cannot be used to detect absence — value-based checks must be used.
+            // The own property remains (as undefined) to shadow the native method, so `in` can't
+            // detect absence — value-based checks must be used.
             expect('getElementById' in shadowRoot).toBe(true);
         });
 
         it('throws a plain TypeError — not the descriptive error — when an `in`-guarded caller invokes the undefined value', () => {
-            // A caller that guards with `in` rather than a value check still enters the branch and
-            // calls `undefined()`, which throws a native TypeError. This is deliberately distinct
-            // from the flag-off throwing stub, whose descriptive `Disallowed method` Error is a
-            // plain Error (not a TypeError) — so the two assertions below pin the exact error kind.
+            // An `in`-guarded caller enters the branch and calls `undefined()` → native TypeError,
+            // distinct from the flag-off stub's descriptive (plain-Error) throw. Both assertions
+            // below pin the exact error kind.
             const callViaInGuard = () => {
                 if ('getElementById' in shadowRoot) {
                     return shadowRoot.getElementById('injected-marker');
@@ -95,26 +80,22 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
         });
 
         it('silently no-ops for truthy-guard and optional-chaining callers', () => {
-            // Pin the precondition inline so this test is self-contained: with the flag on, the
-            // value is genuinely `undefined` (not a stub function), which is what makes the guards
-            // below short-circuit rather than invoke-and-return-undefined.
+            // Precondition: genuinely `undefined` (not a stub), which is what makes the guards below
+            // short-circuit rather than invoke-and-return-undefined.
             expect(shadowRoot.getElementById).toBe(undefined);
 
-            // `if (root.getElementById)` skips the branch, and `root.getElementById?.(id)`
-            // short-circuits — both yield undefined with no throw, rather than a resolved element.
             expect(shadowRoot.getElementById?.('injected-marker')).toBe(undefined);
 
             let result = 'unset';
             if (shadowRoot.getElementById) {
                 result = shadowRoot.getElementById('injected-marker');
             }
-            // The sentinel survives only if the truthy branch was skipped; had it been entered and
-            // returned undefined, `result` would be undefined (≠ 'unset') and this would fail.
+            // The sentinel survives only if the branch was skipped — entering it would set `result`
+            // to undefined and fail here.
             expect(result).toBe('unset');
         });
 
         it('lets a feature-detecting caller resolve an element without throwing', () => {
-            // The guard now fails and the caller falls back to querySelector — no throw.
             expect(() => resolveById(shadowRoot, 'injected-marker')).not.toThrow();
         });
 
@@ -125,15 +106,11 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
         });
     });
 
-    // Some consumers monkey-patch the unsupported method with a working implementation. Before this
-    // flag, `getElementById` was a plain `writable: true` data property, so `root.getElementById = fn`
-    // just worked. Exposing it via an accessor (so the flag read stays dynamic) would break that — a
-    // getter-only accessor throws on assignment in strict mode and silently drops it in sloppy mode —
-    // so the descriptor pairs the getter with a setter that restores the writable-data-property
-    // behavior. These tests pin that reassignment contract in both flag states.
+    // Some consumers monkey-patch the method with a working implementation. It was a plain
+    // `writable` data property before this flag; the accessor's paired setter must preserve that
+    // `root.getElementById = fn` behavior (a getter-only accessor would throw on assignment in
+    // strict mode). Assignments below run in strict mode (ES module). Pinned in both flag states.
     describe('preserves reassignment (writable) semantics', () => {
-        // This spec module is an ES module, so these assignments run in strict mode — the case that
-        // would throw against a getter-only accessor.
         it('allows replacing getElementById on an instance (flag off)', () => {
             const elm = createElement('x-lookup', { is: Lookup });
             const replacement = () => 'replaced';
@@ -166,8 +143,8 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
         });
 
         it('still allows replacing getElementById with the flag on', () => {
-            // The setter is flag-independent: reassignment must keep working even when the getter
-            // would otherwise return undefined. Guards against re-coupling the setter to the flag.
+            // Guards against re-coupling the setter to the flag: reassignment must work even when
+            // the getter would otherwise return undefined.
             setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', true);
             try {
                 const elm = createElement('x-lookup', { is: Lookup });

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
@@ -2,10 +2,7 @@ import { createElement, setFeatureFlagForTest } from 'lwc';
 
 import Lookup from 'x/lookup';
 
-// Feature-detecting caller, as used by RUM/analytics libraries that resolve an id off
-// `node.getRootNode()`: use `getElementById` if present, else fall back to `querySelector`. On the
-// synthetic ShadowRoot the default throwing stub passes the guard and then throws; the
-// ENABLE_SHADOW_ROOT_UNDEFINED_METHODS flag makes it `undefined` so the caller falls back instead.
+// A feature-detecting caller: use `getElementById` if present, else fall back to `querySelector`.
 function resolveById(root, id) {
     if (typeof root.getElementById === 'function') {
         return root.getElementById(id);
@@ -18,20 +15,18 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
 
     beforeAll(() => {
         const elm = createElement('x-lookup', { is: Lookup });
-        // Must be connected so renderedCallback runs and injects the marker node.
         document.body.appendChild(elm);
         shadowRoot = elm.shadowRoot;
     });
 
     // Default (flag off): the throwing stub defeats feature detection — this is the reported bug.
-    describe('by default (ENABLE_SHADOW_ROOT_UNDEFINED_METHODS off)', () => {
+    describe('by default (ENABLE_SHADOW_ROOT_UNDEFINED_GET_ELEMENT_BY_ID off)', () => {
         it('exposes getElementById as a callable stub that defeats feature detection', () => {
             expect(typeof shadowRoot.getElementById).toBe('function');
         });
 
         it('reports getElementById as present via the `in` operator', () => {
-            // Stays true flag-on too (the own property shadows the native method), so `in` never
-            // distinguishes the two states.
+            // True flag-on too — the own property shadows the native method — so `in` never distinguishes them.
             expect('getElementById' in shadowRoot).toBe(true);
         });
 
@@ -43,13 +38,13 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
     });
 
     // Opt-in (flag on): the method is absent, so the caller falls back to querySelector and works.
-    describe('with ENABLE_SHADOW_ROOT_UNDEFINED_METHODS enabled', () => {
+    describe('with ENABLE_SHADOW_ROOT_UNDEFINED_GET_ELEMENT_BY_ID enabled', () => {
         beforeAll(() => {
-            setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', true);
+            setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_GET_ELEMENT_BY_ID', true);
         });
 
         afterAll(() => {
-            setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', false);
+            setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_GET_ELEMENT_BY_ID', false);
         });
 
         it('exposes getElementById as absent so feature detection reveals it', () => {
@@ -58,15 +53,12 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
         });
 
         it('still reports getElementById as present via the `in` operator (by design)', () => {
-            // The own property remains (as undefined) to shadow the native method, so `in` can't
-            // detect absence — value-based checks must be used.
+            // The own property (now undefined) still shadows the native method, so `in` can't detect absence.
             expect('getElementById' in shadowRoot).toBe(true);
         });
 
         it('throws a plain TypeError — not the descriptive error — when an `in`-guarded caller invokes the undefined value', () => {
-            // An `in`-guarded caller enters the branch and calls `undefined()` → native TypeError,
-            // distinct from the flag-off stub's descriptive (plain-Error) throw. Both assertions
-            // below pin the exact error kind.
+            // Enters the branch, calls `undefined()` → native TypeError, not the flag-off stub's descriptive throw.
             const callViaInGuard = () => {
                 if ('getElementById' in shadowRoot) {
                     return shadowRoot.getElementById('injected-marker');
@@ -80,18 +72,14 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
         });
 
         it('silently no-ops for truthy-guard and optional-chaining callers', () => {
-            // Precondition: genuinely `undefined` (not a stub), which is what makes the guards below
-            // short-circuit rather than invoke-and-return-undefined.
             expect(shadowRoot.getElementById).toBe(undefined);
-
             expect(shadowRoot.getElementById?.('injected-marker')).toBe(undefined);
 
             let result = 'unset';
             if (shadowRoot.getElementById) {
                 result = shadowRoot.getElementById('injected-marker');
             }
-            // The sentinel survives only if the branch was skipped — entering it would set `result`
-            // to undefined and fail here.
+            // The sentinel survives only if the guard skipped the branch.
             expect(result).toBe('unset');
         });
 
@@ -106,10 +94,8 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
         });
     });
 
-    // Some consumers monkey-patch the method with a working implementation. It was a plain
-    // `writable` data property before this flag; the accessor's paired setter must preserve that
-    // `root.getElementById = fn` behavior (a getter-only accessor would throw on assignment in
-    // strict mode). Assignments below run in strict mode (ES module). Pinned in both flag states.
+    // Consumers may monkey-patch the method, so the accessor's setter must preserve the old
+    // `writable` data-property behavior (a getter-only accessor throws on assignment in strict mode).
     describe('preserves reassignment (writable) semantics', () => {
         it('allows replacing getElementById on an instance (flag off)', () => {
             const elm = createElement('x-lookup', { is: Lookup });
@@ -145,7 +131,7 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
         it('still allows replacing getElementById with the flag on', () => {
             // Guards against re-coupling the setter to the flag: reassignment must work even when
             // the getter would otherwise return undefined.
-            setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', true);
+            setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_GET_ELEMENT_BY_ID', true);
             try {
                 const elm = createElement('x-lookup', { is: Lookup });
                 const replacement = () => 'replaced';
@@ -157,7 +143,7 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
                 expect(desc.writable).toBe(true);
                 expect(typeof desc.value).toBe('function');
             } finally {
-                setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', false);
+                setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_GET_ELEMENT_BY_ID', false);
             }
         });
     });

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement, setFeatureFlagForTest } from 'lwc';
 
 import Lookup from 'x/lookup';
 
@@ -13,11 +13,12 @@ import Lookup from 'x/lookup';
 //         return root.querySelector('#' + id);
 //     }
 //
-// On the synthetic ShadowRoot `getElementById` is intentionally not emulated. It must therefore be
-// feature-detectable as ABSENT: exposing it as a throwing stub is worse than not exposing it at all,
-// because a stub is still a callable function — `typeof root.getElementById === 'function'` is `true`
-// — so the guard passes and the caller invokes it, only for it to throw. Leaving it `undefined`
-// makes the guard fail, so the caller pivots to the supported, shadow-scoped `querySelector`.
+// On the synthetic ShadowRoot `getElementById` is intentionally not emulated. By default it is a
+// throwing stub — which is worse than useless for these callers, because a stub is still a callable
+// function (`typeof root.getElementById === 'function'` is `true`), so the guard passes, the caller
+// invokes it, and it throws. The ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag makes the method
+// `undefined` instead, so the guard fails and the caller pivots to the supported, shadow-scoped
+// `querySelector`. These tests exercise both states through the exact feature-detecting caller.
 function resolveById(root, id) {
     if (typeof root.getElementById === 'function') {
         return root.getElementById(id);
@@ -35,22 +36,44 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
         shadowRoot = elm.shadowRoot;
     });
 
-    it('exposes getElementById as absent (not a callable stub) so feature detection reveals it', () => {
-        // The crux of the fix: detection must report the method as unavailable.
-        expect(typeof shadowRoot.getElementById === 'function').toBe(false);
-        expect(shadowRoot.getElementById).toBe(undefined);
+    // Default (flag off): the throwing stub defeats feature detection — this is the reported bug.
+    describe('by default (ENABLE_SHADOW_ROOT_UNDEFINED_METHODS off)', () => {
+        it('exposes getElementById as a callable stub that defeats feature detection', () => {
+            expect(typeof shadowRoot.getElementById).toBe('function');
+        });
+
+        it('makes a feature-detecting caller throw (the reported failure mode)', () => {
+            // The guard passes (it IS a function), the caller invokes it, and it throws.
+            expect(() => resolveById(shadowRoot, 'injected-marker')).toThrowError(
+                `Disallowed method "getElementById" on ShadowRoot.`
+            );
+        });
     });
 
-    it('lets a feature-detecting caller resolve an element without throwing', () => {
-        // Before the fix, `getElementById` was a throwing stub: the guard above passed (it IS a
-        // function), the caller invoked it, and it threw `Disallowed method "getElementById" ...`.
-        // After the fix the guard fails and the caller falls back to querySelector — no throw.
-        expect(() => resolveById(shadowRoot, 'injected-marker')).not.toThrow();
-    });
+    // Opt-in (flag on): the method is absent, so the caller falls back to querySelector and works.
+    describe('with ENABLE_SHADOW_ROOT_UNDEFINED_METHODS enabled', () => {
+        beforeAll(() => {
+            setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', true);
+        });
 
-    it('resolves the element end-to-end via the querySelector fallback', () => {
-        const el = resolveById(shadowRoot, 'injected-marker');
-        expect(el).not.toBeNull();
-        expect(el.textContent).toBe('Injected Marker');
+        afterAll(() => {
+            setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', false);
+        });
+
+        it('exposes getElementById as absent so feature detection reveals it', () => {
+            expect(typeof shadowRoot.getElementById === 'function').toBe(false);
+            expect(shadowRoot.getElementById).toBe(undefined);
+        });
+
+        it('lets a feature-detecting caller resolve an element without throwing', () => {
+            // The guard now fails and the caller falls back to querySelector — no throw.
+            expect(() => resolveById(shadowRoot, 'injected-marker')).not.toThrow();
+        });
+
+        it('resolves the element end-to-end via the querySelector fallback', () => {
+            const el = resolveById(shadowRoot, 'injected-marker');
+            expect(el).not.toBeNull();
+            expect(el.textContent).toBe('Injected Marker');
+        });
     });
 });

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
@@ -42,6 +42,12 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
             expect(typeof shadowRoot.getElementById).toBe('function');
         });
 
+        it('reports getElementById as present via the `in` operator', () => {
+            // `in` is true here and stays true flag-on (the own property shadows the native
+            // DocumentFragment method), so it never distinguishes the two states.
+            expect('getElementById' in shadowRoot).toBe(true);
+        });
+
         it('makes a feature-detecting caller throw (the reported failure mode)', () => {
             // The guard passes (it IS a function), the caller invokes it, and it throws.
             expect(() => resolveById(shadowRoot, 'injected-marker')).toThrowError(
@@ -63,6 +69,36 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
         it('exposes getElementById as absent so feature detection reveals it', () => {
             expect(typeof shadowRoot.getElementById === 'function').toBe(false);
             expect(shadowRoot.getElementById).toBe(undefined);
+        });
+
+        it('still reports getElementById as present via the `in` operator (by design)', () => {
+            // The own property remains (as undefined) to shadow the native DocumentFragment
+            // method, so `in` cannot be used to detect absence — value-based checks must be used.
+            expect('getElementById' in shadowRoot).toBe(true);
+        });
+
+        it('throws a plain TypeError when an `in`-guarded caller invokes the undefined value', () => {
+            // A caller that guards with `in` rather than a value check still enters the branch and
+            // calls `undefined()`, which throws a native TypeError (not the descriptive stub error).
+            const callViaInGuard = () => {
+                if ('getElementById' in shadowRoot) {
+                    return shadowRoot.getElementById('injected-marker');
+                }
+                return null;
+            };
+            expect(callViaInGuard).toThrowError(TypeError);
+        });
+
+        it('silently no-ops for truthy-guard and optional-chaining callers', () => {
+            // `if (root.getElementById)` skips the branch, and `root.getElementById?.(id)`
+            // short-circuits — both yield undefined with no throw, rather than a resolved element.
+            expect(shadowRoot.getElementById?.('injected-marker')).toBe(undefined);
+
+            let result = 'unset';
+            if (shadowRoot.getElementById) {
+                result = shadowRoot.getElementById('injected-marker');
+            }
+            expect(result).toBe('unset');
         });
 
         it('lets a feature-detecting caller resolve an element without throwing', () => {

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/getElementById-feature-detection.spec.js
@@ -124,4 +124,64 @@ describe.skipIf(process.env.NATIVE_SHADOW)('ShadowRoot.getElementById feature de
             expect(el.textContent).toBe('Injected Marker');
         });
     });
+
+    // Some consumers monkey-patch the unsupported method with a working implementation. Before this
+    // flag, `getElementById` was a plain `writable: true` data property, so `root.getElementById = fn`
+    // just worked. Exposing it via an accessor (so the flag read stays dynamic) would break that — a
+    // getter-only accessor throws on assignment in strict mode and silently drops it in sloppy mode —
+    // so the descriptor pairs the getter with a setter that restores the writable-data-property
+    // behavior. These tests pin that reassignment contract in both flag states.
+    describe('preserves reassignment (writable) semantics', () => {
+        // This spec module is an ES module, so these assignments run in strict mode — the case that
+        // would throw against a getter-only accessor.
+        it('allows replacing getElementById on an instance (flag off)', () => {
+            const elm = createElement('x-lookup', { is: Lookup });
+            const replacement = () => 'replaced';
+            expect(() => {
+                elm.shadowRoot.getElementById = replacement;
+            }).not.toThrow();
+            expect(elm.shadowRoot.getElementById).toBe(replacement);
+            expect(elm.shadowRoot.getElementById()).toBe('replaced');
+        });
+
+        it('records the replacement as an own writable data property', () => {
+            const elm = createElement('x-lookup', { is: Lookup });
+            elm.shadowRoot.getElementById = () => 'replaced';
+            const desc = Object.getOwnPropertyDescriptor(elm.shadowRoot, 'getElementById');
+            expect(desc).toBeDefined();
+            expect(desc.writable).toBe(true);
+            expect(desc.enumerable).toBe(true);
+            expect(desc.configurable).toBe(true);
+            expect(typeof desc.value).toBe('function');
+        });
+
+        it('isolates the replacement to the reassigned instance', () => {
+            const a = createElement('x-lookup', { is: Lookup });
+            const b = createElement('x-lookup', { is: Lookup });
+            a.shadowRoot.getElementById = () => 'replaced';
+            // A sibling instance still sees the original throwing stub.
+            expect(() => b.shadowRoot.getElementById()).toThrowError(
+                `Disallowed method "getElementById" on ShadowRoot.`
+            );
+        });
+
+        it('still allows replacing getElementById with the flag on', () => {
+            // The setter is flag-independent: reassignment must keep working even when the getter
+            // would otherwise return undefined. Guards against re-coupling the setter to the flag.
+            setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', true);
+            try {
+                const elm = createElement('x-lookup', { is: Lookup });
+                const replacement = () => 'replaced';
+                expect(() => {
+                    elm.shadowRoot.getElementById = replacement;
+                }).not.toThrow();
+                expect(elm.shadowRoot.getElementById).toBe(replacement);
+                const desc = Object.getOwnPropertyDescriptor(elm.shadowRoot, 'getElementById');
+                expect(desc.writable).toBe(true);
+                expect(typeof desc.value).toBe('function');
+            } finally {
+                setFeatureFlagForTest('ENABLE_SHADOW_ROOT_UNDEFINED_METHODS', false);
+            }
+        });
+    });
 });

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/x/lookup/lookup.html
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/x/lookup/lookup.html
@@ -1,0 +1,3 @@
+<template>
+    <div lwc:dom="manual"></div>
+</template>

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/x/lookup/lookup.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/x/lookup/lookup.js
@@ -1,0 +1,19 @@
+import { LightningElement } from 'lwc';
+
+// A component that injects a plain element carrying an *unscoped* native id into its own shadow
+// tree — mirroring how a third-party script (e.g. an analytics/RUM agent) inserts its own marker
+// node and later looks it up by that id relative to the node's root (`node.getRootNode()`).
+// The id is set imperatively via `lwc:dom="manual"`, so LWC's synthetic-shadow id scoping (which
+// rewrites *template-static* ids to `id-<idx>`) does not apply — the id in the DOM is exactly the
+// one we search for.
+export default class Lookup extends LightningElement {
+    renderedCallback() {
+        const host = this.template.querySelector('div');
+        if (host && !host.querySelector('#injected-marker')) {
+            const marker = document.createElement('span');
+            marker.id = 'injected-marker';
+            marker.textContent = 'Injected Marker';
+            host.appendChild(marker);
+        }
+    }
+}

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/x/lookup/lookup.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/x/lookup/lookup.js
@@ -1,11 +1,9 @@
 import { LightningElement } from 'lwc';
 
-// A component that injects a plain element carrying an *unscoped* native id into its own shadow
-// tree — mirroring how a third-party script (e.g. an analytics/RUM agent) inserts its own marker
-// node and later looks it up by that id relative to the node's root (`node.getRootNode()`).
-// The id is set imperatively via `lwc:dom="manual"`, so LWC's synthetic-shadow id scoping (which
-// rewrites *template-static* ids to `id-<idx>`) does not apply — the id in the DOM is exactly the
-// one we search for.
+// Injects a marker node with an unscoped native id into its own shadow tree, mirroring how an
+// analytics/RUM agent inserts and later looks up its own node. The id is set imperatively (not in
+// the template), so synthetic-shadow id scoping doesn't rewrite it — the DOM id is exactly what we
+// search for.
 export default class Lookup extends LightningElement {
     renderedCallback() {
         const host = this.template.querySelector('div');

--- a/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/x/lookup/lookup.js
+++ b/packages/@lwc/integration-wtr/test/shadow-dom/ShadowRoot-properties/x/lookup/lookup.js
@@ -1,17 +1,15 @@
 import { LightningElement } from 'lwc';
 
-// Injects a marker node with an unscoped native id into its own shadow tree, mirroring how an
-// analytics/RUM agent inserts and later looks up its own node. The id is set imperatively (not in
-// the template), so synthetic-shadow id scoping doesn't rewrite it — the DOM id is exactly what we
-// search for.
+// Injects a marker with an unscoped native id into its own shadow tree, like an analytics/RUM agent
+// inserting and later looking up its own node. Injected imperatively (not in the template) so
+// synthetic-shadow id scoping leaves the id alone. renderedCallback, not connectedCallback: the
+// template isn't rendered yet at connect time, so `this.template.querySelector('div')` is null there.
 export default class Lookup extends LightningElement {
     renderedCallback() {
         const host = this.template.querySelector('div');
-        if (host && !host.querySelector('#injected-marker')) {
-            const marker = document.createElement('span');
-            marker.id = 'injected-marker';
-            marker.textContent = 'Injected Marker';
-            host.appendChild(marker);
-        }
+        const marker = document.createElement('span');
+        marker.id = 'injected-marker';
+        marker.textContent = 'Injected Marker';
+        host.appendChild(marker);
     }
 }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -617,13 +617,19 @@ const ParentNodePatchDescriptors = {
             return children.item(children.length - 1) || null;
         },
     },
+    // `getElementById` is intentionally not emulated on the synthetic ShadowRoot: a
+    // document-wide id lookup has no correct shadow-scoped semantics. Rather than expose a
+    // throwing stub (which is still a callable function, so callers that feature-detect
+    // `typeof root.getElementById === 'function'` invoke it and blow up), we leave it
+    // `undefined` so feature detection reveals its absence and callers fall back to the
+    // supported, shadow-scoped `querySelector('#' + id)`. An explicit own property is required
+    // to shadow the native `DocumentFragment.prototype.getElementById`, which would otherwise
+    // run against the (empty) underlying fragment and silently return null.
     getElementById: {
         writable: true,
         enumerable: true,
         configurable: true,
-        value(this: ShadowRoot): Selection | null {
-            throw new Error('Disallowed method "getElementById" on ShadowRoot.');
-        },
+        value: undefined,
     },
     querySelector: {
         writable: true,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -200,28 +200,8 @@ function containsPatched(this: ShadowRoot, otherNode: Node): boolean {
 }
 
 /**
- * Several `ShadowRoot` methods have no correct shadow-scoped semantics and are therefore not
- * emulated. `getSelection` and `cloneNode` are exposed as stubs that throw when invoked. There is
- * no meaningful native behavior to fall back to for either: native `ShadowRoot.cloneNode()` throws
- * `NotSupportedError` (cloning a shadow root is forbidden by the DOM clone algorithm), and
- * `getSelection` is non-standard on `ShadowRoot` (present in Blink/WebKit, absent in Firefox, since
- * the Selection API defines it only on `Document`/`Window`). This is the long-standing behavior,
- * exposed as a `writable: true` data property exactly as it always has been.
- */
-function createDisallowedMethodDescriptor(methodName: string): PropertyDescriptor {
-    return {
-        writable: true,
-        enumerable: true,
-        configurable: true,
-        value(this: ShadowRoot): never {
-            throw new Error(`Disallowed method "${methodName}" on ShadowRoot.`);
-        },
-    };
-}
-
-/**
- * `getElementById` is a special case among the unsupported `ShadowRoot` methods. Like the others it
- * has historically been a stub that throws when invoked — but unlike them, native `ShadowRoot`
+ * `getElementById` has historically been a stub that throws when invoked, like the other unsupported
+ * `ShadowRoot` methods (`getSelection`, `cloneNode`). Unlike them, though, native `ShadowRoot`
  * inherits a *working* `getElementById` from `DocumentFragment`. So third-party code that
  * feature-detects the method with a *value-based* check (`typeof root.getElementById === 'function'`,
  * `if (root.getElementById)`, or `root.getElementById?.(id)`) succeeds in native shadow but, because
@@ -232,7 +212,8 @@ function createDisallowedMethodDescriptor(methodName: string): PropertyDescripto
  * The `ENABLE_SHADOW_ROOT_UNDEFINED_METHODS` runtime flag lets an app opt into friendlier behavior:
  * when enabled, `getElementById` is exposed as `undefined` instead of a throwing stub, so value-based
  * feature detection reveals its absence and callers fall back to the supported, shadow-scoped
- * `querySelector('#' + id)`.
+ * `querySelector('#' + id)`. The flag is scoped to `getElementById` alone; the other unsupported
+ * methods (`getSelection`, `cloneNode`) are left untouched as plain throwing stubs.
  *
  * `'getElementById' in root` stays `true` even with the flag on — by design, not a gap. The own
  * accessor below is exactly what shadows the native `DocumentFragment.prototype.getElementById`;
@@ -365,8 +346,14 @@ const ShadowRootDescriptors = {
             return fauxElementsFromPoint(this, doc, left, top);
         },
     },
-    // See createDisallowedMethodDescriptor: a throwing stub with no shadow-scoped semantics.
-    getSelection: createDisallowedMethodDescriptor('getSelection'),
+    getSelection: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(this: ShadowRoot): Selection | null {
+            throw new Error('Disallowed method "getSelection" on ShadowRoot.');
+        },
+    },
     host: {
         enumerable: true,
         configurable: true,
@@ -479,8 +466,14 @@ const NodePatchDescriptors = {
             return createStaticNodeList(shadowRootChildNodes(this));
         },
     },
-    // See createDisallowedMethodDescriptor: a throwing stub with no shadow-scoped semantics.
-    cloneNode: createDisallowedMethodDescriptor('cloneNode'),
+    cloneNode: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(this: ShadowRoot): Selection | null {
+            throw new Error('Disallowed method "cloneNode" on ShadowRoot.');
+        },
+    },
     compareDocumentPosition: {
         writable: true,
         enumerable: true,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -200,43 +200,22 @@ function containsPatched(this: ShadowRoot, otherNode: Node): boolean {
 }
 
 /**
- * `getElementById` has historically been a stub that throws when invoked, like the other unsupported
- * `ShadowRoot` methods (`getSelection`, `cloneNode`). Unlike them, though, native `ShadowRoot`
- * inherits a *working* `getElementById` from `DocumentFragment`. So third-party code that
- * feature-detects the method with a *value-based* check (`typeof root.getElementById === 'function'`,
- * `if (root.getElementById)`, or `root.getElementById?.(id)`) succeeds in native shadow but, because
- * a throwing stub is still a *callable function*, commits to calling it in synthetic shadow and then
- * hits the throw — a genuine native-vs-synthetic divergence (reported by RUM/analytics libraries
- * that resolve an id off `node.getRootNode()`).
+ * `getElementById` is not emulated on the synthetic `ShadowRoot`. Unlike the other unsupported
+ * methods, native `ShadowRoot` inherits a *working* one from `DocumentFragment`, so third-party code
+ * that value-detects it (`typeof`, `if`, `?.`) works in native shadow but hits the throwing stub in
+ * synthetic — a real divergence (RUM/analytics libraries resolving an id off `getRootNode()`).
  *
- * The `ENABLE_SHADOW_ROOT_UNDEFINED_METHODS` runtime flag lets an app opt into friendlier behavior:
- * when enabled, `getElementById` is exposed as `undefined` instead of a throwing stub, so value-based
- * feature detection reveals its absence and callers fall back to the supported, shadow-scoped
- * `querySelector('#' + id)`. The flag is scoped to `getElementById` alone; the other unsupported
- * methods (`getSelection`, `cloneNode`) are left untouched as plain throwing stubs.
+ * The `ENABLE_SHADOW_ROOT_UNDEFINED_METHODS` flag exposes it as `undefined` instead, so value-based
+ * detection reveals its absence and callers fall back to `querySelector('#' + id)`. Default OFF to
+ * preserve the long-standing throwing-stub behavior. The flag is read through a getter because
+ * runtime flags are set during app init, after this module is imported.
  *
- * `'getElementById' in root` stays `true` even with the flag on — by design, not a gap. The own
- * accessor below is exactly what shadows the native `DocumentFragment.prototype.getElementById`;
- * deleting the property to make `in` report `false` would expose that native method, which runs
- * against the underlying (empty) fragment and silently returns `null` — a worse, silent-wrong
- * failure. The trade-off is that an `in`-guarded caller (`if ('x' in root) root.x()`) still enters
- * the branch and, flag-on, throws `TypeError: … is not a function` instead of the descriptive
- * `Disallowed method` error. Well-behaved detection uses value-based checks, which the flag fixes.
- *
- * This is a visible, behavioral change to an API that has shipped unchanged for years, so it is
- * DEFAULT OFF: with the flag unset/false the throwing stub is returned, preserving the legacy
- * behavior — including write semantics (the setter below keeps `root.getElementById = fn` working
- * exactly as the old `writable` data property did, in both strict and sloppy mode). The one residual
- * observable difference, regardless of flag state, is descriptor *kind*:
- * `getOwnPropertyDescriptor(prototype, 'getElementById')` reports an accessor (`get`/`set`) rather
- * than a data property (`value`/`writable`). That is intrinsic to reading the flag dynamically — a
- * data property would have to capture its `value` when the prototype is built, before the flag is
- * set — and it affects only tooling that introspects this prototype descriptor to distinguish
- * data-vs-accessor, never normal invocation, reassignment, or feature detection.
- *
- * The flag is read dynamically through a getter (rather than captured when the prototype is built),
- * because runtime feature flags are set during app initialization — after this polyfill module is
- * imported.
+ * Notes:
+ * - The setter keeps `root.getElementById = fn` working as the old `writable` data property did
+ *   (a getter-only accessor would throw on assignment in strict mode).
+ * - `'getElementById' in root` stays `true` in both states: the own accessor is what shadows the
+ *   native `DocumentFragment.prototype.getElementById`. An `in`-guarded caller therefore still
+ *   enters the branch and, flag-on, throws a plain `TypeError` on the `undefined` value.
  */
 function createGetElementByIdDescriptor(): PropertyDescriptor {
     function disallowedGetElementById(this: ShadowRoot): never {
@@ -679,9 +658,7 @@ const ParentNodePatchDescriptors = {
             return children.item(children.length - 1) || null;
         },
     },
-    // See createGetElementByIdDescriptor: throws by default, `undefined` when the
-    // ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag is enabled. This is the flag's sole
-    // motivating case: RUM/analytics libraries feature-detect `getElementById` on the shadow root.
+    // Throws by default; `undefined` when ENABLE_SHADOW_ROOT_UNDEFINED_METHODS is on. See below.
     getElementById: createGetElementByIdDescriptor(),
     querySelector: {
         writable: true,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -199,45 +199,8 @@ function containsPatched(this: ShadowRoot, otherNode: Node): boolean {
     );
 }
 
-/**
- * `getElementById` is not emulated on the synthetic `ShadowRoot`. Unlike the other unsupported
- * methods, native `ShadowRoot` inherits a *working* one from `DocumentFragment`, so third-party code
- * that value-detects it (`typeof`, `if`, `?.`) works in native shadow but hits the throwing stub in
- * synthetic — a real divergence (RUM/analytics libraries resolving an id off `getRootNode()`).
- *
- * The `ENABLE_SHADOW_ROOT_UNDEFINED_METHODS` flag exposes it as `undefined` instead, so value-based
- * detection reveals its absence and callers fall back to `querySelector('#' + id)`. Default OFF to
- * preserve the long-standing throwing-stub behavior. The flag is read through a getter because
- * runtime flags are set during app init, after this module is imported.
- *
- * Notes:
- * - The setter keeps `root.getElementById = fn` working as the old `writable` data property did
- *   (a getter-only accessor would throw on assignment in strict mode).
- * - `'getElementById' in root` stays `true` in both states: the own accessor is what shadows the
- *   native `DocumentFragment.prototype.getElementById`. An `in`-guarded caller therefore still
- *   enters the branch and, flag-on, throws a plain `TypeError` on the `undefined` value.
- */
-function createGetElementByIdDescriptor(): PropertyDescriptor {
-    function disallowedGetElementById(this: ShadowRoot): never {
-        throw new Error(`Disallowed method "getElementById" on ShadowRoot.`);
-    }
-    return {
-        enumerable: true,
-        configurable: true,
-        get(this: ShadowRoot): (() => never) | undefined {
-            return lwcRuntimeFlags.ENABLE_SHADOW_ROOT_UNDEFINED_METHODS
-                ? undefined
-                : disallowedGetElementById;
-        },
-        set(this: ShadowRoot, value: unknown): void {
-            defineProperty(this, 'getElementById', {
-                writable: true,
-                enumerable: true,
-                configurable: true,
-                value,
-            });
-        },
-    };
+function disallowedGetElementById(this: ShadowRoot): never {
+    throw new Error(`Disallowed method "getElementById" on ShadowRoot.`);
 }
 
 const SyntheticShadowRootDescriptors = {
@@ -658,8 +621,26 @@ const ParentNodePatchDescriptors = {
             return children.item(children.length - 1) || null;
         },
     },
-    // Throws by default; `undefined` when ENABLE_SHADOW_ROOT_UNDEFINED_METHODS is on. See below.
-    getElementById: createGetElementByIdDescriptor(),
+    // An accessor, unlike the other stubs, so the flag is read at call time (not at import) and the
+    // setter preserves `root.getElementById = fn`. The flag exposes it as `undefined` so callers
+    // that value-detect it fall back to `querySelector`; default OFF keeps the throwing stub.
+    getElementById: {
+        enumerable: true,
+        configurable: true,
+        get(this: ShadowRoot): (() => never) | undefined {
+            return lwcRuntimeFlags.ENABLE_SHADOW_ROOT_UNDEFINED_GET_ELEMENT_BY_ID
+                ? undefined
+                : disallowedGetElementById;
+        },
+        set(this: ShadowRoot, value: unknown): void {
+            defineProperty(this, 'getElementById', {
+                writable: true,
+                enumerable: true,
+                configurable: true,
+                value,
+            });
+        },
+    },
     querySelector: {
         writable: true,
         enumerable: true,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -232,11 +232,14 @@ function containsPatched(this: ShadowRoot, otherNode: Node): boolean {
  *
  * This is a visible, behavioral change to an API that has shipped unchanged for years to every
  * synthetic-shadow consumer, so it is DEFAULT OFF: with the flag unset/false the throwing stub is
- * returned, preserving the legacy *call* behavior. (One subtle observable difference regardless of
- * flag state: the descriptor is now a getter-only accessor rather than a `writable` data property,
- * so `getOwnPropertyDescriptor` reports an accessor and *reassigning* the method throws in strict
- * mode where it previously succeeded — an edge case that affects only code trying to replace the
- * method, never normal invocation.)
+ * returned, preserving the legacy behavior — including write semantics (see the accessor's setter
+ * below, which keeps `root.getElementById = fn` working exactly as the old `writable` data property
+ * did). The one residual observable difference, regardless of flag state, is descriptor *kind*:
+ * `getOwnPropertyDescriptor(prototype, methodName)` now reports an accessor (`get`/`set`) rather
+ * than a data property (`value`/`writable`). That is intrinsic to reading the flag dynamically — a
+ * data property would have to capture its `value` when the prototype is built, before the flag is
+ * set — and it affects only tooling that introspects these three prototype descriptors to
+ * distinguish data-vs-accessor, never normal invocation, reassignment, or feature detection.
  *
  * The flag is read dynamically through a getter (rather than captured when the prototype is built),
  * because runtime feature flags are set during app initialization — after this polyfill module is
@@ -253,6 +256,21 @@ function createDisallowedMethodDescriptor(methodName: string): PropertyDescripto
             return lwcRuntimeFlags.ENABLE_SHADOW_ROOT_UNDEFINED_METHODS
                 ? undefined
                 : disallowedMethod;
+        },
+        // The pre-flag descriptor was a `writable: true` data property, so assigning the method
+        // (`root.getElementById = fn`) created an own data property on the receiver. A getter-only
+        // accessor would instead throw in strict mode (and silently drop the write in sloppy mode),
+        // which is an observable change even with the flag off. This setter preserves the original
+        // write semantics: it installs an own, writable data property on the receiver — matching
+        // the byte-for-byte descriptor the inherited `writable` data property used to produce —
+        // while the getter above keeps the flag read dynamic until such a reassignment occurs.
+        set(this: ShadowRoot, value: unknown): void {
+            defineProperty(this, methodName, {
+                writable: true,
+                enumerable: true,
+                configurable: true,
+                value,
+            });
         },
     };
 }

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -199,6 +199,46 @@ function containsPatched(this: ShadowRoot, otherNode: Node): boolean {
     );
 }
 
+/**
+ * Some `ShadowRoot` methods have no correct shadow-scoped semantics, so synthetic shadow has
+ * historically exposed them as stubs that throw when invoked: `getElementById`, `getSelection`,
+ * and `cloneNode`. The problem is that a throwing stub is still a *callable function*, so
+ * third-party code that feature-detects the method (`typeof root.getElementById === 'function'`,
+ * or `'getElementById' in root`) sees it as present, commits to calling it, and only then hits the
+ * throw. Native shadow inherits a working method from `DocumentFragment`, so the exact same code
+ * succeeds in native but throws in synthetic.
+ *
+ * The `ENABLE_SHADOW_ROOT_UNDEFINED_METHODS` runtime flag lets an app opt into friendlier behavior:
+ * when enabled, these methods are exposed as `undefined` instead of a throwing stub, so feature
+ * detection reveals their absence and callers can fall back to the supported, shadow-scoped
+ * `querySelector('#' + id)`.
+ *
+ * This is a visible, behavioral change to an API that has shipped unchanged for years to every
+ * synthetic-shadow consumer, so it is DEFAULT OFF: with the flag unset/false the throwing stub is
+ * returned, exactly preserving the legacy behavior. Only when an org explicitly enables the flag do
+ * the methods become `undefined`.
+ *
+ * The flag is read dynamically through a getter (rather than captured when the prototype is built),
+ * because runtime feature flags are set during app initialization — after this polyfill module is
+ * imported. An explicit own accessor is still required to shadow the corresponding native
+ * `DocumentFragment.prototype` method, which would otherwise run against the underlying (empty)
+ * fragment and silently return `null`.
+ */
+function createDisallowedMethodDescriptor(methodName: string): PropertyDescriptor {
+    function disallowedMethod(this: ShadowRoot): never {
+        throw new Error(`Disallowed method "${methodName}" on ShadowRoot.`);
+    }
+    return {
+        enumerable: true,
+        configurable: true,
+        get(this: ShadowRoot): (() => never) | undefined {
+            return lwcRuntimeFlags.ENABLE_SHADOW_ROOT_UNDEFINED_METHODS
+                ? undefined
+                : disallowedMethod;
+        },
+    };
+}
+
 const SyntheticShadowRootDescriptors = {
     constructor: {
         writable: true,
@@ -284,14 +324,9 @@ const ShadowRootDescriptors = {
             return fauxElementsFromPoint(this, doc, left, top);
         },
     },
-    getSelection: {
-        writable: true,
-        enumerable: true,
-        configurable: true,
-        value(this: ShadowRoot): Selection | null {
-            throw new Error('Disallowed method "getSelection" on ShadowRoot.');
-        },
-    },
+    // See createDisallowedMethodDescriptor: throws by default, `undefined` when the
+    // ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag is enabled.
+    getSelection: createDisallowedMethodDescriptor('getSelection'),
     host: {
         enumerable: true,
         configurable: true,
@@ -404,14 +439,9 @@ const NodePatchDescriptors = {
             return createStaticNodeList(shadowRootChildNodes(this));
         },
     },
-    cloneNode: {
-        writable: true,
-        enumerable: true,
-        configurable: true,
-        value(this: ShadowRoot): Selection | null {
-            throw new Error('Disallowed method "cloneNode" on ShadowRoot.');
-        },
-    },
+    // See createDisallowedMethodDescriptor: throws by default, `undefined` when the
+    // ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag is enabled.
+    cloneNode: createDisallowedMethodDescriptor('cloneNode'),
     compareDocumentPosition: {
         writable: true,
         enumerable: true,
@@ -617,20 +647,10 @@ const ParentNodePatchDescriptors = {
             return children.item(children.length - 1) || null;
         },
     },
-    // `getElementById` is intentionally not emulated on the synthetic ShadowRoot: a
-    // document-wide id lookup has no correct shadow-scoped semantics. Rather than expose a
-    // throwing stub (which is still a callable function, so callers that feature-detect
-    // `typeof root.getElementById === 'function'` invoke it and blow up), we leave it
-    // `undefined` so feature detection reveals its absence and callers fall back to the
-    // supported, shadow-scoped `querySelector('#' + id)`. An explicit own property is required
-    // to shadow the native `DocumentFragment.prototype.getElementById`, which would otherwise
-    // run against the (empty) underlying fragment and silently return null.
-    getElementById: {
-        writable: true,
-        enumerable: true,
-        configurable: true,
-        value: undefined,
-    },
+    // See createDisallowedMethodDescriptor: throws by default, `undefined` when the
+    // ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag is enabled. This is the flag's original
+    // motivating case: RUM/analytics libraries feature-detect `getElementById` on the shadow root.
+    getElementById: createDisallowedMethodDescriptor('getElementById'),
     querySelector: {
         writable: true,
         enumerable: true,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -200,54 +200,66 @@ function containsPatched(this: ShadowRoot, otherNode: Node): boolean {
 }
 
 /**
- * Some `ShadowRoot` methods have no correct shadow-scoped semantics, so synthetic shadow has
- * historically exposed them as stubs that throw when invoked: `getElementById`, `getSelection`,
- * and `cloneNode`. The problem is that a throwing stub is still a *callable function*, so
- * third-party code that feature-detects the method with a *value-based* check
- * (`typeof root.getElementById === 'function'`, `if (root.getElementById)`, or
- * `root.getElementById?.(id)`) sees it as present, commits to calling it, and only then hits the
- * throw.
- *
- * The motivating case is `getElementById`: native `ShadowRoot` inherits a *working* one from
- * `DocumentFragment`, so the exact same feature-detecting code succeeds in native but throws in
- * synthetic — a genuine native-vs-synthetic divergence. `getSelection` and `cloneNode` are swept in
- * so the three unsupported methods present a uniform surface, NOT because `undefined` matches
- * native for them: native `cloneNode` is present but *throws* `NotSupportedError` (cloning a shadow
- * root is forbidden by the DOM clone algorithm), and `getSelection` is non-standard (present in
- * Blink/WebKit, absent in Firefox, since the Selection API defines it only on `Document`/`Window`).
- * For those two, flag-on `undefined` is a deliberate, uniform choice rather than native parity.
+ * Several `ShadowRoot` methods have no correct shadow-scoped semantics and are therefore not
+ * emulated. `getSelection` and `cloneNode` are exposed as stubs that throw when invoked. There is
+ * no meaningful native behavior to fall back to for either: native `ShadowRoot.cloneNode()` throws
+ * `NotSupportedError` (cloning a shadow root is forbidden by the DOM clone algorithm), and
+ * `getSelection` is non-standard on `ShadowRoot` (present in Blink/WebKit, absent in Firefox, since
+ * the Selection API defines it only on `Document`/`Window`). This is the long-standing behavior,
+ * exposed as a `writable: true` data property exactly as it always has been.
+ */
+function createDisallowedMethodDescriptor(methodName: string): PropertyDescriptor {
+    return {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(this: ShadowRoot): never {
+            throw new Error(`Disallowed method "${methodName}" on ShadowRoot.`);
+        },
+    };
+}
+
+/**
+ * `getElementById` is a special case among the unsupported `ShadowRoot` methods. Like the others it
+ * has historically been a stub that throws when invoked — but unlike them, native `ShadowRoot`
+ * inherits a *working* `getElementById` from `DocumentFragment`. So third-party code that
+ * feature-detects the method with a *value-based* check (`typeof root.getElementById === 'function'`,
+ * `if (root.getElementById)`, or `root.getElementById?.(id)`) succeeds in native shadow but, because
+ * a throwing stub is still a *callable function*, commits to calling it in synthetic shadow and then
+ * hits the throw — a genuine native-vs-synthetic divergence (reported by RUM/analytics libraries
+ * that resolve an id off `node.getRootNode()`).
  *
  * The `ENABLE_SHADOW_ROOT_UNDEFINED_METHODS` runtime flag lets an app opt into friendlier behavior:
- * when enabled, these methods are exposed as `undefined` instead of a throwing stub, so value-based
- * feature detection reveals their absence and callers can fall back to the supported, shadow-scoped
- * `querySelector('#' + id)` (only `getElementById` has such a fallback).
+ * when enabled, `getElementById` is exposed as `undefined` instead of a throwing stub, so value-based
+ * feature detection reveals its absence and callers fall back to the supported, shadow-scoped
+ * `querySelector('#' + id)`.
  *
- * `'methodName' in root` stays `true` even with the flag on — by design, not a gap. The own
- * accessor below is exactly what shadows the corresponding native `DocumentFragment.prototype`
- * method; deleting the property to make `in` report `false` would expose that native method, which
- * runs against the underlying (empty) fragment and silently returns `null` — a worse, silent-wrong
+ * `'getElementById' in root` stays `true` even with the flag on — by design, not a gap. The own
+ * accessor below is exactly what shadows the native `DocumentFragment.prototype.getElementById`;
+ * deleting the property to make `in` report `false` would expose that native method, which runs
+ * against the underlying (empty) fragment and silently returns `null` — a worse, silent-wrong
  * failure. The trade-off is that an `in`-guarded caller (`if ('x' in root) root.x()`) still enters
  * the branch and, flag-on, throws `TypeError: … is not a function` instead of the descriptive
  * `Disallowed method` error. Well-behaved detection uses value-based checks, which the flag fixes.
  *
- * This is a visible, behavioral change to an API that has shipped unchanged for years to every
- * synthetic-shadow consumer, so it is DEFAULT OFF: with the flag unset/false the throwing stub is
- * returned, preserving the legacy behavior — including write semantics (see the accessor's setter
- * below, which keeps `root.getElementById = fn` working exactly as the old `writable` data property
- * did). The one residual observable difference, regardless of flag state, is descriptor *kind*:
- * `getOwnPropertyDescriptor(prototype, methodName)` now reports an accessor (`get`/`set`) rather
+ * This is a visible, behavioral change to an API that has shipped unchanged for years, so it is
+ * DEFAULT OFF: with the flag unset/false the throwing stub is returned, preserving the legacy
+ * behavior — including write semantics (the setter below keeps `root.getElementById = fn` working
+ * exactly as the old `writable` data property did, in both strict and sloppy mode). The one residual
+ * observable difference, regardless of flag state, is descriptor *kind*:
+ * `getOwnPropertyDescriptor(prototype, 'getElementById')` reports an accessor (`get`/`set`) rather
  * than a data property (`value`/`writable`). That is intrinsic to reading the flag dynamically — a
  * data property would have to capture its `value` when the prototype is built, before the flag is
- * set — and it affects only tooling that introspects these three prototype descriptors to
- * distinguish data-vs-accessor, never normal invocation, reassignment, or feature detection.
+ * set — and it affects only tooling that introspects this prototype descriptor to distinguish
+ * data-vs-accessor, never normal invocation, reassignment, or feature detection.
  *
  * The flag is read dynamically through a getter (rather than captured when the prototype is built),
  * because runtime feature flags are set during app initialization — after this polyfill module is
  * imported.
  */
-function createDisallowedMethodDescriptor(methodName: string): PropertyDescriptor {
-    function disallowedMethod(this: ShadowRoot): never {
-        throw new Error(`Disallowed method "${methodName}" on ShadowRoot.`);
+function createGetElementByIdDescriptor(): PropertyDescriptor {
+    function disallowedGetElementById(this: ShadowRoot): never {
+        throw new Error(`Disallowed method "getElementById" on ShadowRoot.`);
     }
     return {
         enumerable: true,
@@ -255,17 +267,10 @@ function createDisallowedMethodDescriptor(methodName: string): PropertyDescripto
         get(this: ShadowRoot): (() => never) | undefined {
             return lwcRuntimeFlags.ENABLE_SHADOW_ROOT_UNDEFINED_METHODS
                 ? undefined
-                : disallowedMethod;
+                : disallowedGetElementById;
         },
-        // The pre-flag descriptor was a `writable: true` data property, so assigning the method
-        // (`root.getElementById = fn`) created an own data property on the receiver. A getter-only
-        // accessor would instead throw in strict mode (and silently drop the write in sloppy mode),
-        // which is an observable change even with the flag off. This setter preserves the original
-        // write semantics: it installs an own, writable data property on the receiver — matching
-        // the byte-for-byte descriptor the inherited `writable` data property used to produce —
-        // while the getter above keeps the flag read dynamic until such a reassignment occurs.
         set(this: ShadowRoot, value: unknown): void {
-            defineProperty(this, methodName, {
+            defineProperty(this, 'getElementById', {
                 writable: true,
                 enumerable: true,
                 configurable: true,
@@ -360,8 +365,7 @@ const ShadowRootDescriptors = {
             return fauxElementsFromPoint(this, doc, left, top);
         },
     },
-    // See createDisallowedMethodDescriptor: throws by default, `undefined` when the
-    // ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag is enabled.
+    // See createDisallowedMethodDescriptor: a throwing stub with no shadow-scoped semantics.
     getSelection: createDisallowedMethodDescriptor('getSelection'),
     host: {
         enumerable: true,
@@ -475,8 +479,7 @@ const NodePatchDescriptors = {
             return createStaticNodeList(shadowRootChildNodes(this));
         },
     },
-    // See createDisallowedMethodDescriptor: throws by default, `undefined` when the
-    // ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag is enabled.
+    // See createDisallowedMethodDescriptor: a throwing stub with no shadow-scoped semantics.
     cloneNode: createDisallowedMethodDescriptor('cloneNode'),
     compareDocumentPosition: {
         writable: true,
@@ -683,10 +686,10 @@ const ParentNodePatchDescriptors = {
             return children.item(children.length - 1) || null;
         },
     },
-    // See createDisallowedMethodDescriptor: throws by default, `undefined` when the
-    // ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag is enabled. This is the flag's original
+    // See createGetElementByIdDescriptor: throws by default, `undefined` when the
+    // ENABLE_SHADOW_ROOT_UNDEFINED_METHODS runtime flag is enabled. This is the flag's sole
     // motivating case: RUM/analytics libraries feature-detect `getElementById` on the shadow root.
-    getElementById: createDisallowedMethodDescriptor('getElementById'),
+    getElementById: createGetElementByIdDescriptor(),
     querySelector: {
         writable: true,
         enumerable: true,

--- a/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/faux-shadow/shadow-root.ts
@@ -203,26 +203,44 @@ function containsPatched(this: ShadowRoot, otherNode: Node): boolean {
  * Some `ShadowRoot` methods have no correct shadow-scoped semantics, so synthetic shadow has
  * historically exposed them as stubs that throw when invoked: `getElementById`, `getSelection`,
  * and `cloneNode`. The problem is that a throwing stub is still a *callable function*, so
- * third-party code that feature-detects the method (`typeof root.getElementById === 'function'`,
- * or `'getElementById' in root`) sees it as present, commits to calling it, and only then hits the
- * throw. Native shadow inherits a working method from `DocumentFragment`, so the exact same code
- * succeeds in native but throws in synthetic.
+ * third-party code that feature-detects the method with a *value-based* check
+ * (`typeof root.getElementById === 'function'`, `if (root.getElementById)`, or
+ * `root.getElementById?.(id)`) sees it as present, commits to calling it, and only then hits the
+ * throw.
+ *
+ * The motivating case is `getElementById`: native `ShadowRoot` inherits a *working* one from
+ * `DocumentFragment`, so the exact same feature-detecting code succeeds in native but throws in
+ * synthetic — a genuine native-vs-synthetic divergence. `getSelection` and `cloneNode` are swept in
+ * so the three unsupported methods present a uniform surface, NOT because `undefined` matches
+ * native for them: native `cloneNode` is present but *throws* `NotSupportedError` (cloning a shadow
+ * root is forbidden by the DOM clone algorithm), and `getSelection` is non-standard (present in
+ * Blink/WebKit, absent in Firefox, since the Selection API defines it only on `Document`/`Window`).
+ * For those two, flag-on `undefined` is a deliberate, uniform choice rather than native parity.
  *
  * The `ENABLE_SHADOW_ROOT_UNDEFINED_METHODS` runtime flag lets an app opt into friendlier behavior:
- * when enabled, these methods are exposed as `undefined` instead of a throwing stub, so feature
- * detection reveals their absence and callers can fall back to the supported, shadow-scoped
- * `querySelector('#' + id)`.
+ * when enabled, these methods are exposed as `undefined` instead of a throwing stub, so value-based
+ * feature detection reveals their absence and callers can fall back to the supported, shadow-scoped
+ * `querySelector('#' + id)` (only `getElementById` has such a fallback).
+ *
+ * `'methodName' in root` stays `true` even with the flag on — by design, not a gap. The own
+ * accessor below is exactly what shadows the corresponding native `DocumentFragment.prototype`
+ * method; deleting the property to make `in` report `false` would expose that native method, which
+ * runs against the underlying (empty) fragment and silently returns `null` — a worse, silent-wrong
+ * failure. The trade-off is that an `in`-guarded caller (`if ('x' in root) root.x()`) still enters
+ * the branch and, flag-on, throws `TypeError: … is not a function` instead of the descriptive
+ * `Disallowed method` error. Well-behaved detection uses value-based checks, which the flag fixes.
  *
  * This is a visible, behavioral change to an API that has shipped unchanged for years to every
  * synthetic-shadow consumer, so it is DEFAULT OFF: with the flag unset/false the throwing stub is
- * returned, exactly preserving the legacy behavior. Only when an org explicitly enables the flag do
- * the methods become `undefined`.
+ * returned, preserving the legacy *call* behavior. (One subtle observable difference regardless of
+ * flag state: the descriptor is now a getter-only accessor rather than a `writable` data property,
+ * so `getOwnPropertyDescriptor` reports an accessor and *reassigning* the method throws in strict
+ * mode where it previously succeeded — an edge case that affects only code trying to replace the
+ * method, never normal invocation.)
  *
  * The flag is read dynamically through a getter (rather than captured when the prototype is built),
  * because runtime feature flags are set during app initialization — after this polyfill module is
- * imported. An explicit own accessor is still required to shadow the corresponding native
- * `DocumentFragment.prototype` method, which would otherwise run against the underlying (empty)
- * fragment and silently return `null`.
+ * imported.
  */
 function createDisallowedMethodDescriptor(methodName: string): PropertyDescriptor {
     function disallowedMethod(this: ShadowRoot): never {


### PR DESCRIPTION
## Details

Synthetic shadow exposes several `ShadowRoot` methods that have **no correct shadow-scoped semantics** and are therefore not emulated — `getElementById`, `getSelection`, and `cloneNode`. Each is a **throwing stub**: a function that throws the moment it is invoked.

The problem: a throwing stub is still a *callable function*, so **value-based** feature detection passes and callers commit to calling it before hitting the throw.

```js
typeof root.getElementById === 'function'  // true  — looks supported...
if (root.getElementById) { /* ... */ }      // truthy
root.getElementById?.('x')                   // not short-circuited
root.getElementById('x')                     // ...then throws
```

The motivating case is **`getElementById`**: a native `ShadowRoot` inherits a working one from `DocumentFragment`, so third-party code that feature-detects it (RUM / analytics agents that resolve an id off `node.getRootNode()`, etc.) works in native shadow but throws in synthetic. This is the reported failure in **W-23449229**.

### The fix: a default-off runtime flag, scoped to `getElementById`

This behavior has shipped unchanged for years to every synthetic-shadow consumer, so rather than change it unconditionally we gate it behind a new runtime feature flag, **`ENABLE_SHADOW_ROOT_UNDEFINED_GET_ELEMENT_BY_ID`**:

| Flag state | Behavior of `getElementById` |
|---|---|
| **off / unset (default)** | Throwing stub — the legacy call behavior, preserved. |
| **on (opt-in)** | `undefined` — value-based feature detection reveals the method's absence, so well-behaved callers fall back to the supported, shadow-scoped `querySelector('#' + id)`. |

**The change is scoped to `getElementById` alone.** It is the only unsupported `ShadowRoot` method with a genuine native-vs-synthetic feature-detection divergence *and* a working `querySelector` fallback:

- **`getElementById`** — native is present and *works*. Flag-on `undefined` + the `querySelector('#' + id)` fallback is the closest synthetic can get to native, and is what well-behaved feature detection expects.
- **`cloneNode`** — native is present but *throws* `NotSupportedError` (the DOM clone algorithm forbids cloning a shadow root). `undefined` would be a *new* divergence with no `querySelector` fallback.
- **`getSelection`** — non-standard on `ShadowRoot`: present in Blink/WebKit, absent in Firefox (the Selection API defines it on `Document`/`Window`). There is no single "native" behavior to match.

`getSelection` and `cloneNode` therefore stay exactly as they are on `master` — **this PR does not touch them or any other `ShadowRoot` method.** (An earlier revision swept all three behind the flag for a uniform surface; per review it is now narrowed to the one method the flag actually helps.)

### Implementation notes

- **Only `getElementById`'s descriptor changes.** `getSelection` / `cloneNode` are byte-for-byte identical to `master` — plain `writable: true` throwing-stub data properties.
- `getElementById`'s descriptor reads the flag **dynamically through a getter**, not captured when the prototype is built — runtime flags are set during app initialization, *after* this polyfill module is imported. The getter is paired with a **setter** so the descriptor preserves the original `writable: true` data-property *write* semantics (see breaking-change note below).
- An explicit **own accessor** is retained for `getElementById` in both flag states. `SyntheticShadowRoot.prototype` derives from `DocumentFragment.prototype`, which has a native `getElementById`; without shadowing it, the native method would run against the underlying (empty) fragment and silently return `null` — a worse, silent-wrong-answer failure. A consequence is that **`'getElementById' in root` stays `true` in both flag states** by design; a caller that guards with `in` rather than a value check still enters the branch and, flag-on, throws a plain `TypeError` on the `undefined` value.

### Tests

Integration tests (`integration-wtr`), all scoped to `getElementById`, cover **both flag states** and skip under native shadow:

- **flag off:** `getElementById` is a callable function (`typeof === 'function'`), `'getElementById' in root === true`, and a feature-detecting caller throws the descriptive `Disallowed method` error (the reported bug). Reassigning it (`root.getElementById = fn`) succeeds in strict mode, records an own `writable` data property, and is isolated to that instance (a sibling still sees the throwing stub).
- **flag on:** `getElementById` is `undefined`, the own property is preserved (`'getElementById' in root === true`), value-based and optional-chaining guards silently no-op, an `in`-guarded call throws a plain `TypeError` (not the descriptive error), reassignment still works through the setter, and a feature-detecting caller resolves an injected marker end-to-end via the `querySelector('#' + id)` fallback.

`ShadowRoot.spec.js` is unchanged from `master` — its existing throwing-stub assertions for all three methods still guard `getSelection` / `cloneNode` (and the flag-off `getElementById` path).

## Does this pull request introduce a breaking change?

- [ ] Yes, it does introduce a breaking change.
- [x] No, it does not introduce a breaking change.

The change is **default off**. With the flag unset — as it is for every existing consumer — `getElementById` remains a throwing stub with the **same observable behavior** as before, including *write* semantics: it is exposed through an accessor (so the flag read stays dynamic), but the accessor carries a **setter** that preserves the original `writable: true` data-property behavior — `root.getElementById = fn` still installs an own writable data property on the instance, exactly as before, in both strict and sloppy mode. The one residual difference, regardless of flag state, is descriptor *kind*: `getOwnPropertyDescriptor(prototype, 'getElementById')` reports an accessor (`get`/`set`) rather than a data property (`value`/`writable`). That is intrinsic to reading the flag dynamically — a data property would have to capture its value when the prototype is built, before the flag is set — and it affects only tooling that introspects that one prototype descriptor, never invocation, reassignment, or feature detection. `getSelection` / `cloneNode` are byte-for-byte unchanged from `master`. Only an org that explicitly enables `ENABLE_SHADOW_ROOT_UNDEFINED_GET_ELEMENT_BY_ID` sees `getElementById` become `undefined`, and that org is opting into it deliberately.

## GUS

W-23449229

