### PR TITLE
@W-23590585 fix(engine-core): only change attribute for components

### DIFF
--- a/.strata.yml
+++ b/.strata.yml
@@ -1,6 +1,5 @@
 global:
     email-reply-to: raptorteam@salesforce.com
-    preprocessor-tag: jenkins-sfci-sfci-managed-preprocessor-PR-6322-40-itest
 
 stages:
     build:

--- a/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
@@ -89,22 +89,28 @@ function createAttributeChangedCallback(
         oldValue: string,
         newValue: string
     ) {
-        if (oldValue === newValue) {
-            // Ignore same values.
-            return;
-        }
-        const propName = attributeToPropMap[attrName];
-        if (isUndefined(propName)) {
-            if (!isUndefined(superAttributeChangedCallback)) {
-                // delegate unknown attributes to the super.
-                // Typescript does not like it when you treat the `arguments` object as an array
-                // @ts-expect-error type-mismatch
-                superAttributeChangedCallback.apply(this, arguments);
+        // W-17420330 & W-23590585
+        if (
+            this instanceof BaseBridgeElement ||
+            lwcRuntimeFlags.ENABLE_LEGACY_ATTRIBUTE_CHANGED_CALLBACK
+        ) {
+            if (oldValue === newValue) {
+                // Ignore same values.
+                return;
             }
-            return;
+            const propName = attributeToPropMap[attrName];
+            if (isUndefined(propName)) {
+                if (!isUndefined(superAttributeChangedCallback)) {
+                    // delegate unknown attributes to the super.
+                    // Typescript does not like it when you treat the `arguments` object as an array
+                    // @ts-expect-error type-mismatch
+                    superAttributeChangedCallback.apply(this, arguments);
+                }
+                return;
+            }
+            // Reflect attribute change to the corresponding property when changed from outside.
+            (this as any)[propName] = newValue;
         }
-        // Reflect attribute change to the corresponding property when changed from outside.
-        (this as any)[propName] = newValue;
     };
 }
 

--- a/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
+++ b/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
@@ -122,7 +122,10 @@ export function buildCustomElementConstructor(Ctor: ComponentConstructor): HTMLE
         }
 
         attributeChangedCallback(name: string, oldValue: any, newValue: any) {
-            if (this instanceof BaseBridgeElement) {
+            if (
+                !lwcRuntimeFlags.ENABLE_LEGACY_ATTRIBUTE_CHANGED_CALLBACK ||
+                this instanceof BaseBridgeElement
+            ) {
                 // W-17420330
                 attributeChangedCallback.call(this, name, oldValue, newValue);
             }

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -26,6 +26,8 @@ const features: FeatureFlagMap = {
     ENABLE_SHADOW_ROOT_UNDEFINED_GET_ELEMENT_BY_ID: null,
     // Remove in 270
     ENABLE_BROKEN_HTML_COLLECTION_NAMED_ITEM: null,
+    // Remove in 270
+    ENABLE_LEGACY_ATTRIBUTE_CHANGED_CALLBACK: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -99,8 +99,11 @@ export interface FeatureFlagMap {
      * out-of-bounds `items[length]` slot instead of the current index, reproducing the broken
      * lookup behavior it had prior to 266. If false or unset (default), it iterates items correctly.
      */
-    // Remove in 270
     ENABLE_BROKEN_HTML_COLLECTION_NAMED_ITEM: FeatureFlagValue;
+    /**
+     * If true, the `attributeChangedCallback` guard behaves as it did prior to 266.
+     */
+    ENABLE_LEGACY_ATTRIBUTE_CHANGED_CALLBACK: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-wtr/test/component/lifecycle-callbacks/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/component/lifecycle-callbacks/index.spec.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement, setFeatureFlagForTest } from 'lwc';
 import Single from 'x/single';
 import Parent from 'x/parent';
 import ParentIf from 'x/parentIf';
@@ -11,6 +11,7 @@ import TimingParentLight from 'timing/parentLight';
 import ReorderingList from 'reordering/list';
 import ReorderingListLight from 'reordering/listLight';
 import Details from 'x/details';
+import MoreDetails from 'x/moreDetails';
 import MutationsParent from 'mutations/parent';
 import MutationsParentLight from 'mutations/parentLight';
 
@@ -427,7 +428,9 @@ describe('dispatchEvent from connectedCallback/disconnectedCallback', () => {
 });
 
 describe('attributeChangedCallback', () => {
-    it('W-17420330 - only fires for registered component', async () => {
+    afterEach(() => setFeatureFlagForTest('ENABLE_LEGACY_ATTRIBUTE_CHANGED_CALLBACK', false));
+
+    it('W-17420330 - only fires for registered component from element', async () => {
         const root = createElement('x-details', { is: Details });
         document.body.appendChild(root);
         await Promise.resolve();
@@ -436,6 +439,21 @@ describe('attributeChangedCallback', () => {
         const cb = Details.CustomElementConstructor.prototype.attributeChangedCallback;
         cb.call(details, 'open', '', 'open');
         expect(details.getAttribute('open')).toBeNull();
+    });
+
+    it('W-23590585 - only fires for registered component from within component', async () => {
+        const details = createElement('x-more-details', { is: MoreDetails });
+        document.body.appendChild(details);
+        await Promise.resolve();
+        expect(details.details.hasAttribute('open')).toBeFalse();
+    });
+
+    it('W-23590585 - preserves legacy behavior with flag', async () => {
+        setFeatureFlagForTest('ENABLE_LEGACY_ATTRIBUTE_CHANGED_CALLBACK', true);
+        const details = createElement('x-more-details', { is: MoreDetails });
+        document.body.appendChild(details);
+        await Promise.resolve();
+        expect(details.details.hasAttribute('open')).toBeTrue();
     });
 });
 

--- a/packages/@lwc/integration-wtr/test/component/lifecycle-callbacks/x/moreDetails/moreDetails.html
+++ b/packages/@lwc/integration-wtr/test/component/lifecycle-callbacks/x/moreDetails/moreDetails.html
@@ -1,0 +1,4 @@
+<template>
+  <p>More details:</p>
+  <x-details lwc:ref="details"></x-details>
+</template>

--- a/packages/@lwc/integration-wtr/test/component/lifecycle-callbacks/x/moreDetails/moreDetails.js
+++ b/packages/@lwc/integration-wtr/test/component/lifecycle-callbacks/x/moreDetails/moreDetails.js
@@ -1,0 +1,8 @@
+import { api, LightningElement } from 'lwc';
+
+export default class MoreDetails extends LightningElement {
+    @api details = document.createElement('details');
+    renderedCallback() {
+        this.refs.details.attributeChangedCallback.call(this.details, 'open', '', 'open');
+    }
+}


### PR DESCRIPTION
## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
