### PR TITLE
chore: remove deprecated enableLwcSpread compiler option

### DIFF
--- a/packages/@lwc/compiler/src/__tests__/options.spec.ts
+++ b/packages/@lwc/compiler/src/__tests__/options.spec.ts
@@ -28,16 +28,6 @@ describe('validateTransformOptions', () => {
 
         const baseOptions: TransformOptions = { name: 'foo', namespace: 'x' };
 
-        test('warns once when enableLwcSpread is passed', () => {
-            validateTransformOptions({ ...baseOptions, enableLwcSpread: true });
-            validateTransformOptions({ ...baseOptions, enableLwcSpread: true });
-
-            expect(warnSpy).toHaveBeenCalledTimes(1);
-            expect(warnSpy).toHaveBeenCalledWith(
-                expect.stringContaining('"enableLwcSpread" property is deprecated')
-            );
-        });
-
         test('warns once when stylesheetConfig is passed', () => {
             validateTransformOptions({ ...baseOptions, stylesheetConfig: {} });
             validateTransformOptions({ ...baseOptions, stylesheetConfig: {} });

--- a/packages/@lwc/compiler/src/options.ts
+++ b/packages/@lwc/compiler/src/options.ts
@@ -16,11 +16,6 @@ import type { InstrumentationObject } from '@lwc/errors';
 import type { CustomRendererConfig } from '@lwc/template-compiler';
 
 /**
- * Flag indicating that a warning about still using the deprecated `enableLwcSpread`
- * compiler option has already been logged to the `console`.
- */
-let alreadyWarnedAboutLwcSpread = false;
-/**
  * Flag indicating that a warning about still using the deprecated `stylesheetConfig`
  * compiler option has already been logged to the `console`.
  */
@@ -126,8 +121,6 @@ export interface TransformOptions {
     enableStaticContentOptimization?: boolean;
     /** Custom renderer config to pass to `@lwc/template-compiler`. See that package's README for details. */
     customRendererConfig?: CustomRendererConfig;
-    /** @deprecated Ignored by compiler. `lwc:spread` is always enabled. */
-    enableLwcSpread?: boolean;
     /** Flag to enable usage of dynamic event listeners (lwc:on) directive in HTML template */
     enableLwcOn?: boolean;
     /** Set to true if synthetic shadow DOM support is not needed, which can result in smaller/faster output. */
@@ -158,7 +151,6 @@ type OptionalTransformKeys =
     | 'namespace'
     | 'scopedStyles'
     | 'customRendererConfig'
-    | 'enableLwcSpread'
     | 'enableLwcOn'
     | 'enableLightningWebSecurityTransforms'
     | 'enableDynamicComponents'
@@ -192,15 +184,6 @@ export function validateTransformOptions(options: TransformOptions): NormalizedT
 
 function validateOptions(options: TransformOptions) {
     invariant(!isUndefined(options), CompilerValidationErrors.MISSING_OPTIONS_OBJECT, [options]);
-
-    if (!isUndefined(options.enableLwcSpread) && !alreadyWarnedAboutLwcSpread) {
-        alreadyWarnedAboutLwcSpread = true;
-
-        // eslint-disable-next-line no-console
-        console.warn(
-            `"enableLwcSpread" property is deprecated. The value doesn't impact the compilation and can safely be removed.`
-        );
-    }
 
     if (!isUndefined(options.stylesheetConfig) && !alreadyWarnedOnStylesheetConfig) {
         alreadyWarnedOnStylesheetConfig = true;

--- a/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/fixtures.spec.ts
@@ -147,24 +147,37 @@ function testFixtures(options?: RollupLwcOptions) {
             let result;
             let err;
             try {
-                config?.features?.forEach((flag) => {
-                    setFeatureFlagForProductionTest(flag, true);
-                });
-
+                // Import the compiled module inside this `try` so that fixtures which throw at
+                // import time (e.g. `wire/errors/*`, whose `registerDecorators` runs at module
+                // eval) still have their error captured into `error.txt`.
                 const module: LightningElementConstructor = (await import(compiledFixturePath))
                     .default;
 
-                result = formatHTML(renderComponent('fixture-test', module, config?.props ?? {}));
+                // These fixtures run concurrently (`describe.concurrent`) and feature flags are
+                // global, so this set → render → reset sequence must stay fully synchronous. An
+                // `await` between setting and resetting would yield to a sibling fixture that could
+                // clobber the shared flag, causing flaky failures (e.g. `scope-token-extended` in
+                // production mode). The `finally` guarantees the flag is reset even if rendering
+                // throws, so a leaked `true` can't poison other concurrent fixtures.
+                try {
+                    config?.features?.forEach((flag) => {
+                        setFeatureFlagForProductionTest(flag, true);
+                    });
+
+                    result = formatHTML(
+                        renderComponent('fixture-test', module, config?.props ?? {})
+                    );
+                } finally {
+                    config?.features?.forEach((flag) => {
+                        setFeatureFlagForProductionTest(flag, false);
+                    });
+                }
             } catch (_err: any) {
                 if (_err?.name === 'AssertionError') {
                     throw _err;
                 }
                 err = _err?.message || 'An empty error occurred?!';
             }
-
-            config?.features?.forEach((flag) => {
-                setFeatureFlagForProductionTest(flag, false);
-            });
 
             return {
                 'expected.html': result,

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -57,8 +57,6 @@ export interface RollupLwcOptions {
     // TODO [#3370]: remove experimental template expression flag
     /** The configuration to pass to `@lwc/template-compiler`. */
     experimentalComplexExpressions?: boolean;
-    /** @deprecated Spread operator is now always enabled. */
-    enableLwcSpread?: boolean;
     /** The configuration to pass to the `@lwc/template-compiler`. */
     enableLwcOn?: boolean;
     /** The configuration to pass to `@lwc/compiler` to disable synthetic shadow support */

--- a/packages/@lwc/template-compiler/src/__tests__/config.spec.ts
+++ b/packages/@lwc/template-compiler/src/__tests__/config.spec.ts
@@ -51,7 +51,6 @@ describe('customRendererConfig normalization', () => {
             "disableSyntheticShadowSupport": false,
             "enableDynamicComponents": false,
             "enableLwcOn": false,
-            "enableLwcSpread": true,
             "enableStaticContentOptimization": true,
             "experimentalComplexExpressions": false,
             "experimentalComputedMemberExpression": false,

--- a/packages/@lwc/template-compiler/src/config.ts
+++ b/packages/@lwc/template-compiler/src/config.ts
@@ -73,11 +73,6 @@ export interface Config {
     enableStaticContentOptimization?: boolean;
 
     /**
-     * @deprecated Spread operator is now always enabled.
-     */
-    enableLwcSpread?: boolean;
-
-    /**
      * When true, enables `lwc:on` directive.
      */
     enableLwcOn?: boolean;
@@ -103,7 +98,6 @@ export type NormalizedConfig = RequiredConfigOptions & OptionalConfigOptions;
 const AVAILABLE_OPTION_NAMES = new Set([
     'apiVersion',
     'customRendererConfig',
-    'enableLwcSpread',
     'enableLwcOn',
     'enableStaticContentOptimization',
     // TODO [#3370]: remove experimental template expression flag
@@ -181,7 +175,6 @@ export function normalizeConfig(config: Config): NormalizedConfig {
         experimentalDynamicDirective: false,
         enableDynamicComponents: false,
         enableStaticContentOptimization: true,
-        enableLwcSpread: true,
         enableLwcOn: false,
         disableSyntheticShadowSupport: false,
         ...config,


### PR DESCRIPTION
## Details

Removes the deprecated `enableLwcSpread` option from `@lwc/template-compiler`, `@lwc/compiler`, and `@lwc/rollup-plugin`.

`lwc:spread` has been always-on for some time. `enableLwcSpread` was already a documented no-op — `@lwc/compiler` emitted a deprecation warning stating *"the value doesn't impact the compilation and can safely be removed"* — and it was **never forwarded** from `@lwc/compiler`/`@lwc/rollup-plugin` down into `@lwc/template-compiler`'s `compile()`. So removing it produces **no change in compilation output**.

**Changes:**
- `@lwc/template-compiler` `config.ts`: remove the `enableLwcSpread` type member, its entry in `AVAILABLE_OPTION_NAMES`, and its default.
- `@lwc/compiler` `options.ts`: remove the type member, the `OptionalTransformKeys` entry, the deprecation-warning block, and the now-unused `alreadyWarnedAboutLwcSpread` latch.
- `@lwc/rollup-plugin` `index.ts`: remove the option.
- Update `config.spec.ts` inline snapshot and drop the `enableLwcSpread` deprecation-warning test in `options.spec.ts`.

### Scope note — `enableLwcOn` deliberately NOT removed

The sibling work item covers both `lwc:spread` and `lwc:on` gates, but `enableLwcOn` is **still an active gate**: it defaults to `false`, the template parser throws `LWC1206` when it's unset, and `lwc:on` only reached GA in API v260. Removing it would change behavior for all consumers with no api-version fallback, so it stays for now. This PR intentionally handles only the safe, dead `enableLwcSpread` half.

## Does this pull request introduce a breaking change?

- 💔 Yes, it does introduce a breaking change.

**Impact:** `@lwc/template-compiler`'s `normalizeConfig` throws `UNKNOWN_OPTION_PROPERTY` on unrecognized keys. A consumer calling `@lwc/template-compiler` **directly** and still passing `enableLwcSpread` would now get an error instead of a silent ignore. Consumers going through `@lwc/compiler` / `@lwc/rollup-plugin` are unaffected (the option was never forwarded, and `@lwc/compiler` still accepts—now simply ignores without warning—unknown extras per its own normalization). **Migration:** remove the `enableLwcSpread` option from your compiler config; it has had no effect for several releases.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change.

Compilation output is unchanged.

## GUS work item

W-21769003