### PR TITLE
ci: scope workflow permissions to minimum required

### DIFF
--- a/.github/workflows/benchmark-release.yml
+++ b/.github/workflows/benchmark-release.yml
@@ -21,6 +21,9 @@ on:
 env:
     NODE_VERSION: '24.11.1'
 
+permissions:
+    contents: read
+
 jobs:
     run-performance-tests:
         # It is important to use this image so that we have a consistent IP address

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,7 @@ env:
 
 permissions:
     contents: write
-    pull-requests: write
     id-token: write
-    packages: write
 
 jobs:
     release:


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` to `benchmark-release.yml`, which previously had no `permissions` block and fell back to broader default settings.
- Drop `pull-requests: write` and `packages: write` from `release.yml` — neither scope is exercised by any step in the workflow (no PR API calls; npm publish targets registry.npmjs.org via OIDC provenance, not GitHub Packages). Kept `contents: write` (push/tag/release) and `id-token: write` (npm provenance).

## Test plan
- [x] Reviewed every step in both workflows to confirm no removed/added scope is used
- [ ] CI run on this branch to confirm workflows still execute (no write-permission steps triggered by this PR itself)
