### PR TITLE
chore: less dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
           default-days: 2
       directory: '/' # Location of package manifests
       schedule:
-          interval: 'weekly'
+          interval: 'monthly'
       ignore:
           # As a library, we intentionally avoid updating TypeScript and @types/node so that we
           # don't accidentally use features from a version newer than our downstream users have installed


### PR DESCRIPTION
Scroll through https://github.com/salesforce/lwc/releases. Most generated release notes are polluted with dependabot PRs. We're releasing on a much lower cadence now, so we can bundle the dependency changes into one PR a month instead of four.

## Details

## Does this pull request introduce a breaking change?

<!--
    Any change that can cause downstream consumers to fail qualifies as a breaking change.

    Examples:
        - Removing the code for a deprecated API.
        - Adding a new restriction to the compiler which might result in a compilation failure for existing code.
        - Changing the return type of a function in a non-backward compatible fashion.

    Remove the incorrect item for the list.
-->

- 😮‍💨 No, it does not introduce a breaking change.
- 💔 Yes, it does introduce a breaking change.

<!-- If yes, please describe the impact and migration path for existing applications. -->

## Does this pull request introduce an observable change?

<!--
    Observable changes are internal changes that can be observed by downstream consumers.
    Such changes don't qualify as breaking changes because they don't impact any publicly defined
    APIs.

    Examples:
        - Fixing a bug.
        - Changing the invocation timing of a callback, for a callback that has no invocation timing
          guarantee.

    Remove the incorrect item from the list.
-->

- 🤞 No, it does not introduce an observable change.
- 🔬 Yes, it does include an observable change.

<!-- If yes, please describe the anticipated observable changes. -->

## GUS work item

<!-- Work ID in text, if applicable. -->
