### PR TITLE
chore(ci): remove stale SFCI itest preprocessor-tag pin

### DIFF
--- a/.strata.yml
+++ b/.strata.yml
@@ -1,6 +1,5 @@
 global:
     email-reply-to: raptorteam@salesforce.com
-    preprocessor-tag: jenkins-sfci-sfci-managed-preprocessor-PR-6322-40-itest
 
 stages:
     build:


### PR DESCRIPTION
## Why

`.strata.yml` pinned the SFCI preprocessor to a temporary itest tag (`jenkins-sfci-sfci-managed-preprocessor-PR-6322-40-itest`, added Feb 2026 in "chore: Enable SFCI"). SFCI enforces a 2-week retention policy on itest preprocessor tags and garbage-collected this one.

The preprocessor renders the pipeline *before any build step runs*, so the missing image makes strata-falcon report "This commit cannot be built" — a pre-pipeline failure with no Jenkins logs. Master builds (e.g. #118, #119) fast-fail in the Setup stage with `manifest unknown` pulling that image.

GitHub Actions (build + all unit/integration/hydration matrices) stayed green throughout, and `yarn install && yarn build && yarn test` reproduces clean locally — this is purely the stale preprocessor pin, not an LWC code regression.

## What

Removes the `preprocessor-tag` line from `.strata.yml`. Per SFCI docs, production repos should not pin `preprocessor-tag` at all so the preprocessor runs at `:latest`. Removing the line restores the canonical config and unblocks master plus the PR queue.

Detection: `grep -r "jenkins-sfci-sfci-managed-preprocessor.*-itest" .strata.yml` returns nothing after this change.
