### PR TITLE
fix(engine-core): guard bridge element property accessors against non-public member access

### DIFF
--- a/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
+++ b/packages/@lwc/engine-core/src/framework/base-bridge-element.ts
@@ -17,6 +17,7 @@ import {
     freeze,
     getOwnPropertyNames,
     getOwnPropertyDescriptors,
+    hasOwnProperty,
     isUndefined,
     seal,
     keys,
@@ -30,6 +31,7 @@ import { getReadOnlyProxy } from './membrane';
 import { HTMLElementConstructor, HTMLElementPrototype } from './html-element';
 import { HTMLElementOriginalDescriptors } from './html-properties';
 import type { LightningElement } from './base-lightning-element';
+import type { VM } from './vm';
 
 // A bridge descriptor is a descriptor whose job is just to get the component instance
 // from the element instance, and get the value or set a new value on the component.
@@ -38,11 +40,31 @@ import type { LightningElement } from './base-lightning-element';
 const cachedGetterByKey: Record<string, (this: HTMLElement) => any> = create(null);
 const cachedSetterByKey: Record<string, (this: HTMLElement, newValue: any) => any> = create(null);
 
+// Because bridge descriptors are cached by member name and shared across every component's bridge
+// element, a descriptor captured from one component can be re-invoked against an unrelated component
+// (e.g. `donorDescriptor.get.call(otherHost)`). The cached accessor recovers the component VM from
+// the invocation receiver (`this`), so without this guard it would forward the call to whatever
+// like-named member exists on the other component — including a *private* one that the other
+// component never exposed publicly. `vm.def.props`/`vm.def.methods` are the authoritative sets of
+// members the bridge is allowed to expose for that component, so we verify the member is present
+// there before forwarding. See W-23641816.
+function assertPublicBridgeMember(vm: VM, memberMap: PropertyDescriptorMap, memberName: string) {
+    if (lwcRuntimeFlags.DISABLE_BRIDGE_ELEMENT_PROPERTY_GUARD) {
+        return;
+    }
+    if (!hasOwnProperty.call(memberMap, memberName)) {
+        throw new TypeError(
+            `Invalid attempt to access "${memberName}" on <${vm.def.name}>. This member is not a public property or method of the component.`
+        );
+    }
+}
+
 function createGetter(key: string) {
     let fn = cachedGetterByKey[key];
     if (isUndefined(fn)) {
         fn = cachedGetterByKey[key] = function (this: HTMLElement): any {
             const vm = getAssociatedVM(this);
+            assertPublicBridgeMember(vm, vm.def.props, key);
             const { getHook } = vm;
             return getHook(vm.component, key);
         };
@@ -55,6 +77,7 @@ function createSetter(key: string) {
     if (isUndefined(fn)) {
         fn = cachedSetterByKey[key] = function (this: HTMLElement, newValue: any): any {
             const vm = getAssociatedVM(this);
+            assertPublicBridgeMember(vm, vm.def.props, key);
             const { setHook } = vm;
             newValue = getReadOnlyProxy(newValue);
             setHook(vm.component, key, newValue);
@@ -66,6 +89,7 @@ function createSetter(key: string) {
 function createMethodCaller(methodName: string): (...args: any[]) => any {
     return function (this: HTMLElement): any {
         const vm = getAssociatedVM(this);
+        assertPublicBridgeMember(vm, vm.def.methods, methodName);
         const { callHook, component } = vm;
         const fn = (component as any)[methodName];
         return callHook(vm.component, fn, ArraySlice.call(arguments as unknown as unknown[]));

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -21,6 +21,7 @@ const features: FeatureFlagMap = {
     DISABLE_HOST_ATTACH_SHADOW_GUARD: null,
     DISABLE_STRICT_VALIDATION: null,
     DISABLE_DETACHED_REHYDRATION: null,
+    DISABLE_BRIDGE_ELEMENT_PROPERTY_GUARD: null,
     // Remove in 270
     ENABLE_LEGACY_ITEM_POLYFILL: null,
     // Remove in 270

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -84,6 +84,16 @@ export interface FeatureFlagMap {
     DISABLE_HOST_ATTACH_SHADOW_GUARD: FeatureFlagValue;
 
     /**
+     * If true, skips the guard that verifies a bridge element property accessor or method is public on
+     * the component receiving the call before forwarding to the component instance. Bridge descriptors
+     * are cached by member name and shared across every component bridge, so without the guard a
+     * descriptor captured from one component can be invoked (via `descriptor.get/set.call(otherHost)`)
+     * against a different component to reach a like-named non-public member. When false or unset, the
+     * guard is active (default).
+     */
+    DISABLE_BRIDGE_ELEMENT_PROPERTY_GUARD: FeatureFlagValue;
+
+    /**
      * If true, the synthetic-shadow `NodeList`/`HTMLCollection` `item` method skips the receiver
      * check and returns `this[index]` for any receiver, as it did prior to 266.
      */

--- a/packages/@lwc/integration-wtr/test/regression/bridge-property-descriptor-escape/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/regression/bridge-property-descriptor-escape/index.spec.js
@@ -1,0 +1,102 @@
+import { createElement, setFeatureFlagForTest } from 'lwc';
+import Donor from 'x/donor';
+import Target from 'x/target';
+
+// W-23641816: LWC bridge property descriptors are cached by member name and shared across every
+// component's bridge element. Their getter/setter/method recover the component VM from the
+// invocation receiver (`this`) but historically never verified that the captured member was public
+// on that receiver's component definition. That let an attacker borrow a public descriptor from one
+// component (the "donor") and re-invoke it against an unrelated component (the "target") to reach a
+// like-named *private* member — e.g. a private `pageReference` accessor — from outside the sandbox.
+
+// Grabs the donor's public bridge descriptor the way the exploit does: walk the element's prototype
+// chain (the descriptors live on the bridge element prototype, not the instance) and return the
+// first descriptor found for `name`.
+function getDonorBridgeDescriptor(element, name) {
+    let proto = Object.getPrototypeOf(element);
+    while (proto !== null) {
+        const descriptor = Object.getOwnPropertyDescriptor(proto, name);
+        if (descriptor) {
+            return descriptor;
+        }
+        proto = Object.getPrototypeOf(proto);
+    }
+    return undefined;
+}
+
+describe('bridge property descriptor escape (W-23641816)', () => {
+    let donor;
+    let target;
+
+    beforeEach(() => {
+        donor = createElement('x-donor', { is: Donor });
+        target = createElement('x-target', { is: Target });
+        document.body.appendChild(donor);
+        document.body.appendChild(target);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(donor);
+        document.body.removeChild(target);
+        setFeatureFlagForTest('DISABLE_BRIDGE_ELEMENT_PROPERTY_GUARD', false);
+    });
+
+    it('exposes public accessor/method descriptors on the donor (sanity check)', () => {
+        // The donor legitimately makes pageReference and donorMethod public, so its bridge exposes
+        // real getter/setter/method descriptors for them. These are what an attacker borrows.
+        const propDescriptor = getDonorBridgeDescriptor(donor, 'pageReference');
+        expect(typeof propDescriptor.get).toBe('function');
+        expect(typeof propDescriptor.set).toBe('function');
+        expect(typeof getDonorBridgeDescriptor(donor, 'donorMethod').value).toBe('function');
+    });
+
+    it('blocks a borrowed setter from reaching a private member on another component', () => {
+        const descriptor = getDonorBridgeDescriptor(donor, 'pageReference');
+
+        expect(() =>
+            descriptor.set.call(target, { attributes: 'attacker-controlled' })
+        ).toThrowError(/not a public property or method/);
+        // The private setter on the target must never have run.
+        expect(target.privateSetterInvokedWith).toBeUndefined();
+    });
+
+    it('blocks a borrowed getter from reading a private member on another component', () => {
+        const descriptor = getDonorBridgeDescriptor(donor, 'pageReference');
+
+        expect(() => descriptor.get.call(target)).toThrowError(/not a public property or method/);
+        expect(target.privateGetterInvoked).toBe(false);
+    });
+
+    it('blocks a borrowed method from invoking a private method on another component', () => {
+        const descriptor = getDonorBridgeDescriptor(donor, 'donorMethod');
+
+        expect(() => descriptor.value.call(target)).toThrowError(/not a public property or method/);
+        expect(target.privateMethodInvoked).toBe(false);
+    });
+
+    it('still allows a descriptor to be used against its own public member', () => {
+        const descriptor = getDonorBridgeDescriptor(donor, 'pageReference');
+
+        // Using the descriptor on the donor itself (where pageReference IS public) must keep working.
+        expect(() => descriptor.set.call(donor, 'legit-value')).not.toThrow();
+        expect(descriptor.get.call(donor)).toBe('legit-value');
+    });
+
+    it('does not break normal public property/method access', () => {
+        // Regular external access to the donor's public members goes through the same bridge
+        // descriptors and must be unaffected by the guard.
+        donor.pageReference = 'external-value';
+        expect(donor.pageReference).toBe('external-value');
+        expect(donor.donorMethod()).toBe('donor-method-result');
+    });
+
+    it('does not throw when the guard is disabled via feature flag (legacy behavior)', () => {
+        setFeatureFlagForTest('DISABLE_BRIDGE_ELEMENT_PROPERTY_GUARD', true);
+        const descriptor = getDonorBridgeDescriptor(donor, 'pageReference');
+
+        // With the guard off, the borrowed setter reaches the target's private accessor (the
+        // vulnerable pre-fix behavior). We assert the escape happens so the flag is a real kill switch.
+        expect(() => descriptor.set.call(target, 'attacker-controlled')).not.toThrow();
+        expect(target.privateSetterInvokedWith).toBe('attacker-controlled');
+    });
+});

--- a/packages/@lwc/integration-wtr/test/regression/bridge-property-descriptor-escape/x/donor/donor.html
+++ b/packages/@lwc/integration-wtr/test/regression/bridge-property-descriptor-escape/x/donor/donor.html
@@ -1,0 +1,3 @@
+<template>
+    <div>donor</div>
+</template>

--- a/packages/@lwc/integration-wtr/test/regression/bridge-property-descriptor-escape/x/donor/donor.js
+++ b/packages/@lwc/integration-wtr/test/regression/bridge-property-descriptor-escape/x/donor/donor.js
@@ -1,0 +1,12 @@
+import { LightningElement, api } from 'lwc';
+
+// Donor exposes `pageReference` and `donorMethod` as public members, so its bridge element
+// prototype has getter/setter/method descriptors for them. Those descriptors are the ones an
+// attacker borrows and re-invokes against an unrelated component.
+export default class Donor extends LightningElement {
+    @api pageReference;
+
+    @api donorMethod() {
+        return 'donor-method-result';
+    }
+}

--- a/packages/@lwc/integration-wtr/test/regression/bridge-property-descriptor-escape/x/target/target.html
+++ b/packages/@lwc/integration-wtr/test/regression/bridge-property-descriptor-escape/x/target/target.html
@@ -1,0 +1,3 @@
+<template>
+    <div>target</div>
+</template>

--- a/packages/@lwc/integration-wtr/test/regression/bridge-property-descriptor-escape/x/target/target.js
+++ b/packages/@lwc/integration-wtr/test/regression/bridge-property-descriptor-escape/x/target/target.js
@@ -1,0 +1,28 @@
+import { LightningElement, api } from 'lwc';
+
+// Target has a `pageReference` accessor and a `secretMethod`, but neither is `@api`, so they are
+// NOT public. A borrowed donor descriptor must not be able to reach them from outside the component.
+export default class Target extends LightningElement {
+    // Records whether the private accessor/method was actually reached, so the test can assert the
+    // guard blocked the borrowed descriptor before it hit the component instance.
+    @api privateSetterInvokedWith = undefined;
+    @api privateGetterInvoked = false;
+    @api privateMethodInvoked = false;
+
+    _pageReference = 'private-target-value';
+
+    get pageReference() {
+        this.privateGetterInvoked = true;
+        return this._pageReference;
+    }
+
+    set pageReference(value) {
+        this.privateSetterInvokedWith = value;
+        this._pageReference = value;
+    }
+
+    donorMethod() {
+        this.privateMethodInvoked = true;
+        return 'target-private-method';
+    }
+}


### PR DESCRIPTION
## Details

Hardens the visibility boundary of LWC bridge element property accessors and methods.

Bridge property descriptors are cached by member name and shared across every component's bridge element. The cached getter/setter/method recovers the component VM from the invocation receiver (`this`), but did not verify that the accessed member is actually a public member of the component receiving the call. As a result, a bridge accessor could resolve a member on a component that never declared that member public.

This change adds `assertPublicBridgeMember`, which verifies the accessed member is an own property of the receiving component's authoritative public-member maps — `vm.def.props` for property getters/setters and `vm.def.methods` for methods — before forwarding to the component instance. Those maps already represent exactly the set of members the bridge is permitted to expose (public `@api` members plus the base `HTMLElement`/ARIA reflective properties), so legitimate external property and method access is unaffected, while access to a non-public member throws a `TypeError`.

The guard is protected by a new runtime feature flag, `DISABLE_BRIDGE_ELEMENT_PROPERTY_GUARD`, which acts as a kill switch. It defaults to off (guard active); setting it to `true` restores the prior behavior.

### Testing

- New WTR regression suite `integration-wtr/test/regression/bridge-property-descriptor-escape` covering the guard, the kill-switch flag, and continued normal public access. Passes across dev / prod / native-shadow modes.
- Existing bridge-path regression suites (component properties, `@api` props/methods, ARIA reflection, HTML properties, attribute-aria, locker-live-property) pass unchanged in both dev and prod.
- `@lwc/engine-core` unit tests and lint pass.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

<!--
Accessing a non-public member through a bridge element accessor was never a supported public API.
Legitimate access to public `@api` members and base HTMLElement/ARIA reflective properties is
unaffected, and the behavior is guarded by a runtime kill-switch flag.
-->

## Does this pull request introduce an observable change?

- 🔬 Yes, it does include an observable change.

Invoking a bridge element property accessor or method for a member that is not public on the receiving component now throws a `TypeError` instead of silently forwarding to the component instance. This is gated behind the `DISABLE_BRIDGE_ELEMENT_PROPERTY_GUARD` feature flag.

## GUS work item

W-23641816
