### PR TITLE
fix(engine-core): brand sanitized HTML by identity, not object shape (W-23680734)

### DIFF
--- a/packages/@lwc/engine-core/src/framework/__tests__/sanitized-html-content.spec.ts
+++ b/packages/@lwc/engine-core/src/framework/__tests__/sanitized-html-content.spec.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+// Importing `@lwc/features` for its side effect: it defines the ambient `lwcRuntimeFlags`
+// global that `sanitized-html-content.ts` reads.
+import { setFeatureFlagForTest } from '@lwc/features';
+import {
+    createSanitizedHtmlContent,
+    safelySetProperty,
+    unwrapIfNecessary,
+} from '../sanitized-html-content';
+
+const FLAG = 'DISABLE_SANITIZED_HTML_CONTENT_IDENTITY_CHECK';
+
+// W-23680734: an object whose property semantics are caller-controlled. The legacy brand check
+// relied on `symbol in value` and `value[symbol]`, which for such an object resolve to whatever
+// its `has`/`get` handlers return — so it could report the sanitized-content brand it does not
+// legitimately hold. This stand-in models exactly that: `in` reports true, and any read returns
+// the (benign, marker-only) string below. The identity brand must not be fooled by it.
+const UNTRUSTED_MARKUP = '<span data-untrusted></span>';
+function makeBrandForgingObject(markup: string = UNTRUSTED_MARKUP) {
+    return new Proxy(
+        {},
+        {
+            has() {
+                return true;
+            },
+            get() {
+                return markup;
+            },
+        }
+    );
+}
+
+describe('sanitized-html-content', () => {
+    afterEach(() => {
+        // Reset the kill-switch between tests (non-production allows re-setting).
+        setFeatureFlagForTest(FLAG, false);
+        vi.restoreAllMocks();
+    });
+
+    describe('default (identity brand) — the fix', () => {
+        it('round-trips a legitimately-created sanitized value', () => {
+            const wrapper = createSanitizedHtmlContent('<b>ok</b>');
+            expect(unwrapIfNecessary(wrapper)).toBe('<b>ok</b>');
+        });
+
+        it('sets innerHTML for a legitimately-created sanitized value', () => {
+            const setProperty = vi.fn();
+            const elm = {} as Element;
+            const wrapper = createSanitizedHtmlContent('<b>ok</b>');
+            safelySetProperty(setProperty, elm, 'innerHTML', wrapper);
+            expect(setProperty).toHaveBeenCalledWith(elm, 'innerHTML', '<b>ok</b>');
+        });
+
+        it('does NOT trust a brand-forging object (unwrap returns it unchanged, not its markup)', () => {
+            const obj = makeBrandForgingObject();
+            // It is not a real sanitized-content object → it is returned as-is, never unwrapped
+            // to the untrusted string.
+            expect(unwrapIfNecessary(obj)).toBe(obj);
+        });
+
+        it('does NOT pass a brand-forging object through to innerHTML (W-23680734)', () => {
+            const setProperty = vi.fn();
+            const elm = {} as Element;
+            const obj = makeBrandForgingObject();
+            safelySetProperty(setProperty, elm, 'innerHTML', obj);
+            // The renderer must never be driven to write the untrusted string.
+            expect(setProperty).not.toHaveBeenCalledWith(
+                elm,
+                'innerHTML',
+                expect.stringContaining('data-untrusted')
+            );
+            // And in particular it must not be called at all for the untrusted value.
+            expect(setProperty).not.toHaveBeenCalled();
+        });
+
+        it('does NOT pass a brand-forging object through to outerHTML either', () => {
+            const setProperty = vi.fn();
+            const elm = {} as Element;
+            safelySetProperty(setProperty, elm, 'outerHTML', makeBrandForgingObject());
+            expect(setProperty).not.toHaveBeenCalled();
+        });
+
+        it('is not fooled by an object that merely copies a real wrapper (own-symbol) — identity, not shape', () => {
+            const real = createSanitizedHtmlContent('<b>ok</b>');
+            // Copy every own property (incl. the symbol) onto a fresh object.
+            const lookalike = Object.create(null, Object.getOwnPropertyDescriptors(real as object));
+            // The lookalike has the symbol but was never registered by us → not trusted.
+            expect(unwrapIfNecessary(lookalike)).toBe(lookalike);
+        });
+    });
+
+    describe('kill-switch enabled (legacy structural brand)', () => {
+        it('restores the legacy symbol brand so the legit path still works', () => {
+            setFeatureFlagForTest(FLAG, true);
+            const wrapper = createSanitizedHtmlContent('<b>ok</b>');
+            expect(unwrapIfNecessary(wrapper)).toBe('<b>ok</b>');
+        });
+
+        it('reverts to the legacy structural behavior — proving the flag is a real kill-switch', () => {
+            setFeatureFlagForTest(FLAG, true);
+            const obj = makeBrandForgingObject();
+            // With the legacy structural check, a brand-forging object is (undesirably) trusted.
+            // This asserts the flag genuinely toggles behavior; the default (flag off) is safe.
+            expect(unwrapIfNecessary(obj)).toBe(UNTRUSTED_MARKUP);
+        });
+    });
+
+    describe('non-object inputs are passed through unchanged (both modes)', () => {
+        it.each([null, undefined, 'a string', 42, true])('%s', (value) => {
+            expect(unwrapIfNecessary(value)).toBe(value);
+        });
+    });
+});

--- a/packages/@lwc/engine-core/src/framework/__tests__/sanitized-html-content.spec.ts
+++ b/packages/@lwc/engine-core/src/framework/__tests__/sanitized-html-content.spec.ts
@@ -95,21 +95,28 @@ describe('sanitized-html-content', () => {
         });
     });
 
-    describe('kill-switch enabled (legacy structural brand)', () => {
-        it('restores the legacy symbol brand so the legit path still works', () => {
-            setFeatureFlagForTest(FLAG, true);
-            const wrapper = createSanitizedHtmlContent('<b>ok</b>');
-            expect(unwrapIfNecessary(wrapper)).toBe('<b>ok</b>');
-        });
+    // `setFeatureFlagForTest` is a no-op in production (flags can't be toggled there), so these
+    // kill-switch assertions are only meaningful in non-production. Same guard idiom as
+    // `engine-dom/.../formatters/__tests__/component.spec.ts`.
+    describe.skipIf(process.env.NODE_ENV === 'production')(
+        'kill-switch enabled (legacy structural brand)',
+        () => {
+            it('restores the legacy symbol brand so the legit path still works', () => {
+                setFeatureFlagForTest(FLAG, true);
+                const wrapper = createSanitizedHtmlContent('<b>ok</b>');
+                expect(unwrapIfNecessary(wrapper)).toBe('<b>ok</b>');
+            });
 
-        it('reverts to the legacy structural behavior — proving the flag is a real kill-switch', () => {
-            setFeatureFlagForTest(FLAG, true);
-            const obj = makeBrandForgingObject();
-            // With the legacy structural check, a brand-forging object is (undesirably) trusted.
-            // This asserts the flag genuinely toggles behavior; the default (flag off) is safe.
-            expect(unwrapIfNecessary(obj)).toBe(UNTRUSTED_MARKUP);
-        });
-    });
+            it('reverts to the legacy structural behavior — proving the flag is a real kill-switch', () => {
+                setFeatureFlagForTest(FLAG, true);
+                const obj = makeBrandForgingObject();
+                // With the legacy structural check, a brand-forging object is (undesirably)
+                // trusted. This asserts the flag genuinely toggles behavior; the default (flag
+                // off) is safe.
+                expect(unwrapIfNecessary(obj)).toBe(UNTRUSTED_MARKUP);
+            });
+        }
+    );
 
     describe('non-object inputs are passed through unchanged (both modes)', () => {
         it.each([null, undefined, 'a string', 42, true])('%s', (value) => {

--- a/packages/@lwc/engine-core/src/framework/sanitized-html-content.ts
+++ b/packages/@lwc/engine-core/src/framework/sanitized-html-content.ts
@@ -11,32 +11,68 @@ import type { RendererAPI } from './renderer';
 
 const sanitizedHtmlContentSymbol = Symbol('lwc-get-sanitized-html-content');
 
+// W-23680734: brand "trusted sanitized HTML" objects by IDENTITY, not by a structural
+// property/symbol. The previous brand check (`sanitizedHtmlContentSymbol in value`) and read
+// (`value[sanitizedHtmlContentSymbol]`) resolve through `value`'s own property semantics, so an
+// object with caller-controlled property behavior can report the brand and yield markup it does
+// not legitimately hold — trust based on shape rather than provenance.
+//
+// A WeakMap keyed on the wrapper's identity closes that gap: `WeakMap.prototype.has`/`get`
+// perform an internal-slot identity lookup that does not consult the object's property handlers,
+// and only wrappers we created were ever registered — so any other object is `false` regardless
+// of its shape. This mirrors the existing identity-based trust sets for signals/context in
+// `@lwc/shared` (`isTrustedSignal`, `isTrustedContext`).
+const sanitizedContentToString: WeakMap<object, unknown> = new WeakMap();
+
 export type SanitizedHtmlContent = {
     [sanitizedHtmlContentSymbol]: unknown;
 };
 
 function isSanitizedHtmlContent(object: any): object is SanitizedHtmlContent {
-    return isObject(object) && !isNull(object) && sanitizedHtmlContentSymbol in object;
+    if (!isObject(object) || isNull(object)) {
+        return false;
+    }
+    // Kill-switch: when the flag is set, fall back to the legacy structural symbol brand.
+    // Present so the hardening can be disabled at runtime if it regresses a legit integration;
+    // the default (flag unset) is the safe, identity-based check.
+    if (lwcRuntimeFlags.DISABLE_SANITIZED_HTML_CONTENT_IDENTITY_CHECK) {
+        return sanitizedHtmlContentSymbol in object;
+    }
+    // Identity check — only wrappers we created are members, independent of `object`'s shape.
+    return sanitizedContentToString.has(object);
+}
+
+function getSanitizedContent(object: SanitizedHtmlContent): unknown {
+    if (lwcRuntimeFlags.DISABLE_SANITIZED_HTML_CONTENT_IDENTITY_CHECK) {
+        return object[sanitizedHtmlContentSymbol];
+    }
+    // Read the sanitized string from OUR map by identity, never from a property access on
+    // `object` (whose semantics may be caller-controlled).
+    return sanitizedContentToString.get(object);
 }
 
 export function unwrapIfNecessary(object: any) {
-    return isSanitizedHtmlContent(object) ? object[sanitizedHtmlContentSymbol] : object;
+    return isSanitizedHtmlContent(object) ? getSanitizedContent(object) : object;
 }
 
 /**
  * Wrap a pre-sanitized string designated for `.innerHTML` via `lwc:inner-html`
- * as an object with a Symbol that only we have access to.
+ * as an object branded by identity in a module-private WeakMap that only we have access to.
  * @param sanitizedString
  * @returns SanitizedHtmlContent
  */
 export function createSanitizedHtmlContent(sanitizedString: unknown): SanitizedHtmlContent {
-    return ObjectCreate(null, {
+    // The wrapper keeps the non-enumerable symbol property so the legacy kill-switch path and
+    // any structural consumers still work; the authoritative brand is WeakMap membership.
+    const wrapper: SanitizedHtmlContent = ObjectCreate(null, {
         [sanitizedHtmlContentSymbol]: {
             value: sanitizedString,
             configurable: false,
             writable: false,
         },
     });
+    sanitizedContentToString.set(wrapper, sanitizedString);
+    return wrapper;
 }
 
 /**
@@ -58,7 +94,7 @@ export function safelySetProperty(
     if ((key === 'innerHTML' || key === 'outerHTML') && !isUndefined(value)) {
         if (isSanitizedHtmlContent(value)) {
             // it's a SanitizedHtmlContent object
-            setProperty(elm, key, value[sanitizedHtmlContentSymbol]);
+            setProperty(elm, key, getSanitizedContent(value));
         } else {
             // not a SanitizedHtmlContent object
             if (process.env.NODE_ENV !== 'production') {

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -29,6 +29,7 @@ const features: FeatureFlagMap = {
     ENABLE_BROKEN_HTML_COLLECTION_NAMED_ITEM: null,
     // Remove in 270
     DISABLE_HYDRATION_CUSTOM_ELEMENT_CHECK: null,
+    DISABLE_SANITIZED_HTML_CONTENT_IDENTITY_CHECK: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -111,6 +111,15 @@ export interface FeatureFlagMap {
      */
     // Remove in 270
     DISABLE_HYDRATION_CUSTOM_ELEMENT_CHECK: FeatureFlagValue;
+
+    /**
+     * Kill-switch for the W-23680734 hardening. If true, reverts the sanitized-HTML brand check
+     * used by `lwc:inner-html` to the legacy structural `sanitizedHtmlContentSymbol in value` /
+     * `value[symbol]` behavior. If false or unset (default), the brand is verified by WeakMap
+     * identity, which does not depend on the object's own property semantics. Only enable this to
+     * unblock a regression; the default is the more secure behavior.
+     */
+    DISABLE_SANITIZED_HTML_CONTENT_IDENTITY_CHECK: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-wtr/test/template/inner-html-brand-identity/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/template/inner-html-brand-identity/index.spec.js
@@ -1,0 +1,64 @@
+import { createElement } from 'lwc';
+import XInnerHtmlBrand from 'x/innerHtmlBrand';
+import { getHooks, setHooks } from '../../../helpers/hooks.js';
+import { resetDOM } from '../../../helpers/reset.js';
+
+// W-23680734: the sanitized-HTML brand is now verified by object identity (a module-private
+// WeakMap in engine-core `sanitized-html-content.ts`) instead of the structural
+// `sanitizedHtmlContentSymbol in value` / `value[symbol]` operations, which depend on the
+// value's own property semantics.
+//
+// The unit-level regression for the brand check itself lives in the engine-core test
+// `framework/__tests__/sanitized-html-content.spec.ts`, exercised at the
+// `safelySetProperty` / `unwrapIfNecessary` boundary (not reachable through the public
+// `lwc:inner-html` flow, which always routes content through `shc()`). These real-browser tests
+// instead guard that the identity brand does not regress the full render pipeline
+// (create + update + clear), which the pure-function unit tests do not exercise.
+
+let originalSanitizeHtmlContent;
+
+beforeAll(() => {
+    originalSanitizeHtmlContent = getHooks().sanitizeHtmlContent;
+    // Identity passthrough sanitizer, matching the sibling directive-lwc-inner-html suite.
+    setHooks({ sanitizeHtmlContent: (content) => content });
+});
+
+afterAll(() => {
+    setHooks({ sanitizeHtmlContent: originalSanitizeHtmlContent });
+});
+
+afterEach(resetDOM);
+
+it('renders legitimately-sanitized content as HTML (create)', () => {
+    const elm = createElement('x-inner-html-brand', { is: XInnerHtmlBrand });
+    elm.content = 'Hello <b>World</b>';
+    document.body.appendChild(elm);
+
+    const div = elm.shadowRoot.querySelector('div');
+    expect(div.childNodes.length).toBe(2);
+    expect(div.childNodes[0].textContent).toBe('Hello ');
+    expect(div.childNodes[1].tagName).toBe('B');
+    expect(div.childNodes[1].textContent).toBe('World');
+});
+
+it('re-renders legitimately-sanitized content on update', async () => {
+    const elm = createElement('x-inner-html-brand', { is: XInnerHtmlBrand });
+    elm.content = 'Hello <b>World</b>';
+    document.body.appendChild(elm);
+    expect(elm.shadowRoot.querySelector('b').textContent).toBe('World');
+
+    elm.content = 'Hello <b>LWC</b>';
+    await Promise.resolve();
+    expect(elm.shadowRoot.querySelector('b').textContent).toBe('LWC');
+});
+
+it('clears content when set to an empty string', async () => {
+    const elm = createElement('x-inner-html-brand', { is: XInnerHtmlBrand });
+    elm.content = 'Hello <b>World</b>';
+    document.body.appendChild(elm);
+    expect(elm.shadowRoot.querySelector('b')).not.toBeNull();
+
+    elm.content = '';
+    await Promise.resolve();
+    expect(elm.shadowRoot.querySelector('div').innerHTML).toBe('');
+});

--- a/packages/@lwc/integration-wtr/test/template/inner-html-brand-identity/x/innerHtmlBrand/innerHtmlBrand.html
+++ b/packages/@lwc/integration-wtr/test/template/inner-html-brand-identity/x/innerHtmlBrand/innerHtmlBrand.html
@@ -1,0 +1,3 @@
+<template>
+    <div lwc:inner-html={content}></div>
+</template>

--- a/packages/@lwc/integration-wtr/test/template/inner-html-brand-identity/x/innerHtmlBrand/innerHtmlBrand.js
+++ b/packages/@lwc/integration-wtr/test/template/inner-html-brand-identity/x/innerHtmlBrand/innerHtmlBrand.js
@@ -1,0 +1,5 @@
+import { LightningElement, api } from 'lwc';
+
+export default class InnerHtmlBrand extends LightningElement {
+    @api content;
+}


### PR DESCRIPTION
## Details

### Summary (W-23680734)

`lwc:inner-html` decided whether a value was pre-sanitized HTML using two operations in `engine-core`'s `sanitized-html-content.ts`:

- brand check: `sanitizedHtmlContentSymbol in value`
- read: `value[sanitizedHtmlContentSymbol]`

Both resolve through the value's **own property semantics**, so trust was based on the object's *shape* rather than its *provenance*. An object that reports the brand and yields a string it did not legitimately obtain from LWC would be accepted and written to `element.innerHTML`. (Full details, reproduction, and impact analysis are in the linked GUS work item — intentionally omitted here since this repo is public.)

### The fix

Brand trusted objects by **identity** via a module-private `WeakMap`, instead of a structural property/symbol:

- `WeakMap.prototype.has` / `get` perform an internal-slot identity lookup that does **not** consult the object's property handlers.
- Only wrappers we created (via `createSanitizedHtmlContent`) were ever registered, so any other object is rejected regardless of its shape.

This mirrors LWC's existing identity-based trust sets for signals/context (`isTrustedSignal`, `isTrustedContext` in `@lwc/shared`). The wrapper keeps its non-enumerable symbol property so the kill-switch path and any structural consumers still function; **WeakMap membership is authoritative**.

### Flag protection

Gated behind a new `DISABLE_SANITIZED_HTML_CONTENT_IDENTITY_CHECK` feature flag (default `null` — present, disabled, **default-safe**). Enabling it reverts to the legacy structural brand to unblock a regression; the default is the more secure behavior.

### Tests

- **Unit** (`engine-core`, 13 tests): exercises the brand check at the `unwrapIfNecessary` / `safelySetProperty` boundary — asserting a shape-only lookalike is rejected, that legit values still round-trip, and that the kill-switch genuinely toggles the legacy behavior. Uses a benign marker string, no payload.
- **Integration** (`integration-wtr`, 3 tests, Chromium/Firefox/WebKit): guards the full real-browser `lwc:inner-html` render pipeline (create / update / clear) against regression.

All green; `eslint` clean on all touched files.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

The wrapper produced by `createSanitizedHtmlContent` (the only creator, via `shc()`) is always registered in the WeakMap, so every legitimate `lwc:inner-html` value continues to be trusted.

## Does this pull request introduce an observable change?

- 🔬 Yes, it does include an observable change.

A value that structurally *looks* like sanitized content (carries the symbol) but was **not** produced by LWC is no longer trusted — this is precisely the hardening. Legitimate usage is unaffected.

## GUS work item

W-23680734

🤖 Generated with [Claude Code](https://claude.com/claude-code)