### PR TITLE
chore: legacy scope token cleanup

### DIFF
--- a/packages/@lwc/engine-core/src/framework/freeze-template.ts
+++ b/packages/@lwc/engine-core/src/framework/freeze-template.ts
@@ -28,13 +28,7 @@ import type { Template } from './template';
 import type { Stylesheet, Stylesheets } from '@lwc/shared';
 
 // See @lwc/engine-core/src/framework/template.ts
-const TEMPLATE_PROPS = [
-    'slots',
-    'stylesheetToken',
-    'stylesheets',
-    'renderMode',
-    'legacyStylesheetToken',
-] as const;
+const TEMPLATE_PROPS = ['slots', 'stylesheetToken', 'stylesheets', 'renderMode'] as const;
 
 // Expandos that may be placed on a stylesheet factory function, and which are meaningful to LWC at runtime
 const STYLESHEET_PROPS = [KEY__SCOPED_CSS, KEY__NATIVE_ONLY_CSS] as const;

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -657,7 +657,7 @@ function validateClassAttr(
     // ---------- Step 2: handle the scope tokens
 
     // we don't care about legacy for hydration. it's a new use case
-    const scopeToken = getScopeTokenClass(owner, /* legacy */ false);
+    const scopeToken = getScopeTokenClass(owner);
 
     // Classnames for scoped CSS are added directly to the DOM during rendering,
     // or to the VDOM on the server in the case of SSR. As such, these classnames

--- a/packages/@lwc/engine-core/src/framework/hydration.ts
+++ b/packages/@lwc/engine-core/src/framework/hydration.ts
@@ -655,8 +655,6 @@ function validateClassAttr(
     }
 
     // ---------- Step 2: handle the scope tokens
-
-    // we don't care about legacy for hydration. it's a new use case
     const scopeToken = getScopeTokenClass(owner);
 
     // Classnames for scoped CSS are added directly to the DOM during rendering,

--- a/packages/@lwc/engine-core/src/framework/rendering.ts
+++ b/packages/@lwc/engine-core/src/framework/rendering.ts
@@ -605,7 +605,7 @@ function applyStyleScoping(elm: Element, owner: VM, renderer: RendererAPI) {
     const { getClassList } = renderer;
 
     // Set the class name for `*.scoped.css` style scoping.
-    const scopeToken = getScopeTokenClass(owner, /* legacy */ false);
+    const scopeToken = getScopeTokenClass(owner);
     if (!isNull(scopeToken)) {
         if (!isValidScopeToken(scopeToken)) {
             // See W-16614556

--- a/packages/@lwc/engine-core/src/framework/stylesheet.ts
+++ b/packages/@lwc/engine-core/src/framework/stylesheet.ts
@@ -93,9 +93,7 @@ function createInlineStyleVNode(content: string): VNode {
     );
 }
 
-// TODO [#3733]: remove this dead legacy-scope-token plumbing (the ENABLE_LEGACY_SCOPE_TOKENS
-// runtime flag has been removed, so the `legacy` argument is now always false).
-export function updateStylesheetToken(vm: VM, template: Template, legacy: boolean) {
+export function updateStylesheetToken(vm: VM, template: Template) {
     const {
         elm,
         context,
@@ -104,7 +102,7 @@ export function updateStylesheetToken(vm: VM, template: Template, legacy: boolea
         renderer: { getClassList, removeAttribute, setAttribute },
     } = vm;
     const { stylesheets: newStylesheets } = template;
-    const newStylesheetToken = legacy ? template.legacyStylesheetToken : template.stylesheetToken;
+    const newStylesheetToken = template.stylesheetToken;
     const { stylesheets: newVmStylesheets } = vm;
     const isSyntheticShadow =
         renderMode === RenderMode.Shadow && shadowMode === ShadowMode.Synthetic;
@@ -115,18 +113,9 @@ export function updateStylesheetToken(vm: VM, template: Template, legacy: boolea
     let newHasTokenInAttribute: boolean | undefined;
 
     // Reset the styling token applied to the host element.
-    let oldToken;
-    let oldHasTokenInClass;
-    let oldHasTokenInAttribute;
-    if (legacy) {
-        oldToken = context.legacyStylesheetToken;
-        oldHasTokenInClass = context.hasLegacyTokenInClass;
-        oldHasTokenInAttribute = context.hasLegacyTokenInAttribute;
-    } else {
-        oldToken = context.stylesheetToken;
-        oldHasTokenInClass = context.hasTokenInClass;
-        oldHasTokenInAttribute = context.hasTokenInAttribute;
-    }
+    const oldToken = context.stylesheetToken;
+    const oldHasTokenInClass = context.hasTokenInClass;
+    const oldHasTokenInAttribute = context.hasTokenInAttribute;
     if (!isUndefined(oldToken)) {
         if (oldHasTokenInClass) {
             getClassList(elm).remove(makeHostToken(oldToken));
@@ -163,15 +152,9 @@ export function updateStylesheetToken(vm: VM, template: Template, legacy: boolea
     }
 
     // Update the styling tokens present on the context object.
-    if (legacy) {
-        context.legacyStylesheetToken = newToken;
-        context.hasLegacyTokenInClass = newHasTokenInClass;
-        context.hasLegacyTokenInAttribute = newHasTokenInAttribute;
-    } else {
-        context.stylesheetToken = newToken;
-        context.hasTokenInClass = newHasTokenInClass;
-        context.hasTokenInAttribute = newHasTokenInAttribute;
-    }
+    context.stylesheetToken = newToken;
+    context.hasTokenInClass = newHasTokenInClass;
+    context.hasTokenInAttribute = newHasTokenInAttribute;
 }
 
 function evaluateStylesheetsContent(
@@ -313,17 +296,10 @@ function getNearestShadowComponent(vm: VM): VM | null {
  * this returns the unique token for that scoped stylesheet. Otherwise
  * it returns null.
  * @param owner
- * @param legacy
  */
-// TODO [#3733]: remove this dead legacy-scope-token plumbing (the ENABLE_LEGACY_SCOPE_TOKENS
-// runtime flag has been removed, so the `legacy` argument is now always false).
-export function getScopeTokenClass(owner: VM, legacy: boolean): string | null {
+export function getScopeTokenClass(owner: VM): string | null {
     const { cmpTemplate, context } = owner;
-    return (
-        (context.hasScopedStyles &&
-            (legacy ? cmpTemplate?.legacyStylesheetToken : cmpTemplate?.stylesheetToken)) ||
-        null
-    );
+    return (context.hasScopedStyles && cmpTemplate?.stylesheetToken) || null;
 }
 
 function getNearestNativeShadowComponent(vm: VM): VM | null {

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -53,8 +53,7 @@ export interface Template {
     /** The string used for synthetic shadow style scoping and light DOM style scoping. */
     stylesheetToken?: string;
     /** Same as the above, but for legacy use cases (pre-LWC v3.0.0) */
-    // TODO [#3733]: remove this dead legacy-scope-token plumbing (the ENABLE_LEGACY_SCOPE_TOKENS
-    // runtime flag has been removed, so this token is no longer read at render time).
+    // TODO [#3733]: remove this dead legacy-scope-token plumbing
     legacyStylesheetToken?: string;
     /** Render mode for the template. Could be light or undefined (which means it's shadow) */
     renderMode?: 'light';
@@ -393,7 +392,7 @@ export function evaluateTemplate(vm: VM, html: Template): VNodes {
                     context.hasScopedStyles = computeHasScopedStyles(html, vm);
 
                     // Update the scoping token on the host element.
-                    updateStylesheetToken(vm, html, /* legacy */ false);
+                    updateStylesheetToken(vm, html);
 
                     // Evaluate, create stylesheet and cache the produced VNode for future
                     // re-rendering.

--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -52,9 +52,6 @@ export interface Template {
     stylesheets?: Stylesheets;
     /** The string used for synthetic shadow style scoping and light DOM style scoping. */
     stylesheetToken?: string;
-    /** Same as the above, but for legacy use cases (pre-LWC v3.0.0) */
-    // TODO [#3733]: remove this dead legacy-scope-token plumbing
-    legacyStylesheetToken?: string;
     /** Render mode for the template. Could be light or undefined (which means it's shadow) */
     renderMode?: 'light';
     /** True if this template contains template refs, undefined or false otherwise */

--- a/packages/@lwc/engine-core/src/framework/vm.ts
+++ b/packages/@lwc/engine-core/src/framework/vm.ts
@@ -100,14 +100,6 @@ export interface Context {
     hasTokenInClass: boolean | undefined;
     /** True if a stylesheetToken was added to the host attributes */
     hasTokenInAttribute: boolean | undefined;
-    /** The legacy string used for synthetic shadow DOM and light DOM style scoping. */
-    // TODO [#3733]: remove this dead legacy-scope-token plumbing (the ENABLE_LEGACY_SCOPE_TOKENS
-    // runtime flag has been removed, so this token is no longer read at render time).
-    legacyStylesheetToken: string | undefined;
-    /** True if a legacyStylesheetToken was added to the host class */
-    hasLegacyTokenInClass: boolean | undefined;
-    /** True if a legacyStylesheetToken was added to the host attributes */
-    hasLegacyTokenInAttribute: boolean | undefined;
     /** Whether or not light DOM scoped styles are present in the stylesheets. */
     hasScopedStyles: boolean | undefined;
     /** The VNodes injected in all the shadow trees to apply the associated component stylesheets. */
@@ -362,9 +354,6 @@ export function createVM<HostNode, HostElement>(
             stylesheetToken: undefined,
             hasTokenInClass: undefined,
             hasTokenInAttribute: undefined,
-            legacyStylesheetToken: undefined,
-            hasLegacyTokenInClass: undefined,
-            hasLegacyTokenInAttribute: undefined,
             hasScopedStyles: undefined,
             styleVNodes: null,
             tplCache: EmptyObject,

--- a/packages/@lwc/integration-wtr/test/rendering/scope-tokens/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/rendering/scope-tokens/index.spec.js
@@ -34,13 +34,6 @@ describe('scope tokens', () => {
         return [LOWERCASE_SCOPE_TOKENS ? modern : legacy].filter(Boolean).sort();
     }
 
-    function expectShadowAttrTokens(modern, legacy) {
-        if (process.env.NATIVE_SHADOW) {
-            return []; // no scope attributes added in native shadow
-        }
-        return expectTokens(modern, legacy);
-    }
-
     it('light dom', async () => {
         const elm = createElement('x-light', { is: Light });
         document.body.appendChild(elm);
@@ -108,22 +101,20 @@ describe('scope tokens', () => {
             );
 
             expect(getAttributes(elm)).toEqual(
-                expectShadowAttrTokens('lwc-2idtulmc17f-host', 'x-shadow_shadow-host')
+                expectTokens('lwc-2idtulmc17f-host', 'x-shadow_shadow-host')
             );
             expect(getAttributes(staticDiv)).toEqual(
-                expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
             );
             expect(getAttributes(dynamicDiv)).toEqual(
-                expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
             );
             expect(getClasses(manualDiv)).toEqual(
-                expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
             );
-            expect(getAttributes(span)).toEqual(
-                expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
-            );
+            expect(getAttributes(span)).toEqual(expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow'));
             expect(getAttributes(expressionDiv)).toEqual(
-                expectShadowAttrTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
+                expectTokens('lwc-2idtulmc17f', 'x-shadow_shadow')
             );
         };
 

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/adjacent-text-and-comments/non-static-optimized/no-preserve-comments/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/adjacent-text-and-comments/non-static-optimized/no-preserve-comments/expected.js
@@ -16,7 +16,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-351u0g5gdss";
-tmpl.legacyStylesheetToken = "x-no-preserve-comments_no-preserve-comments";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/adjacent-text-and-comments/non-static-optimized/preserve-comments/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/adjacent-text-and-comments/non-static-optimized/preserve-comments/expected.js
@@ -25,7 +25,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-332m459dd46";
-tmpl.legacyStylesheetToken = "x-preserve-comments_preserve-comments";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/adjacent-text-and-comments/static-optimized/no-preserve-comments/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/adjacent-text-and-comments/static-optimized/no-preserve-comments/expected.js
@@ -22,7 +22,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-351u0g5gdss";
-tmpl.legacyStylesheetToken = "x-no-preserve-comments_no-preserve-comments";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/adjacent-text-and-comments/static-optimized/preserve-comments/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/adjacent-text-and-comments/static-optimized/preserve-comments/expected.js
@@ -19,7 +19,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-332m459dd46";
-tmpl.legacyStylesheetToken = "x-preserve-comments_preserve-comments";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-allow/expected.js
@@ -15,7 +15,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-q2oidhauj2";
-tmpl.legacyStylesheetToken = "x-attribute-allow_attribute-allow";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-crossorigin/expected.js
@@ -16,7 +16,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2bplc35dp3p";
-tmpl.legacyStylesheetToken = "x-attribute-crossorigin_attribute-crossorigin";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/non-static-optimized/attribute-href-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/non-static-optimized/attribute-href-expression/expected.js
@@ -37,8 +37,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7ng244mf2sm";
-tmpl.legacyStylesheetToken =
-  "x-attribute-href-expression_attribute-href-expression";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/non-static-optimized/attribute-href-no-hash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/non-static-optimized/attribute-href-no-hash/expected.js
@@ -36,7 +36,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1sm3fsuk72n";
-tmpl.legacyStylesheetToken = "x-attribute-href-no-hash_attribute-href-no-hash";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/non-static-optimized/attribute-href-with-id-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/non-static-optimized/attribute-href-with-id-expression/expected.js
@@ -52,8 +52,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4s0jmj9uli4";
-tmpl.legacyStylesheetToken =
-  "x-attribute-href-with-id-expression_attribute-href-with-id-expression";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/non-static-optimized/attribute-href-with-id-no-hash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/non-static-optimized/attribute-href-with-id-no-hash/expected.js
@@ -46,8 +46,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-37mnkrd5rqc";
-tmpl.legacyStylesheetToken =
-  "x-attribute-href-with-id-no-hash_attribute-href-with-id-no-hash";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/non-static-optimized/attribute-href-with-id/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/non-static-optimized/attribute-href-with-id/expected.js
@@ -52,7 +52,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-k7u0u67but";
-tmpl.legacyStylesheetToken = "x-attribute-href-with-id_attribute-href-with-id";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/non-static-optimized/attribute-href/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/non-static-optimized/attribute-href/expected.js
@@ -36,7 +36,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5jt7h1qitjc";
-tmpl.legacyStylesheetToken = "x-attribute-href_attribute-href";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/static-optimized/attribute-href-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/static-optimized/attribute-href-expression/expected.js
@@ -43,8 +43,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7ng244mf2sm";
-tmpl.legacyStylesheetToken =
-  "x-attribute-href-expression_attribute-href-expression";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/static-optimized/attribute-href-no-hash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/static-optimized/attribute-href-no-hash/expected.js
@@ -14,7 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1sm3fsuk72n";
-tmpl.legacyStylesheetToken = "x-attribute-href-no-hash_attribute-href-no-hash";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/static-optimized/attribute-href-with-id-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/static-optimized/attribute-href-with-id-expression/expected.js
@@ -60,8 +60,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4s0jmj9uli4";
-tmpl.legacyStylesheetToken =
-  "x-attribute-href-with-id-expression_attribute-href-with-id-expression";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/static-optimized/attribute-href-with-id-no-hash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/static-optimized/attribute-href-with-id-no-hash/expected.js
@@ -30,8 +30,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-37mnkrd5rqc";
-tmpl.legacyStylesheetToken =
-  "x-attribute-href-with-id-no-hash_attribute-href-with-id-no-hash";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/static-optimized/attribute-href-with-id/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/static-optimized/attribute-href-with-id/expected.js
@@ -60,7 +60,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-k7u0u67but";
-tmpl.legacyStylesheetToken = "x-attribute-href-with-id_attribute-href-with-id";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/static-optimized/attribute-href/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-href/static-optimized/attribute-href/expected.js
@@ -14,7 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5jt7h1qitjc";
-tmpl.legacyStylesheetToken = "x-attribute-href_attribute-href";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-part/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-part/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4plj0m3hj0";
-tmpl.legacyStylesheetToken = "x-attribute-part_attribute-part";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-props-transform/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-props-transform/expected.js
@@ -84,8 +84,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6dvmnra325n";
-tmpl.legacyStylesheetToken =
-  "x-attribute-props-transform_attribute-props-transform";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-underscore/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-underscore/expected.js
@@ -32,7 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-36q7c97l1ni";
-tmpl.legacyStylesheetToken = "x-attribute-underscore_attribute-underscore";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-uppercase/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/attribute-uppercase/expected.js
@@ -22,7 +22,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-uguh0pjd13";
-tmpl.legacyStylesheetToken = "x-attribute-uppercase_attribute-uppercase";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/hidden-global-attr/expected.js
@@ -81,7 +81,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5hma34rpdl8";
-tmpl.legacyStylesheetToken = "x-hidden-global-attr_hidden-global-attr";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attribute/required/expected.js
@@ -100,7 +100,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3ohsg11uo67";
-tmpl.legacyStylesheetToken = "x-required_required";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean-attributes-valid/expected.js
@@ -50,8 +50,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3s2d8ffesnq";
-tmpl.legacyStylesheetToken =
-  "x-boolean-attributes-valid_boolean-attributes-valid";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/boolean/expected.js
@@ -24,7 +24,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7c5u711os5r";
-tmpl.legacyStylesheetToken = "x-boolean_boolean";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class-dynamic-deoptimized-with-object-binding/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class-dynamic-deoptimized-with-object-binding/expected.js
@@ -14,8 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5tqvhdlbj7o";
-tmpl.legacyStylesheetToken =
-  "x-class-dynamic-deoptimized-with-object-binding_class-dynamic-deoptimized-with-object-binding";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class-dynamic-deoptimized-without-object-binding/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class-dynamic-deoptimized-without-object-binding/expected.js
@@ -14,8 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2rtjj54ske2";
-tmpl.legacyStylesheetToken =
-  "x-class-dynamic-deoptimized-without-object-binding_class-dynamic-deoptimized-without-object-binding";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class-dynamic-with-object-binding/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class-dynamic-with-object-binding/expected.js
@@ -24,8 +24,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-agbrffqjb4";
-tmpl.legacyStylesheetToken =
-  "x-class-dynamic-with-object-binding_class-dynamic-with-object-binding";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class-dynamic-without-object-binding/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class-dynamic-without-object-binding/expected.js
@@ -20,8 +20,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5euj2le4176";
-tmpl.legacyStylesheetToken =
-  "x-class-dynamic-without-object-binding_class-dynamic-without-object-binding";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/class/expected.js
@@ -24,7 +24,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-44l3bs9cc8q";
-tmpl.legacyStylesheetToken = "x-class_class";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset-complex/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-71sssdb1eho";
-tmpl.legacyStylesheetToken = "x-dataset-complex_dataset-complex";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/dataset/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6p7revfogca";
-tmpl.legacyStylesheetToken = "x-dataset_dataset";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/duplicate-props/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/duplicate-props/expected.js
@@ -26,7 +26,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2tn6o48t2v1";
-tmpl.legacyStylesheetToken = "x-duplicate-props_duplicate-props";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/error-empty-value/expected.js
@@ -21,7 +21,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5kto7mbkvvs";
-tmpl.legacyStylesheetToken = "x-error-empty-value_error-empty-value";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/escaped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/escaped/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-20g0qi2hoa7";
-tmpl.legacyStylesheetToken = "x-escaped_escaped";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-input/expected.js
@@ -22,7 +22,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4dafm4d1lfh";
-tmpl.legacyStylesheetToken = "x-html-input_html-input";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag-invalid/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-31vb55krkoh";
-tmpl.legacyStylesheetToken = "x-html-tag-invalid_html-tag-invalid";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/html-tag/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-qbql3m9vn6";
-tmpl.legacyStylesheetToken = "x-html-tag_html-tag";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/id/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/id/expected.js
@@ -117,7 +117,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6rsnvsuaeq1";
-tmpl.legacyStylesheetToken = "x-id_id";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/mixed-props-attrs/expected.js
@@ -81,7 +81,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-cfdictrqeg";
-tmpl.legacyStylesheetToken = "x-mixed-props-attrs_mixed-props-attrs";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/expression/not-scoped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/expression/not-scoped/expected.js
@@ -26,7 +26,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-68v9rhsbkkg";
-tmpl.legacyStylesheetToken = "x-not-scoped_not-scoped";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/expression/scoped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/expression/scoped/expected.js
@@ -34,7 +34,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-8anf07i38v";
-tmpl.legacyStylesheetToken = "x-scoped_scoped";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/not-scoped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/not-scoped/expected.js
@@ -20,7 +20,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-68v9rhsbkkg";
-tmpl.legacyStylesheetToken = "x-not-scoped_not-scoped";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/scoped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/scoped/expected.js
@@ -25,7 +25,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-8anf07i38v";
-tmpl.legacyStylesheetToken = "x-scoped_scoped";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/static-vs-non-static-optimized/non-static-optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/static-vs-non-static-optimized/non-static-optimized/expected.js
@@ -89,7 +89,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-d9girnpd2k";
-tmpl.legacyStylesheetToken = "x-non-static-optimized_non-static-optimized";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/static-vs-non-static-optimized/static-optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/scoped-id/static-vs-non-static-optimized/static-optimized/expected.js
@@ -70,7 +70,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7n28hdp1g54";
-tmpl.legacyStylesheetToken = "x-static-optimized_static-optimized";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/expression/expected.js
@@ -33,7 +33,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-602vdkaauac";
-tmpl.legacyStylesheetToken = "x-expression_expression";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static-optimized/not-optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static-optimized/not-optimized/expected.js
@@ -88,7 +88,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-76f842e7084";
-tmpl.legacyStylesheetToken = "x-not-optimized_not-optimized";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static-optimized/optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static-optimized/optimized/expected.js
@@ -16,7 +16,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6dfvqpqt2d0";
-tmpl.legacyStylesheetToken = "x-optimized_optimized";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static/false-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static/false-value/expected.js
@@ -32,7 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4oh91tt7sup";
-tmpl.legacyStylesheetToken = "x-false-value_false-value";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static/truthy-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/spellcheck/static/truthy-value/expected.js
@@ -32,7 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7vvscilgpnd";
-tmpl.legacyStylesheetToken = "x-truthy-value_truthy-value";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/style/expected.js
@@ -82,7 +82,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2ubtal7ecmb";
-tmpl.legacyStylesheetToken = "x-style_style";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/tabindex-computed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/tabindex-computed/expected.js
@@ -34,7 +34,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-576tik9amt5";
-tmpl.legacyStylesheetToken = "x-tabindex-computed_tabindex-computed";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/underscore/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/underscore/expected.js
@@ -39,7 +39,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5b02te4b5vj";
-tmpl.legacyStylesheetToken = "x-underscore_underscore";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unknown-html-tag-known-attribute/expected.js
@@ -10,8 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5vl7nbrekm";
-tmpl.legacyStylesheetToken =
-  "x-unknown-html-tag-known-attribute_unknown-html-tag-known-attribute";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unquoted-value-unary/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/unquoted-value-unary/expected.js
@@ -22,7 +22,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-682q3s59guc";
-tmpl.legacyStylesheetToken = "x-unquoted-value-unary_unquoted-value-unary";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/valid-hyphen-attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/valid-hyphen-attribute/expected.js
@@ -74,7 +74,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4rpc6om82jo";
-tmpl.legacyStylesheetToken = "x-valid-hyphen-attribute_valid-hyphen-attribute";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/valid-hyphen-underscore/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/valid-hyphen-underscore/expected.js
@@ -32,8 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-52sd2331v5c";
-tmpl.legacyStylesheetToken =
-  "x-valid-hyphen-underscore_valid-hyphen-underscore";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/valid-non-alphanumeric/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/attributes/valid-non-alphanumeric/expected.js
@@ -32,7 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7m0fdesmolf";
-tmpl.legacyStylesheetToken = "x-valid-non-alphanumeric_valid-non-alphanumeric";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/class/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-44l3bs9cc8q";
-tmpl.legacyStylesheetToken = "x-class_class";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/comment/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/comment/expected.js
@@ -9,7 +9,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-23hkc2o3p7d";
-tmpl.legacyStylesheetToken = "x-comment_comment";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/html-entities/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/html-entities/expected.js
@@ -14,7 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-582p6pifafh";
-tmpl.legacyStylesheetToken = "x-html-entities_html-entities";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-expression/expected.js
@@ -20,7 +20,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1e7dui2pf3p";
-tmpl.legacyStylesheetToken = "x-style-expression_style-expression";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-important/expected.js
@@ -14,7 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2pusua1q7v3";
-tmpl.legacyStylesheetToken = "x-style-important_style-important";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/style-static/expected.js
@@ -16,7 +16,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7g8p0uutims";
-tmpl.legacyStylesheetToken = "x-style-static_style-static";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg-with-iteration/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg-with-iteration/expected.js
@@ -41,7 +41,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4k8f5oq0rrb";
-tmpl.legacyStylesheetToken = "x-svg-with-iteration_svg-with-iteration";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/svg/expected.js
@@ -32,7 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3j142gdvja7";
-tmpl.legacyStylesheetToken = "x-svg_svg";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/template/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2it5vhebv0i";
-tmpl.legacyStylesheetToken = "x-template_template";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/base/text/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/base/text/expected.js
@@ -9,7 +9,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3q20iingih8";
-tmpl.legacyStylesheetToken = "x-text_text";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/basic/expected.js
@@ -13,7 +13,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1rssj1tib70";
-tmpl.legacyStylesheetToken = "x-basic_basic";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-for-each/expected.js
@@ -34,7 +34,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6fjo1bal55e";
-tmpl.legacyStylesheetToken = "x-directive-for-each_directive-for-each";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/directive-if/expected.js
@@ -16,7 +16,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6a2nu6tldoq";
-tmpl.legacyStylesheetToken = "x-directive-if_directive-if";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/preserve-html-comments-option/expected.js
@@ -13,8 +13,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-gaekmoo0tf";
-tmpl.legacyStylesheetToken =
-  "x-preserve-html-comments-option_preserve-html-comments-option";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/comments/slots/expected.js
@@ -23,7 +23,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-54mco27ror1";
-tmpl.legacyStylesheetToken = "x-slots_slots";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/only-child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/only-child/expected.js
@@ -14,7 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6eo18r0urvs";
-tmpl.legacyStylesheetToken = "x-only-child_only-child";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/sibbling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-dynamic/sibbling/expected.js
@@ -19,7 +19,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3gcvleqa6si";
-tmpl.legacyStylesheetToken = "x-sibbling_sibbling";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-external/custom-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-external/custom-element/expected.js
@@ -25,7 +25,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-i4i43q1672";
-tmpl.legacyStylesheetToken = "x-custom-element_custom-element";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-external/data-passing/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-external/data-passing/expected.js
@@ -31,7 +31,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-74096niamqs";
-tmpl.legacyStylesheetToken = "x-data-passing_data-passing";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/children/expected.js
@@ -79,7 +79,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7t3q3ieetp5";
-tmpl.legacyStylesheetToken = "x-children_children";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/dynamic-component/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/dynamic-component/expected.js
@@ -29,7 +29,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2aur4v16kjs";
-tmpl.legacyStylesheetToken = "x-dynamic-component_dynamic-component";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/foreach-with-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/foreach-with-if/expected.js
@@ -32,7 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5c8pq6oa1m7";
-tmpl.legacyStylesheetToken = "x-foreach-with-if_foreach-with-if";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-index/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-index/expected.js
@@ -34,7 +34,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-a96me6lsm3";
-tmpl.legacyStylesheetToken = "x-inline-index_inline-index";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-item/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-item/expected.js
@@ -30,7 +30,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4tcbnpm7lck";
-tmpl.legacyStylesheetToken = "x-inline-item_inline-item";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-outside-scope-reference/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-outside-scope-reference/expected.js
@@ -31,8 +31,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-ijo9j3k237";
-tmpl.legacyStylesheetToken =
-  "x-inline-outside-scope-reference_inline-outside-scope-reference";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-refence-item/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-refence-item/expected.js
@@ -38,7 +38,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3uqjlat37b3";
-tmpl.legacyStylesheetToken = "x-inline-refence-item_inline-refence-item";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline-sibling/expected.js
@@ -43,7 +43,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-48n2bhseivd";
-tmpl.legacyStylesheetToken = "x-inline-sibling_inline-sibling";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/inline/expected.js
@@ -26,7 +26,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-c3t4t4g81u";
-tmpl.legacyStylesheetToken = "x-inline_inline";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/static-content-optimization/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/static-content-optimization/expected.js
@@ -63,8 +63,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-40fo8n330sd";
-tmpl.legacyStylesheetToken =
-  "x-static-content-optimization_static-content-optimization";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-multiple-children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-multiple-children/expected.js
@@ -36,8 +36,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4phdsojc879";
-tmpl.legacyStylesheetToken =
-  "x-template-multiple-children_template-multiple-children";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-outside-scope-reference/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-outside-scope-reference/expected.js
@@ -44,8 +44,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5jakk9rc2bg";
-tmpl.legacyStylesheetToken =
-  "x-template-outside-scope-reference_template-outside-scope-reference";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-sibling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template-sibling/expected.js
@@ -43,7 +43,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4clse9dpbrh";
-tmpl.legacyStylesheetToken = "x-template-sibling_template-sibling";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-for-each/template/expected.js
@@ -30,7 +30,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2it5vhebv0i";
-tmpl.legacyStylesheetToken = "x-template_template";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/dynamic-component/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/dynamic-component/expected.js
@@ -28,7 +28,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2aur4v16kjs";
-tmpl.legacyStylesheetToken = "x-dynamic-component_dynamic-component";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-custom-element/expected.js
@@ -13,8 +13,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6nf737430vn";
-tmpl.legacyStylesheetToken =
-  "x-inline-both-custom-element_inline-both-custom-element";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-both-standard-element/expected.js
@@ -10,8 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5i94se9dprh";
-tmpl.legacyStylesheetToken =
-  "x-inline-both-standard-element_inline-both-standard-element";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-multiple/expected.js
@@ -21,7 +21,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1ehv46vni88";
-tmpl.legacyStylesheetToken = "x-inline-multiple_inline-multiple";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-sibling-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/inline-sibling-static/expected.js
@@ -25,7 +25,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1mpsc4up5i6";
-tmpl.legacyStylesheetToken = "x-inline-sibling-static_inline-sibling-static";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/strict-true/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/strict-true/expected.js
@@ -17,7 +17,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5smng9s8ocs";
-tmpl.legacyStylesheetToken = "x-strict-true_strict-true";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-both/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7g1fl59spul";
-tmpl.legacyStylesheetToken = "x-template-both_template-both";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-expression/expected.js
@@ -20,7 +20,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5uvenajcmlb";
-tmpl.legacyStylesheetToken = "x-template-expression_template-expression";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-if-else/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-if-else/expected.js
@@ -14,7 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-f9q64bko29";
-tmpl.legacyStylesheetToken = "x-template-if-else_template-if-else";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-multiple/expected.js
@@ -16,7 +16,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-766do8vn4oi";
-tmpl.legacyStylesheetToken = "x-template-multiple_template-multiple";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template-sibiling/expected.js
@@ -21,7 +21,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4m9tr5ct9rp";
-tmpl.legacyStylesheetToken = "x-template-sibiling_template-sibiling";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-if/template/expected.js
@@ -20,7 +20,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2it5vhebv0i";
-tmpl.legacyStylesheetToken = "x-template_template";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/usage-if-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/usage-if-for-each/expected.js
@@ -64,7 +64,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5m49nb9vba";
-tmpl.legacyStylesheetToken = "x-usage-if-for-each_usage-if-for-each";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-inner-html/valid/expected.js
@@ -36,7 +36,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2jeqhu792ub";
-tmpl.legacyStylesheetToken = "x-valid_valid";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/inline-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/inline-iterator/expected.js
@@ -47,7 +47,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4sfvv4u31r7";
-tmpl.legacyStylesheetToken = "x-inline-iterator_inline-iterator";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-iterator/iterator/expected.js
@@ -47,7 +47,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-34811vn79s2";
-tmpl.legacyStylesheetToken = "x-iterator_iterator";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/component/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/component/expected.js
@@ -35,7 +35,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6a8uqob2ku4";
-tmpl.legacyStylesheetToken = "x-component_component";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/element/expected.js
@@ -30,7 +30,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6bg8rvlcmf8";
-tmpl.legacyStylesheetToken = "x-element_element";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/for-each/expected.js
@@ -30,7 +30,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5ib8hg9k6nn";
-tmpl.legacyStylesheetToken = "x-for-each_for-each";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-identifier/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-identifier/expected.js
@@ -36,8 +36,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-mk60ujrh6t";
-tmpl.legacyStylesheetToken =
-  "x-iterator-key-identifier_iterator-key-identifier";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-member-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-key-member-expression/expected.js
@@ -36,8 +36,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-i4hhmnuqb3";
-tmpl.legacyStylesheetToken =
-  "x-iterator-key-member-expression_iterator-key-member-expression";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-nested-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-nested-each/expected.js
@@ -41,7 +41,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4mlq09kftp4";
-tmpl.legacyStylesheetToken = "x-iterator-nested-each_iterator-nested-each";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-value-as-key/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/iterator-value-as-key/expected.js
@@ -36,7 +36,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-85bmjhkq70";
-tmpl.legacyStylesheetToken = "x-iterator-value-as-key_iterator-value-as-key";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/nested-iterator-if/expected.js
@@ -53,7 +53,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-s0e1j42tjc";
-tmpl.legacyStylesheetToken = "x-nested-iterator-if_nested-iterator-if";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-key/outside-iterator/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7j8af1qds6j";
-tmpl.legacyStylesheetToken = "x-outside-iterator_outside-iterator";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/directive-for-each/html-elements/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/directive-for-each/html-elements/expected.js
@@ -28,7 +28,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5n98hcrisnv";
-tmpl.legacyStylesheetToken = "x-html-elements_html-elements";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/directive-for-each/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/directive-for-each/template/expected.js
@@ -28,7 +28,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2it5vhebv0i";
-tmpl.legacyStylesheetToken = "x-template_template";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/if-else/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/if-else/expected.js
@@ -21,7 +21,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-59e6ud6dj78";
-tmpl.legacyStylesheetToken = "x-if-else_if-else";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/if-elseif-else-nested/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/if-elseif-else-nested/expected.js
@@ -50,7 +50,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2ejbkifb08c";
-tmpl.legacyStylesheetToken = "x-if-elseif-else-nested_if-elseif-else-nested";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/if-elseif-else/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/if-elseif-else/expected.js
@@ -28,7 +28,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-78th695ov3g";
-tmpl.legacyStylesheetToken = "x-if-elseif-else_if-elseif-else";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/if-elseif-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/if-elseif-multiple/expected.js
@@ -31,7 +31,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4ht1tjprfr4";
-tmpl.legacyStylesheetToken = "x-if-elseif-multiple_if-elseif-multiple";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/if-elseif/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/if-elseif/expected.js
@@ -27,7 +27,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-701s5vgen3k";
-tmpl.legacyStylesheetToken = "x-if-elseif_if-elseif";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/if/expected.js
@@ -16,7 +16,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-24vr4p2ioo5";
-tmpl.legacyStylesheetToken = "x-if_if";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/inline/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic-components/inline/expected.js
@@ -55,7 +55,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-c3t4t4g81u";
-tmpl.legacyStylesheetToken = "x-inline_inline";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-else/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-else/expected.js
@@ -31,7 +31,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-59e6ud6dj78";
-tmpl.legacyStylesheetToken = "x-if-else_if-else";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif-else-nested/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif-else-nested/expected.js
@@ -56,7 +56,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2ejbkifb08c";
-tmpl.legacyStylesheetToken = "x-if-elseif-else-nested_if-elseif-else-nested";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif-else/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif-else/expected.js
@@ -34,7 +34,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-78th695ov3g";
-tmpl.legacyStylesheetToken = "x-if-elseif-else_if-elseif-else";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif-multiple/expected.js
@@ -37,7 +37,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4ht1tjprfr4";
-tmpl.legacyStylesheetToken = "x-if-elseif-multiple_if-elseif-multiple";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if-elseif/expected.js
@@ -33,7 +33,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-701s5vgen3k";
-tmpl.legacyStylesheetToken = "x-if-elseif_if-elseif";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/dynamic/if/expected.js
@@ -26,7 +26,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-24vr4p2ioo5";
-tmpl.legacyStylesheetToken = "x-if_if";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-else/components/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-else/components/expected.js
@@ -25,7 +25,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1j5adk6vpb3";
-tmpl.legacyStylesheetToken = "x-components_components";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-else/html-elements/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-else/html-elements/expected.js
@@ -15,7 +15,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5n98hcrisnv";
-tmpl.legacyStylesheetToken = "x-html-elements_html-elements";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-else/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-else/template/expected.js
@@ -13,7 +13,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2it5vhebv0i";
-tmpl.legacyStylesheetToken = "x-template_template";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif-else/components/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif-else/components/expected.js
@@ -35,7 +35,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1j5adk6vpb3";
-tmpl.legacyStylesheetToken = "x-components_components";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif-else/html-elements/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif-else/html-elements/expected.js
@@ -18,7 +18,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5n98hcrisnv";
-tmpl.legacyStylesheetToken = "x-html-elements_html-elements";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif-else/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif-else/template/expected.js
@@ -15,7 +15,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2it5vhebv0i";
-tmpl.legacyStylesheetToken = "x-template_template";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif/components/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif/components/expected.js
@@ -38,7 +38,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1j5adk6vpb3";
-tmpl.legacyStylesheetToken = "x-components_components";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif/html-elements/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif/html-elements/expected.js
@@ -17,7 +17,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5n98hcrisnv";
-tmpl.legacyStylesheetToken = "x-html-elements_html-elements";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-elseif/template/expected.js
@@ -15,7 +15,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2it5vhebv0i";
-tmpl.legacyStylesheetToken = "x-template_template";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-only/components/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-only/components/expected.js
@@ -17,7 +17,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1j5adk6vpb3";
-tmpl.legacyStylesheetToken = "x-components_components";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-only/html-elements/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-only/html-elements/expected.js
@@ -14,7 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5n98hcrisnv";
-tmpl.legacyStylesheetToken = "x-html-elements_html-elements";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-only/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/if-only/template/expected.js
@@ -11,7 +11,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2it5vhebv0i";
-tmpl.legacyStylesheetToken = "x-template_template";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/interop/foreach-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/interop/foreach-if/expected.js
@@ -25,7 +25,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-s9adiv6ieg";
-tmpl.legacyStylesheetToken = "x-foreach-if_foreach-if";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/mixed-elements/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/mixed-elements/expected.js
@@ -33,7 +33,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-c3g2fma7qf";
-tmpl.legacyStylesheetToken = "x-mixed-elements_mixed-elements";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/nested/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/nested/expected.js
@@ -114,7 +114,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-ud1n1pkbjc";
-tmpl.legacyStylesheetToken = "x-nested_nested";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/preserve-comments/preserve-comments-disabled/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/preserve-comments/preserve-comments-disabled/expected.js
@@ -13,8 +13,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2gme9b0kobe";
-tmpl.legacyStylesheetToken =
-  "x-preserve-comments-disabled_preserve-comments-disabled";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/duplicate-slots-warning/not-in-same-condition-tree/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/duplicate-slots-warning/not-in-same-condition-tree/expected.js
@@ -62,8 +62,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = ["outside-slot"];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5hdhvq4c67h";
-tmpl.legacyStylesheetToken =
-  "x-not-in-same-condition-tree_not-in-same-condition-tree";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/duplicate-slots-warning/same-branch-condition-tree/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/duplicate-slots-warning/same-branch-condition-tree/expected.js
@@ -39,8 +39,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = ["nested-slot"];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7498dhinp2o";
-tmpl.legacyStylesheetToken =
-  "x-same-branch-condition-tree_same-branch-condition-tree";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/duplicate-slots-warning/simple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/duplicate-slots-warning/simple/expected.js
@@ -43,7 +43,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = ["conditional-slot"];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1lae0rspni6";
-tmpl.legacyStylesheetToken = "x-simple_simple";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/named-slots/simple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/named-slots/simple/expected.js
@@ -41,7 +41,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1lae0rspni6";
-tmpl.legacyStylesheetToken = "x-simple_simple";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/valid-duplicate-slot-names/complex/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/valid-duplicate-slot-names/complex/expected.js
@@ -128,7 +128,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = ["conditional-slot", "nested-slot", "outer-slot"];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7dlc9jkp653";
-tmpl.legacyStylesheetToken = "x-complex_complex";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/valid-duplicate-slot-names/simple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/slots/valid-duplicate-slot-names/simple/expected.js
@@ -31,7 +31,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = ["conditional-slot"];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1lae0rspni6";
-tmpl.legacyStylesheetToken = "x-simple_simple";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/static-content-optimization/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/static-content-optimization/expected.js
@@ -101,8 +101,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-40fo8n330sd";
-tmpl.legacyStylesheetToken =
-  "x-static-content-optimization_static-content-optimization";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/with-siblings/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-lwc-if-else/with-siblings/expected.js
@@ -178,7 +178,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-17drfojvaju";
-tmpl.legacyStylesheetToken = "x-with-siblings_with-siblings";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-on/built-in-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-on/built-in-element/expected.js
@@ -18,7 +18,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1uv881g6g8o";
-tmpl.legacyStylesheetToken = "x-built-in-element_built-in-element";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-on/custom-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-on/custom-element/expected.js
@@ -19,7 +19,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-i4i43q1672";
-tmpl.legacyStylesheetToken = "x-custom-element_custom-element";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-on/dynamic-component/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-on/dynamic-component/expected.js
@@ -18,7 +18,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2aur4v16kjs";
-tmpl.legacyStylesheetToken = "x-dynamic-component_dynamic-component";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-on/inside-loop-global-var/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-on/inside-loop-global-var/expected.js
@@ -19,7 +19,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7u8n0d6m1f3";
-tmpl.legacyStylesheetToken = "x-inside-loop-global-var_inside-loop-global-var";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-on/inside-loop-local-var/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-on/inside-loop-local-var/expected.js
@@ -19,7 +19,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7tntl2iqog2";
-tmpl.legacyStylesheetToken = "x-inside-loop-local-var_inside-loop-local-var";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-ref/dynamic-components/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-ref/dynamic-components/expected.js
@@ -14,7 +14,6 @@ export default registerTemplate(tmpl);
 tmpl.hasRefs = true;
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-73vspqvsbp7";
-tmpl.legacyStylesheetToken = "x-dynamic-components_dynamic-components";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-ref/dynamic-ref/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-ref/dynamic-ref/expected.js
@@ -24,7 +24,6 @@ export default registerTemplate(tmpl);
 tmpl.hasRefs = true;
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-rok9vrf83v";
-tmpl.legacyStylesheetToken = "x-dynamic-ref_dynamic-ref";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-ref/static-container/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-ref/static-container/expected.js
@@ -14,7 +14,6 @@ export default registerTemplate(tmpl);
 tmpl.hasRefs = true;
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7160slcn7bl";
-tmpl.legacyStylesheetToken = "x-static-container_static-container";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-ref/valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-ref/valid/expected.js
@@ -14,7 +14,6 @@ export default registerTemplate(tmpl);
 tmpl.hasRefs = true;
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2jeqhu792ub";
-tmpl.legacyStylesheetToken = "x-valid_valid";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/shadow-template/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7bbrfmiqgq0";
-tmpl.legacyStylesheetToken = "x-shadow-template_shadow-template";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-render-mode/template/expected.js
@@ -33,7 +33,6 @@ tmpl.slots = ["", "forwarded", "named"];
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2it5vhebv0i";
-tmpl.legacyStylesheetToken = "x-template_template";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-spread/dynamic-components/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-spread/dynamic-components/expected.js
@@ -16,7 +16,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-73vspqvsbp7";
-tmpl.legacyStylesheetToken = "x-dynamic-components_dynamic-components";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-spread/no-renderer-hook/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-spread/no-renderer-hook/expected.js
@@ -23,7 +23,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-54kh0v6mpj0";
-tmpl.legacyStylesheetToken = "x-no-renderer-hook_no-renderer-hook";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-spread/valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/directive-spread/valid/expected.js
@@ -16,7 +16,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2jeqhu792ub";
-tmpl.legacyStylesheetToken = "x-valid_valid";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/dynamic-components/valid/attributes/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/dynamic-components/valid/attributes/expected.js
@@ -24,7 +24,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-33v8klcvlb2";
-tmpl.legacyStylesheetToken = "x-attributes_attributes";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/dynamic-components/valid/basic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/dynamic-components/valid/basic/expected.js
@@ -12,7 +12,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1rssj1tib70";
-tmpl.legacyStylesheetToken = "x-basic_basic";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/dynamic-components/valid/children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/dynamic-components/valid/children/expected.js
@@ -17,7 +17,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7t3q3ieetp5";
-tmpl.legacyStylesheetToken = "x-children_children";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/dynamic-components/valid/nested/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/dynamic-components/valid/nested/expected.js
@@ -53,7 +53,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-ud1n1pkbjc";
-tmpl.legacyStylesheetToken = "x-nested_nested";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/dynamic-components/valid/properties/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/dynamic-components/valid/properties/expected.js
@@ -17,7 +17,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3unrm1630av";
-tmpl.legacyStylesheetToken = "x-properties_properties";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/dynamic-components/valid/siblings/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/dynamic-components/valid/siblings/expected.js
@@ -18,7 +18,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1f6gdeblibr";
-tmpl.legacyStylesheetToken = "x-siblings_siblings";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/component/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/component/expected.js
@@ -25,7 +25,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6a8uqob2ku4";
-tmpl.legacyStylesheetToken = "x-component_component";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/multiple/non-static-optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/multiple/non-static-optimized/expected.js
@@ -21,7 +21,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-d9girnpd2k";
-tmpl.legacyStylesheetToken = "x-non-static-optimized_non-static-optimized";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/multiple/static-optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/multiple/static-optimized/expected.js
@@ -27,7 +27,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7n28hdp1g54";
-tmpl.legacyStylesheetToken = "x-static-optimized_static-optimized";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/non-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/non-static/expected.js
@@ -24,7 +24,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3ncpfrc8qob";
-tmpl.legacyStylesheetToken = "x-non-static_non-static";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/static/expected.js
@@ -25,7 +25,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-548g1ondp5s";
-tmpl.legacyStylesheetToken = "x-static_static";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/tag/expected.js
@@ -36,7 +36,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7v5hvorhnq1";
-tmpl.legacyStylesheetToken = "x-tag_tag";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/events/type-valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/events/type-valid/expected.js
@@ -67,7 +67,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-56j34l79noq";
-tmpl.legacyStylesheetToken = "x-type-valid_type-valid";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/compatibility/base/html-entities/experimental-complex-expressions-true/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/compatibility/base/html-entities/experimental-complex-expressions-true/expected.js
@@ -14,8 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5t3hn3vkg17";
-tmpl.legacyStylesheetToken =
-  "x-experimental-complex-expressions-true_experimental-complex-expressions-true";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/compatibility/base/html-entities/static-content-optimization-false/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/compatibility/base/html-entities/static-content-optimization-false/expected.js
@@ -18,8 +18,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2m6fifibgq7";
-tmpl.legacyStylesheetToken =
-  "x-static-content-optimization-false_static-content-optimization-false";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/compatibility/directive-if/template-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/compatibility/directive-if/template-expression/expected.js
@@ -20,7 +20,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5uvenajcmlb";
-tmpl.legacyStylesheetToken = "x-template-expression_template-expression";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/array-expr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/array-expr/expected.js
@@ -28,7 +28,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4905ctci1tk";
-tmpl.legacyStylesheetToken = "x-array-expr_array-expr";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/arrowfn-scoped-vars/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/arrowfn-scoped-vars/expected.js
@@ -22,7 +22,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4jav1e64a2p";
-tmpl.legacyStylesheetToken = "x-arrowfn-scoped-vars_arrowfn-scoped-vars";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/assignment-inside-arrow/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/assignment-inside-arrow/expected.js
@@ -25,8 +25,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7uuiq9sbjjh";
-tmpl.legacyStylesheetToken =
-  "x-assignment-inside-arrow_assignment-inside-arrow";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/binary-expr-arithmetic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/binary-expr-arithmetic/expected.js
@@ -65,7 +65,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-dhsrcdf074";
-tmpl.legacyStylesheetToken = "x-binary-expr-arithmetic_binary-expr-arithmetic";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/binary-expr-bit-shift/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/binary-expr-bit-shift/expected.js
@@ -34,7 +34,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5p79c89e8dj";
-tmpl.legacyStylesheetToken = "x-binary-expr-bit-shift_binary-expr-bit-shift";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/binary-expr-bitwise/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/binary-expr-bitwise/expected.js
@@ -54,7 +54,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1tvo3p3ap2n";
-tmpl.legacyStylesheetToken = "x-binary-expr-bitwise_binary-expr-bitwise";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/binary-expr-logical/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/binary-expr-logical/expected.js
@@ -43,7 +43,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4oq3a4d8tu9";
-tmpl.legacyStylesheetToken = "x-binary-expr-logical_binary-expr-logical";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/binary-expr-relational/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/binary-expr-relational/expected.js
@@ -38,7 +38,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-39eucbo25ji";
-tmpl.legacyStylesheetToken = "x-binary-expr-relational_binary-expr-relational";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/boolean-literal/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/boolean-literal/expected.js
@@ -39,7 +39,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-34ejl9uakkr";
-tmpl.legacyStylesheetToken = "x-boolean-literal_boolean-literal";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/call-expr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/call-expr/expected.js
@@ -32,7 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6gcm7h7fbpk";
-tmpl.legacyStylesheetToken = "x-call-expr_call-expr";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/computed-property/expected.js
@@ -39,7 +39,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-14g777mv3bo";
-tmpl.legacyStylesheetToken = "x-computed-property_computed-property";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/identifier/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/identifier/expected.js
@@ -65,7 +65,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3fopfkgu5fe";
-tmpl.legacyStylesheetToken = "x-identifier_identifier";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/iterator/expected.js
@@ -31,7 +31,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-34811vn79s2";
-tmpl.legacyStylesheetToken = "x-iterator_iterator";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/member-expr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/member-expr/expected.js
@@ -43,7 +43,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2a1sbir7isn";
-tmpl.legacyStylesheetToken = "x-member-expr_member-expr";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/null-literal/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/null-literal/expected.js
@@ -30,7 +30,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7hg93bi1m0a";
-tmpl.legacyStylesheetToken = "x-null-literal_null-literal";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/numeric-literal-binary/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/numeric-literal-binary/expected.js
@@ -21,7 +21,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6bhl2sst5pp";
-tmpl.legacyStylesheetToken = "x-numeric-literal-binary_numeric-literal-binary";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/numeric-literal-float/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/numeric-literal-float/expected.js
@@ -21,7 +21,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-72hs29kfuv6";
-tmpl.legacyStylesheetToken = "x-numeric-literal-float_numeric-literal-float";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/numeric-literal-hex/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/numeric-literal-hex/expected.js
@@ -21,7 +21,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5qbiqmmuenu";
-tmpl.legacyStylesheetToken = "x-numeric-literal-hex_numeric-literal-hex";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/numeric-literal-int/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/numeric-literal-int/expected.js
@@ -30,7 +30,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6k6g2c8gfo5";
-tmpl.legacyStylesheetToken = "x-numeric-literal-int_numeric-literal-int";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/numeric-literal-octal/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/numeric-literal-octal/expected.js
@@ -21,7 +21,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6o7bdhtgbub";
-tmpl.legacyStylesheetToken = "x-numeric-literal-octal_numeric-literal-octal";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/object-expr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/object-expr/expected.js
@@ -35,7 +35,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6baembf2687";
-tmpl.legacyStylesheetToken = "x-object-expr_object-expr";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/optional-call-expr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/optional-call-expr/expected.js
@@ -32,7 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-pgc7san7rd";
-tmpl.legacyStylesheetToken = "x-optional-call-expr_optional-call-expr";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/string-literal/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/string-literal/expected.js
@@ -23,7 +23,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-76sj5dn4mci";
-tmpl.legacyStylesheetToken = "x-string-literal_string-literal";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/template-literal-tagged/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/template-literal-tagged/expected.js
@@ -32,8 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1bebniq3rl9";
-tmpl.legacyStylesheetToken =
-  "x-template-literal-tagged_template-literal-tagged";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/template-literal/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/template-literal/expected.js
@@ -32,7 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3un1tvam1t0";
-tmpl.legacyStylesheetToken = "x-template-literal_template-literal";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/ternary/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/ternary/expected.js
@@ -60,7 +60,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2aoelu7e1r9";
-tmpl.legacyStylesheetToken = "x-ternary_ternary";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/text-node-adjacency/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/text-node-adjacency/expected.js
@@ -50,7 +50,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6kcfs482gvt";
-tmpl.legacyStylesheetToken = "x-text-node-adjacency_text-node-adjacency";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/typeof-operator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/typeof-operator/expected.js
@@ -22,7 +22,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2o1pscqo7n3";
-tmpl.legacyStylesheetToken = "x-typeof-operator_typeof-operator";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/unary-expr-bitwise/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/unary-expr-bitwise/expected.js
@@ -32,7 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3c5ct80lpft";
-tmpl.legacyStylesheetToken = "x-unary-expr-bitwise_unary-expr-bitwise";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/unary-expr-logical/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/unary-expr-logical/expected.js
@@ -22,7 +22,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1s8kdgpsntb";
-tmpl.legacyStylesheetToken = "x-unary-expr-logical_unary-expr-logical";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/update-inside-arrow/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/update-inside-arrow/expected.js
@@ -25,7 +25,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2nerumn9on6";
-tmpl.legacyStylesheetToken = "x-update-inside-arrow_update-inside-arrow";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/void-operator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression-complex/valid/void-operator/expected.js
@@ -22,7 +22,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3ttvboh650o";
-tmpl.legacyStylesheetToken = "x-void-operator_void-operator";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-deep/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-deep/expected.js
@@ -24,7 +24,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6paibrvdh9b";
-tmpl.legacyStylesheetToken = "x-attribute-deep_attribute-deep";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-multiple/expected.js
@@ -31,7 +31,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3qo8eqopgq6";
-tmpl.legacyStylesheetToken = "x-attribute-multiple_attribute-multiple";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-quoted/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute-quoted/expected.js
@@ -52,7 +52,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6n0ltrg1cd2";
-tmpl.legacyStylesheetToken = "x-attribute-quoted_attribute-quoted";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/attribute/expected.js
@@ -24,7 +24,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4sr9e6p0fgr";
-tmpl.legacyStylesheetToken = "x-attribute_attribute";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/computed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/computed/expected.js
@@ -29,7 +29,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5m7vih8u5bq";
-tmpl.legacyStylesheetToken = "x-computed_computed";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/empty-paranthesis/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/empty-paranthesis/expected.js
@@ -14,7 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-53hv0hq3g9i";
-tmpl.legacyStylesheetToken = "x-empty-paranthesis_empty-paranthesis";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/escaped/expected.js
@@ -15,7 +15,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-20g0qi2hoa7";
-tmpl.legacyStylesheetToken = "x-escaped_escaped";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/parenthesis/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/parenthesis/expected.js
@@ -34,7 +34,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6uuifvb6qqe";
-tmpl.legacyStylesheetToken = "x-parenthesis_parenthesis";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/quoted-empty-paranthesis/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/quoted-empty-paranthesis/expected.js
@@ -14,8 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-70a5ikbn661";
-tmpl.legacyStylesheetToken =
-  "x-quoted-empty-paranthesis_quoted-empty-paranthesis";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/simple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/simple/expected.js
@@ -9,7 +9,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1lae0rspni6";
-tmpl.legacyStylesheetToken = "x-simple_simple";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/tag/expected.js
@@ -18,7 +18,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7v5hvorhnq1";
-tmpl.legacyStylesheetToken = "x-tag_tag";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/trailing-spaces/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/expression/trailing-spaces/expected.js
@@ -9,7 +9,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2t7oqs531sa";
-tmpl.legacyStylesheetToken = "x-trailing-spaces_trailing-spaces";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/non-optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/non-optimized/expected.js
@@ -12,7 +12,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-71tdq7g4m0k";
-tmpl.legacyStylesheetToken = "x-non-optimized_non-optimized";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/backslash-in-tag-name/optimized/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6dfvqpqt2d0";
-tmpl.legacyStylesheetToken = "x-optimized_optimized";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/html-tags/unkown-element/expected.js
@@ -24,7 +24,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-616604d1ker";
-tmpl.legacyStylesheetToken = "x-unkown-element_unkown-element";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/input/non-static-optimized/dynamic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/input/non-static-optimized/dynamic/expected.js
@@ -260,7 +260,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-32cmakp1ss8";
-tmpl.legacyStylesheetToken = "x-dynamic_dynamic";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/input/non-static-optimized/static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/input/non-static-optimized/static/expected.js
@@ -165,7 +165,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-548g1ondp5s";
-tmpl.legacyStylesheetToken = "x-static_static";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/input/static-optimized/dynamic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/input/static-optimized/dynamic/expected.js
@@ -338,7 +338,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-32cmakp1ss8";
-tmpl.legacyStylesheetToken = "x-dynamic_dynamic";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/input/static-optimized/static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/input/static-optimized/static/expected.js
@@ -135,7 +135,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-548g1ondp5s";
-tmpl.legacyStylesheetToken = "x-static_static";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-dom/comments/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-dom/comments/expected.js
@@ -17,7 +17,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-54op2j1dqne";
-tmpl.legacyStylesheetToken = "x-comments_comments";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-dom/manual/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-dom/manual/expected.js
@@ -17,7 +17,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2usko5jeitd";
-tmpl.legacyStylesheetToken = "x-manual_manual";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-tags/invalid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/lwc-tags/invalid/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6hl5rtkl7qa";
-tmpl.legacyStylesheetToken = "x-invalid_invalid";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/metadata/used-attrs/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/metadata/used-attrs/expected.js
@@ -18,7 +18,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-46132jpta3a";
-tmpl.legacyStylesheetToken = "x-used-attrs_used-attrs";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/double-close-div/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-321vvvs7jgq";
-tmpl.legacyStylesheetToken = "x-double-close-div_double-close-div";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-default-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-default-slot/expected.js
@@ -20,7 +20,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = [""];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6euhmo37rlr";
-tmpl.legacyStylesheetToken = "x-duplicate-default-slot_duplicate-default-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-named-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/duplicate-named-slot/expected.js
@@ -26,7 +26,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = ["foo"];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3im0sh599q6";
-tmpl.legacyStylesheetToken = "x-duplicate-named-slot_duplicate-named-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/enableStrictTemplateSyntax-flag-disabled/invalid-attribute-with-children/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/enableStrictTemplateSyntax-flag-disabled/invalid-attribute-with-children/expected.js
@@ -9,8 +9,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-15ba9fr5s6u";
-tmpl.legacyStylesheetToken =
-  "x-invalid-attribute-with-children_invalid-attribute-with-children";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/enableStrictTemplateSyntax-flag-disabled/invalid-attribute/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/enableStrictTemplateSyntax-flag-disabled/invalid-attribute/expected.js
@@ -9,7 +9,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1n02ki6f1ee";
-tmpl.legacyStylesheetToken = "x-invalid-attribute_invalid-attribute";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/enableStrictTemplateSyntax-flag-disabled/mixed-valid-invalid-attributes/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/enableStrictTemplateSyntax-flag-disabled/mixed-valid-invalid-attributes/expected.js
@@ -32,8 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-37n02qqr3et";
-tmpl.legacyStylesheetToken =
-  "x-mixed-valid-invalid-attributes_mixed-valid-invalid-attributes";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/enableStrictTemplateSyntax-flag-disabled/nested-invalid-attributes/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/invalid-template-attribute/enableStrictTemplateSyntax-flag-disabled/nested-invalid-attributes/expected.js
@@ -21,8 +21,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5pibivjbnss";
-tmpl.legacyStylesheetToken =
-  "x-nested-invalid-attributes_nested-invalid-attributes";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/named-slot-in-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/named-slot-in-iterator/expected.js
@@ -25,7 +25,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = ["james"];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-66hm9o8u2h";
-tmpl.legacyStylesheetToken = "x-named-slot-in-iterator_named-slot-in-iterator";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/slot-in-iterator/expected.js
@@ -22,7 +22,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = [""];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7vp41askmik";
-tmpl.legacyStylesheetToken = "x-slot-in-iterator_slot-in-iterator";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/stranded-open-svg-ellipse/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/parsing-errors/stranded-open-svg-ellipse/expected.js
@@ -10,8 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4l5bd87bi6t";
-tmpl.legacyStylesheetToken =
-  "x-stranded-open-svg-ellipse_stranded-open-svg-ellipse";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/attribute-with-equal/expected.js
@@ -20,7 +20,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7uumbeenlgi";
-tmpl.legacyStylesheetToken = "x-attribute-with-equal_attribute-with-equal";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/class-name-slash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/class-name-slash/expected.js
@@ -19,7 +19,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6uii8ct4jjg";
-tmpl.legacyStylesheetToken = "x-class-name-slash_class-name-slash";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/dashed-html-tag/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-490hohg2691";
-tmpl.legacyStylesheetToken = "x-dashed-html-tag_dashed-html-tag";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/deprecated-void-elements/keygen/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/deprecated-void-elements/keygen/expected.js
@@ -15,7 +15,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1tm45udomu6";
-tmpl.legacyStylesheetToken = "x-keygen_keygen";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/deprecated-void-elements/menuitem/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/deprecated-void-elements/menuitem/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-c8rrcpliua";
-tmpl.legacyStylesheetToken = "x-menuitem_menuitem";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/deprecated-void-elements/param/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/deprecated-void-elements/param/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7j75v510urq";
-tmpl.legacyStylesheetToken = "x-param_param";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/excaped-json/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/excaped-json/expected.js
@@ -16,7 +16,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2mip20h8vh2";
-tmpl.legacyStylesheetToken = "x-excaped-json_excaped-json";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/handler-memoization/expected.js
@@ -56,7 +56,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3trccpvgsbq";
-tmpl.legacyStylesheetToken = "x-handler-memoization_handler-memoization";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-closing-style-tag/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-closing-style-tag/expected.js
@@ -9,8 +9,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-72nu6n6rm0a";
-tmpl.legacyStylesheetToken =
-  "x-invalid-closing-style-tag_invalid-closing-style-tag";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/invalid-html-recovery/expected.js
@@ -14,7 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-428hon5nj1a";
-tmpl.legacyStylesheetToken = "x-invalid-html-recovery_invalid-html-recovery";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/nested-if-loops/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/nested-if-loops/expected.js
@@ -24,7 +24,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6ugg4ao851r";
-tmpl.legacyStylesheetToken = "x-nested-if-loops_nested-if-loops";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/slot-name-with-dash/expected.js
@@ -24,7 +24,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = ["secret-slot"];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-69tppsdg3l4";
-tmpl.legacyStylesheetToken = "x-slot-name-with-dash_slot-name-with-dash";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/static-id-in-iteration/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/static-id-in-iteration/expected.js
@@ -91,7 +91,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-41g515g6rr7";
-tmpl.legacyStylesheetToken = "x-static-id-in-iteration_static-id-in-iteration";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/regression/table-with-tr/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3rhlerpfqpi";
-tmpl.legacyStylesheetToken = "x-table-with-tr_table-with-tr";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/config/disallowed-on-custom-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/config/disallowed-on-custom-element/expected.js
@@ -27,8 +27,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4q030adgbk8";
-tmpl.legacyStylesheetToken =
-  "x-disallowed-on-custom-element_disallowed-on-custom-element";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/config/external-component/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/config/external-component/expected.js
@@ -20,7 +20,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5fjt5cr87l5";
-tmpl.legacyStylesheetToken = "x-external-component_external-component";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/config/multiple-tagname/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/config/multiple-tagname/expected.js
@@ -52,7 +52,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4hgahqkce";
-tmpl.legacyStylesheetToken = "x-multiple-tagname_multiple-tagname";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/config/tag-with-namespace/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/config/tag-with-namespace/expected.js
@@ -49,7 +49,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-ed3iv0kbet";
-tmpl.legacyStylesheetToken = "x-tag-with-namespace_tag-with-namespace";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/config/tagname-no-attributes/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/config/tagname-no-attributes/expected.js
@@ -30,7 +30,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-15ubc3rrgkq";
-tmpl.legacyStylesheetToken = "x-tagname-no-attributes_tagname-no-attributes";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/config/tagname-with-attributes/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/config/tagname-with-attributes/expected.js
@@ -24,8 +24,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-mfnbsc228l";
-tmpl.legacyStylesheetToken =
-  "x-tagname-with-attributes_tagname-with-attributes";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/directive-inner-html/usage-if-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/directive-inner-html/usage-if-for-each/expected.js
@@ -55,7 +55,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5m49nb9vba";
-tmpl.legacyStylesheetToken = "x-usage-if-for-each_usage-if-for-each";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/directive-inner-html/valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/directive-inner-html/valid/expected.js
@@ -32,7 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2jeqhu792ub";
-tmpl.legacyStylesheetToken = "x-valid_valid";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/svg/href-with-expression-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/svg/href-with-expression-value/expected.js
@@ -53,8 +53,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4i58lt2008n";
-tmpl.legacyStylesheetToken =
-  "x-href-with-expression-value_href-with-expression-value";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/svg/href-with-literal-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/svg/href-with-literal-value/expected.js
@@ -53,8 +53,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-609tun6ro15";
-tmpl.legacyStylesheetToken =
-  "x-href-with-literal-value_href-with-literal-value";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/svg/xlink-with-expression-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/svg/xlink-with-expression-value/expected.js
@@ -31,8 +31,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1n01u8vu8d9";
-tmpl.legacyStylesheetToken =
-  "x-xlink-with-expression-value_xlink-with-expression-value";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/svg/xlink-with-literal-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/renderer-hooks/svg/xlink-with-literal-value/expected.js
@@ -32,8 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-59dgv24hpm8";
-tmpl.legacyStylesheetToken =
-  "x-xlink-with-literal-value_xlink-with-literal-value";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-id-optimization/static-optimized/light/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-id-optimization/static-optimized/light/expected.js
@@ -67,7 +67,6 @@ export default registerTemplate(tmpl);
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1kadf5igpar";
-tmpl.legacyStylesheetToken = "x-light_light";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-id-optimization/static-optimized/native-shadow/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-id-optimization/static-optimized/native-shadow/expected.js
@@ -66,7 +66,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-54b380gv09b";
-tmpl.legacyStylesheetToken = "x-native-shadow_native-shadow";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-id-optimization/static-optimized/synthetic-shadow/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-id-optimization/static-optimized/synthetic-shadow/expected.js
@@ -111,7 +111,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-520i124ag3i";
-tmpl.legacyStylesheetToken = "x-synthetic-shadow_synthetic-shadow";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-id-optimization/static-unoptimized/light/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-id-optimization/static-unoptimized/light/expected.js
@@ -77,7 +77,6 @@ export default registerTemplate(tmpl);
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1kadf5igpar";
-tmpl.legacyStylesheetToken = "x-light_light";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-id-optimization/static-unoptimized/native-shadow/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-id-optimization/static-unoptimized/native-shadow/expected.js
@@ -76,7 +76,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-54b380gv09b";
-tmpl.legacyStylesheetToken = "x-native-shadow_native-shadow";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-id-optimization/static-unoptimized/synthetic-shadow/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-id-optimization/static-unoptimized/synthetic-shadow/expected.js
@@ -89,7 +89,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-520i124ag3i";
-tmpl.legacyStylesheetToken = "x-synthetic-shadow_synthetic-shadow";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/child-default-slot-api-version-59/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/child-default-slot-api-version-59/expected.js
@@ -20,8 +20,6 @@ tmpl.slots = [""];
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6rfp88tb4pb";
-tmpl.legacyStylesheetToken =
-  "x-child-default-slot-api-version-59_child-default-slot-api-version-59";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/child-default-slot-content/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/child-default-slot-content/expected.js
@@ -21,8 +21,6 @@ tmpl.slots = [""];
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6di869hpvmf";
-tmpl.legacyStylesheetToken =
-  "x-child-default-slot-content_child-default-slot-content";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/child-default-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/child-default-slot/expected.js
@@ -22,7 +22,6 @@ tmpl.slots = [""];
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1fdico6s7m4";
-tmpl.legacyStylesheetToken = "x-child-default-slot_child-default-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/child-mixed-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/child-mixed-slot/expected.js
@@ -37,7 +37,6 @@ tmpl.slots = ["", "slotname1", "slotname2"];
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-75jblr64tev";
-tmpl.legacyStylesheetToken = "x-child-mixed-slot_child-mixed-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/child-named-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/child-named-slot/expected.js
@@ -48,7 +48,6 @@ tmpl.slots = ["", "slotname1", "slotname2"];
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-34oecl8jnu5";
-tmpl.legacyStylesheetToken = "x-child-named-slot_child-named-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/child-with-foreach/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/child-with-foreach/expected.js
@@ -22,7 +22,6 @@ tmpl.slots = [""];
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2gr7k6l9fj";
-tmpl.legacyStylesheetToken = "x-child-with-foreach_child-with-foreach";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/if-block/valid/mixed-slot-types/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/if-block/valid/mixed-slot-types/expected.js
@@ -42,7 +42,6 @@ tmpl.slots = ["slotname1"];
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2og2ir50afk";
-tmpl.legacyStylesheetToken = "x-mixed-slot-types_mixed-slot-types";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/if-block/valid/same-slot-types/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/if-block/valid/same-slot-types/expected.js
@@ -51,7 +51,6 @@ tmpl.slots = ["slotname1"];
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-70bcseng4gg";
-tmpl.legacyStylesheetToken = "x-same-slot-types_same-slot-types";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/name-is-expression/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/name-is-expression/expected.js
@@ -39,7 +39,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-ho8kalrapc";
-tmpl.legacyStylesheetToken = "x-name-is-expression_name-is-expression";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/nested-scoped-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/nested-scoped-slot/expected.js
@@ -71,7 +71,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1uogi8eu1mb";
-tmpl.legacyStylesheetToken = "x-nested-scoped-slot_nested-scoped-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/parent-default-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/parent-default-slot/expected.js
@@ -39,7 +39,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2bvog59ttg6";
-tmpl.legacyStylesheetToken = "x-parent-default-slot_parent-default-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/parent-mixed-slot-content/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/parent-mixed-slot-content/expected.js
@@ -44,8 +44,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3s5q7c313i4";
-tmpl.legacyStylesheetToken =
-  "x-parent-mixed-slot-content_parent-mixed-slot-content";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/parent-named-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/parent-named-slot/expected.js
@@ -59,7 +59,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1f3m2kh4n8r";
-tmpl.legacyStylesheetToken = "x-parent-named-slot_parent-named-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/parent-with-for/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/parent-with-for/expected.js
@@ -51,7 +51,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5cl44u45eun";
-tmpl.legacyStylesheetToken = "x-parent-with-for_parent-with-for";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/slot-content-with-directives/valid/dynamic-components/child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/slot-content-with-directives/valid/dynamic-components/child/expected.js
@@ -58,7 +58,6 @@ tmpl.slots = ["", "slotname1", "slotname2"];
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5h3d35cke7v";
-tmpl.legacyStylesheetToken = "x-child_child";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/slot-content-with-directives/valid/dynamic-components/parent/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/slot-content-with-directives/valid/dynamic-components/parent/expected.js
@@ -44,7 +44,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-ts1rr7v761";
-tmpl.legacyStylesheetToken = "x-parent_parent";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/slot-content-with-directives/valid/if-block/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/slot-content-with-directives/valid/if-block/expected.js
@@ -103,7 +103,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3r9m4mhtbbm";
-tmpl.legacyStylesheetToken = "x-if-block_if-block";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/slot-content-with-directives/valid/if-true/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/slot-content-with-directives/valid/if-true/expected.js
@@ -42,7 +42,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6l5rn7c0v7l";
-tmpl.legacyStylesheetToken = "x-if-true_if-true";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/slots-sharing-bindings/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/slots-sharing-bindings/expected.js
@@ -48,7 +48,6 @@ tmpl.slots = ["", "slotname1", "slotname2"];
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-26f7f538c7h";
-tmpl.legacyStylesheetToken = "x-slots-sharing-bindings_slots-sharing-bindings";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/text-non-direct-child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/text-non-direct-child/expected.js
@@ -41,7 +41,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7snm06k811b";
-tmpl.legacyStylesheetToken = "x-text-non-direct-child_text-non-direct-child";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/with-parent-bindings/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/scoped-slots/with-parent-bindings/expected.js
@@ -45,7 +45,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-ft0hnohr70";
-tmpl.legacyStylesheetToken = "x-with-parent-bindings_with-parent-bindings";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/secure/secure-template/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/secure/secure-template/expected.js
@@ -13,7 +13,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3e181pmdmpc";
-tmpl.legacyStylesheetToken = "x-secure-template_secure-template";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/component-definition/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/component-definition/expected.js
@@ -22,7 +22,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = [""];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5kp75peq61d";
-tmpl.legacyStylesheetToken = "x-component-definition_component-definition";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibiling-slot/expected.js
@@ -34,8 +34,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = ["", "other"];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1o8q2pov2a0";
-tmpl.legacyStylesheetToken =
-  "x-definition-sibiling-slot_definition-sibiling-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition-sibling-static/expected.js
@@ -23,8 +23,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = [""];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5n9s7p96h6j";
-tmpl.legacyStylesheetToken =
-  "x-definition-sibling-static_definition-sibling-static";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/definition/expected.js
@@ -21,7 +21,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = [""];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4ksn4idai2c";
-tmpl.legacyStylesheetToken = "x-definition_definition";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/dynamic-components/content/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/dynamic-components/content/expected.js
@@ -32,7 +32,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = [""];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1up7hhs5a13";
-tmpl.legacyStylesheetToken = "x-content_content";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/dynamic-components/definition/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/dynamic-components/definition/expected.js
@@ -36,7 +36,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = [""];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4ksn4idai2c";
-tmpl.legacyStylesheetToken = "x-definition_definition";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/dynamic-components/light-dom/content/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/dynamic-components/light-dom/content/expected.js
@@ -47,7 +47,6 @@ tmpl.slots = ["body", "footer", "head"];
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1up7hhs5a13";
-tmpl.legacyStylesheetToken = "x-content_content";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/dynamic-components/light-dom/definition/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/dynamic-components/light-dom/definition/expected.js
@@ -39,7 +39,6 @@ tmpl.slots = ["body", "footer", "head"];
 tmpl.renderMode = "light";
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4ksn4idai2c";
-tmpl.legacyStylesheetToken = "x-definition_definition";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/dynamic-components/usage/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/dynamic-components/usage/expected.js
@@ -25,7 +25,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2e79lo5u0ge";
-tmpl.legacyStylesheetToken = "x-usage_usage";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/dynamic-name/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/dynamic-name/expected.js
@@ -20,7 +20,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-619lvcnih24";
-tmpl.legacyStylesheetToken = "x-dynamic-name_dynamic-name";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/ignored/grandparent-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/ignored/grandparent-element/expected.js
@@ -26,7 +26,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4htiliitild";
-tmpl.legacyStylesheetToken = "x-grandparent-element_grandparent-element";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/ignored/grandparent-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/ignored/grandparent-slot/expected.js
@@ -35,7 +35,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = [""];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-g41ii4u05q";
-tmpl.legacyStylesheetToken = "x-grandparent-slot_grandparent-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/ignored/parent-element/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/ignored/parent-element/expected.js
@@ -26,7 +26,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4k671nk0qrh";
-tmpl.legacyStylesheetToken = "x-parent-element_parent-element";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/ignored/parent-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/ignored/parent-slot/expected.js
@@ -35,7 +35,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = [""];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5g5mrivq27e";
-tmpl.legacyStylesheetToken = "x-parent-slot_parent-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/ignored/valid/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/ignored/valid/expected.js
@@ -35,7 +35,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2jeqhu792ub";
-tmpl.legacyStylesheetToken = "x-valid_valid";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed-1/expected.js
@@ -52,7 +52,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = ["", "footer", "header"];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4s8i697dbds";
-tmpl.legacyStylesheetToken = "x-mixed-1_mixed-1";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/mixed/expected.js
@@ -41,7 +41,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3qe0c8mgo6d";
-tmpl.legacyStylesheetToken = "x-mixed_mixed";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/no-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/no-slot/expected.js
@@ -13,7 +13,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-272hucfvl0u";
-tmpl.legacyStylesheetToken = "x-no-slot_no-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if-for-each/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if-for-each/expected.js
@@ -34,7 +34,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5m49nb9vba";
-tmpl.legacyStylesheetToken = "x-usage-if-for-each_usage-if-for-each";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-if/expected.js
@@ -31,7 +31,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6dcki86fmnh";
-tmpl.legacyStylesheetToken = "x-usage-if_usage-if";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage-named/expected.js
@@ -29,7 +29,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = ["test"];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2ok8npp45is";
-tmpl.legacyStylesheetToken = "x-usage-named_usage-named";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/slots/usage/expected.js
@@ -79,7 +79,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2e79lo5u0ge";
-tmpl.legacyStylesheetToken = "x-usage_usage";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-escaping/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-escaping/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7dlcqn5v5n";
-tmpl.legacyStylesheetToken = "x-attr-escaping_attr-escaping";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/non-optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/non-optimized/expected.js
@@ -21,7 +21,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-71tdq7g4m0k";
-tmpl.legacyStylesheetToken = "x-non-optimized_non-optimized";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/optimized/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/attr-name-escape/optimized/expected.js
@@ -14,7 +14,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6dfvqpqt2d0";
-tmpl.legacyStylesheetToken = "x-optimized_optimized";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/class-attr-escaping/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/class-attr-escaping/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-287h74uthl5";
-tmpl.legacyStylesheetToken = "x-class-attr-escaping_class-attr-escaping";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/comment-escaping/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/comment-escaping/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6hk9n52i71a";
-tmpl.legacyStylesheetToken = "x-comment-escaping_comment-escaping";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/deep-data-attrs-only/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/deep-data-attrs-only/expected.js
@@ -49,7 +49,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4vkge12a0vo";
-tmpl.legacyStylesheetToken = "x-deep-data-attrs-only_deep-data-attrs-only";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/deep-data-combined/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/deep-data-combined/expected.js
@@ -54,7 +54,6 @@ export default registerTemplate(tmpl);
 tmpl.hasRefs = true;
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2ekql9nb2jd";
-tmpl.legacyStylesheetToken = "x-deep-data-combined_deep-data-combined";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/deep-data-ref-only/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/deep-data-ref-only/expected.js
@@ -30,7 +30,6 @@ export default registerTemplate(tmpl);
 tmpl.hasRefs = true;
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-64u42t5nfmt";
-tmpl.legacyStylesheetToken = "x-deep-data-ref-only_deep-data-ref-only";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/deep-data-style-only/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/deep-data-style-only/expected.js
@@ -41,7 +41,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2lh7nra2au0";
-tmpl.legacyStylesheetToken = "x-deep-data-style-only_deep-data-style-only";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/deep-data/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/deep-data/expected.js
@@ -96,7 +96,6 @@ export default registerTemplate(tmpl);
 tmpl.hasRefs = true;
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-38lifoo63d4";
-tmpl.legacyStylesheetToken = "x-deep-data_deep-data";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/key-in-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/key-in-slot/expected.js
@@ -43,7 +43,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = ["", "foo"];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2b5l14n492j";
-tmpl.legacyStylesheetToken = "x-key-in-slot_key-in-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/key-invalid-in-slot/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/key-invalid-in-slot/expected.js
@@ -29,7 +29,6 @@ export default registerTemplate(tmpl);
 tmpl.slots = ["", "foo"];
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1ajl4r27aqe";
-tmpl.legacyStylesheetToken = "x-key-invalid-in-slot_key-invalid-in-slot";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/key-multiple/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/key-multiple/expected.js
@@ -32,7 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-8k5meuf7hp";
-tmpl.legacyStylesheetToken = "x-key-multiple_key-multiple";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/key-non-top-level/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/key-non-top-level/expected.js
@@ -31,7 +31,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-7qgdv2kbdr9";
-tmpl.legacyStylesheetToken = "x-key-non-top-level_key-non-top-level";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/key/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/key/expected.js
@@ -31,7 +31,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5npjrhmfrba";
-tmpl.legacyStylesheetToken = "x-key_key";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/no-escaping-tags/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/no-escaping-tags/expected.js
@@ -22,7 +22,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-49vb5jurkcl";
-tmpl.legacyStylesheetToken = "x-no-escaping-tags_no-escaping-tags";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/no-th-or-td/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/no-th-or-td/expected.js
@@ -42,7 +42,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3dqe88fvse3";
-tmpl.legacyStylesheetToken = "x-no-th-or-td_no-th-or-td";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/preserve-comments-off-with-parts/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/preserve-comments-off-with-parts/expected.js
@@ -54,8 +54,6 @@ export default registerTemplate(tmpl);
 tmpl.hasRefs = true;
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-vgq39e7dj1";
-tmpl.legacyStylesheetToken =
-  "x-preserve-comments-off-with-parts_preserve-comments-off-with-parts";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/preserve-comments-off/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/preserve-comments-off/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2i4hqdog1hh";
-tmpl.legacyStylesheetToken = "x-preserve-comments-off_preserve-comments-off";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/preserve-comments-on-with-parts/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/preserve-comments-on-with-parts/expected.js
@@ -47,8 +47,6 @@ export default registerTemplate(tmpl);
 tmpl.hasRefs = true;
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2hhaie9eb6e";
-tmpl.legacyStylesheetToken =
-  "x-preserve-comments-on-with-parts_preserve-comments-on-with-parts";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/preserve-comments-on/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/preserve-comments-on/expected.js
@@ -13,7 +13,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2hege9bfdij";
-tmpl.legacyStylesheetToken = "x-preserve-comments-on_preserve-comments-on";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/shallow-data/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/shallow-data/expected.js
@@ -31,7 +31,6 @@ export default registerTemplate(tmpl);
 tmpl.hasRefs = true;
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1li76rtl7bn";
-tmpl.legacyStylesheetToken = "x-shallow-data_shallow-data";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg-within-div/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg-within-div/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4v1pt61trtl";
-tmpl.legacyStylesheetToken = "x-svg-within-div_svg-within-div";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg-within-g/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg-within-g/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5k70b9009s8";
-tmpl.legacyStylesheetToken = "x-svg-within-g_svg-within-g";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/svg/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3j142gdvja7";
-tmpl.legacyStylesheetToken = "x-svg_svg";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/template-string-escape/expected.js
@@ -42,7 +42,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-742r8pnmnj5";
-tmpl.legacyStylesheetToken = "x-template-string-escape_template-string-escape";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text-escaping/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text-escaping/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-6t1doghra7u";
-tmpl.legacyStylesheetToken = "x-text-escaping_text-escaping";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/child/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/child/expected.js
@@ -18,7 +18,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5h3d35cke7v";
-tmpl.legacyStylesheetToken = "x-child_child";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/comments/no-preserve-comments/basic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/comments/no-preserve-comments/basic/expected.js
@@ -27,7 +27,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1rssj1tib70";
-tmpl.legacyStylesheetToken = "x-basic_basic";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/comments/no-preserve-comments/nested/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/comments/no-preserve-comments/nested/expected.js
@@ -24,7 +24,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-ud1n1pkbjc";
-tmpl.legacyStylesheetToken = "x-nested_nested";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/comments/no-preserve-comments/siblings/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/comments/no-preserve-comments/siblings/expected.js
@@ -43,7 +43,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1f6gdeblibr";
-tmpl.legacyStylesheetToken = "x-siblings_siblings";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/comments/preserve-comments/basic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/comments/preserve-comments/basic/expected.js
@@ -19,7 +19,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1rssj1tib70";
-tmpl.legacyStylesheetToken = "x-basic_basic";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/comments/preserve-comments/nested/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/comments/preserve-comments/nested/expected.js
@@ -21,7 +21,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-ud1n1pkbjc";
-tmpl.legacyStylesheetToken = "x-nested_nested";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/comments/preserve-comments/siblings/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/comments/preserve-comments/siblings/expected.js
@@ -35,7 +35,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1f6gdeblibr";
-tmpl.legacyStylesheetToken = "x-siblings_siblings";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/concatenated/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/concatenated/expected.js
@@ -38,7 +38,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-2mft3qo9a2t";
-tmpl.legacyStylesheetToken = "x-concatenated_concatenated";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/else/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/else/expected.js
@@ -129,7 +129,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-a7tod85hel";
-tmpl.legacyStylesheetToken = "x-else_else";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/elseif/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/elseif/expected.js
@@ -93,7 +93,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5d5paovuv7";
-tmpl.legacyStylesheetToken = "x-elseif_elseif";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/grandchild/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/grandchild/expected.js
@@ -29,7 +29,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-42b236sbaik";
-tmpl.legacyStylesheetToken = "x-grandchild_grandchild";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/if/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/if/expected.js
@@ -55,7 +55,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-24vr4p2ioo5";
-tmpl.legacyStylesheetToken = "x-if_if";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/root/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/root/expected.js
@@ -9,7 +9,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1q6ga5gimtp";
-tmpl.legacyStylesheetToken = "x-root_root";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/siblings/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/static-content/text/siblings/expected.js
@@ -42,7 +42,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1f6gdeblibr";
-tmpl.legacyStylesheetToken = "x-siblings_siblings";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/filter/expected.js
@@ -56,7 +56,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3thc4kq8dg9";
-tmpl.legacyStylesheetToken = "x-filter_filter";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/foreign-object/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5pja51876ng";
-tmpl.legacyStylesheetToken = "x-foreign-object_foreign-object";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/linear-gradient/expected.js
@@ -26,7 +26,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1nbpngf4dh9";
-tmpl.legacyStylesheetToken = "x-linear-gradient_linear-gradient";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-dynamic/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-dynamic/expected.js
@@ -69,7 +69,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-72ju6ij1be7";
-tmpl.legacyStylesheetToken = "x-scoped-id-dynamic_scoped-id-dynamic";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-static/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/scoped-id-static/expected.js
@@ -69,7 +69,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-1h20vq2uq0o";
-tmpl.legacyStylesheetToken = "x-scoped-id-static_scoped-id-static";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/simple-svg/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-4f5bqv1dnt5";
-tmpl.legacyStylesheetToken = "x-simple-svg_simple-svg";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/stranded-open-path/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-25dcqi2nfps";
-tmpl.legacyStylesheetToken = "x-stranded-open-path_stranded-open-path";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-image/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3jdtng6574g";
-tmpl.legacyStylesheetToken = "x-valid-image_valid-image";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/valid-svg/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-5g5a2lm585s";
-tmpl.legacyStylesheetToken = "x-valid-svg_valid-svg";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/non-static-optimized/boolean-true/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/non-static-optimized/boolean-true/expected.js
@@ -27,7 +27,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3ud34a26h2d";
-tmpl.legacyStylesheetToken = "x-boolean-true_boolean-true";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/non-static-optimized/expression-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/non-static-optimized/expression-value/expected.js
@@ -35,7 +35,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-16tq0ukvc6u";
-tmpl.legacyStylesheetToken = "x-expression-value_expression-value";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/non-static-optimized/literal-value-starting-with-hash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/non-static-optimized/literal-value-starting-with-hash/expected.js
@@ -35,8 +35,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-p1v8cfa11m";
-tmpl.legacyStylesheetToken =
-  "x-literal-value-starting-with-hash_literal-value-starting-with-hash";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/non-static-optimized/literal-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/non-static-optimized/literal-value/expected.js
@@ -35,7 +35,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-20i8lahhlnu";
-tmpl.legacyStylesheetToken = "x-literal-value_literal-value";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/static-optimized/boolean-true/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/static-optimized/boolean-true/expected.js
@@ -10,7 +10,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-3ud34a26h2d";
-tmpl.legacyStylesheetToken = "x-boolean-true_boolean-true";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/static-optimized/expression-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/static-optimized/expression-value/expected.js
@@ -36,7 +36,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-16tq0ukvc6u";
-tmpl.legacyStylesheetToken = "x-expression-value_expression-value";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/static-optimized/literal-value-starting-with-hash/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/static-optimized/literal-value-starting-with-hash/expected.js
@@ -36,8 +36,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-p1v8cfa11m";
-tmpl.legacyStylesheetToken =
-  "x-literal-value-starting-with-hash_literal-value-starting-with-hash";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/static-optimized/literal-value/expected.js
+++ b/packages/@lwc/template-compiler/src/__tests__/fixtures/svg/xlink/static-optimized/literal-value/expected.js
@@ -32,7 +32,6 @@ function tmpl($api, $cmp, $slotset, $ctx) {
 export default registerTemplate(tmpl);
 tmpl.stylesheets = [];
 tmpl.stylesheetToken = "lwc-20i8lahhlnu";
-tmpl.legacyStylesheetToken = "x-literal-value_literal-value";
 if (_implicitStylesheets) {
   tmpl.stylesheets.push.apply(tmpl.stylesheets, _implicitStylesheets);
 }

--- a/packages/@lwc/template-compiler/src/codegen/helpers.ts
+++ b/packages/@lwc/template-compiler/src/codegen/helpers.ts
@@ -130,8 +130,8 @@ export function generateTemplateMetadata(codeGen: CodeGen): t.Statement[] {
     );
     metadataExpressions.push(t.expressionStatement(stylesheetsMetadata));
 
-    const stylesheetTokens = generateStylesheetTokens(codeGen);
-    metadataExpressions.push(...stylesheetTokens);
+    const stylesheetToken = generateStylesheetToken(codeGen);
+    metadataExpressions.push(stylesheetToken);
 
     const implicitStylesheetImports = generateImplicitStylesheetImports();
     metadataExpressions.push(...implicitStylesheetImports);
@@ -174,7 +174,7 @@ function generateImplicitStylesheetImports(): t.IfStatement[] {
     return implicitStyleSheets;
 }
 
-function generateStylesheetTokens(codeGen: CodeGen): t.ExpressionStatement[] {
+function generateStylesheetToken(codeGen: CodeGen): t.ExpressionStatement {
     const {
         apiVersion,
         state: {
@@ -182,39 +182,18 @@ function generateStylesheetTokens(codeGen: CodeGen): t.ExpressionStatement[] {
         },
     } = codeGen;
 
-    const generateStyleTokenAssignmentExpr = (
-        styleToken: 'stylesheetToken' | 'legacyStylesheetToken',
-        styleTokenName: string
-    ) => {
-        // tmpl.stylesheetToken | tmpl.legacyStylesheetToken
-        const styleTokenExpr = t.memberExpression(
-            t.identifier(TEMPLATE_FUNCTION_NAME),
-            t.identifier(styleToken)
-        );
-        return t.expressionStatement(
-            t.assignmentExpression('=', styleTokenExpr, t.literal(styleTokenName))
-        );
-    };
+    const styleTokenExpr = t.memberExpression(
+        t.identifier(TEMPLATE_FUNCTION_NAME),
+        t.identifier('stylesheetToken')
+    );
 
-    const styleTokens: t.ExpressionStatement[] = [];
+    const renderedToken = isAPIFeatureEnabled(APIFeature.LOWERCASE_SCOPE_TOKENS, apiVersion)
+        ? scopeToken
+        : legacyScopeToken;
 
-    if (isAPIFeatureEnabled(APIFeature.LOWERCASE_SCOPE_TOKENS, apiVersion)) {
-        // Include both the new and legacy tokens, so that the runtime can decide based on a flag whether
-        // we need to render the legacy one. This is designed for cases where the legacy one is required
-        // for backwards compat (e.g. global stylesheets that rely on the legacy format for a CSS selector).
-        // tmpl.stylesheetToken = "{scopeToken}"
-        styleTokens.push(generateStyleTokenAssignmentExpr('stylesheetToken', scopeToken));
-        // tmpl.legacyStylesheetToken = "{legacyScopeToken}"
-        styleTokens.push(
-            generateStyleTokenAssignmentExpr('legacyStylesheetToken', legacyScopeToken)
-        );
-    } else {
-        // In old API versions, we can just keep doing what we always did
-        // tmpl.stylesheetToken = "{legacyScopeToken}"
-        styleTokens.push(generateStyleTokenAssignmentExpr('stylesheetToken', legacyScopeToken));
-    }
-
-    return styleTokens;
+    return t.expressionStatement(
+        t.assignmentExpression('=', styleTokenExpr, t.literal(renderedToken))
+    );
 }
 
 // Given a map of CSS property keys to values, return an array AST like:

--- a/packages/@lwc/template-compiler/src/scopeTokens.ts
+++ b/packages/@lwc/template-compiler/src/scopeTokens.ts
@@ -68,8 +68,7 @@ export function generateScopeTokens(
     const hashCode = generateHashCode(uniqueToken);
     const scopeToken = `lwc-${hashCode.toString(32)}`;
 
-    // TODO [#3733]: remove this dead legacy-scope-token plumbing (the ENABLE_LEGACY_SCOPE_TOKENS
-    // runtime flag has been removed, so the engine no longer renders this token).
+    // TODO [#3733]: remove this dead legacy-scope-token plumbing
     // This scope token is based on the namespace and name, and contains a mix of uppercase/lowercase chars
     const legacyScopeToken = escapeScopeToken(uniqueToken);
 


### PR DESCRIPTION
## Details

#5846 removed the `ENABLE_LEGACY_SCOPE_TOKENS` feature flag, but did _not_ remove all of the legacy scope tokens code. This PR removes more of it. Not all of it can be removed because we still use it in a few lingering places that aren't guaranteed safe.

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
