### PR TITLE
fix(engine-core): remove html attribute when prop is set to null or undefined

### DIFF
--- a/packages/@lwc/engine-core/src/framework/modules/props.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/props.ts
@@ -43,7 +43,7 @@ export function patchProps(
 
     const isFirstPatch = isNull(oldVnode);
     const { elm, sel } = vnode;
-    const { getProperty, setProperty } = renderer;
+    const { getProperty, setProperty, removeAttribute } = renderer;
 
     for (const key in props) {
         const cur = props[key];
@@ -65,6 +65,13 @@ export function patchProps(
                             key
                         )}", or the attribute does not exist in this browser or DOM implementation.`
                     );
+                }
+            }
+
+            if (isNull(cur) || isUndefined(cur)) {
+                const attrName = htmlPropertyToAttribute(key);
+                if (attrName) {
+                    removeAttribute(elm, attrName);
                 }
             }
             safelySetProperty(setProperty, elm!, key, cur);

--- a/packages/@lwc/integration-wtr/test/spread/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/spread/index.spec.js
@@ -101,7 +101,22 @@ describe('lwc:spread', () => {
             this.spanProps = { className: undefined };
         });
         await Promise.resolve();
-        expect(elm.shadowRoot.querySelector('span').className).toEqual('undefined');
+        expect(elm.shadowRoot.querySelector('span').className).toEqual('');
+        expect(elm.shadowRoot.querySelector('span').getAttribute('class')).toBeNull();
+
+        elm.modify(function () {
+            this.spanProps = { title: 'test-title', lang: 'en' };
+        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('span').getAttribute('title')).toEqual('test-title');
+        expect(elm.shadowRoot.querySelector('span').getAttribute('lang')).toEqual('en');
+
+        elm.modify(function () {
+            this.spanProps = { title: null, lang: undefined };
+        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('span').getAttribute('title')).toBeNull();
+        expect(elm.shadowRoot.querySelector('span').getAttribute('lang')).toBeNull();
 
         elm.modify(function () {
             this.spanProps = { className: '' };


### PR DESCRIPTION
## Summary
When binding attributes to an HTML element using `lwc:spread` or dynamic property assignments, setting a property to `null` or `undefined` resulted in inconsistent behavior compared to standard component attributes:
- Setting standard attributes to `null`/`undefined` calls `removeAttribute()` (in `attrs.ts`).
- Setting properties via `lwc:spread` directly called `setProperty(elm, key, cur)` (in `props.ts`), causing DOM implementations to stringify values to `"null"` or `"undefined"` (e.g. `button.title = null` / `button.lang = null`).

## Solution
In `patchProps()`, if the new value is `isNull(cur) || isUndefined(cur)`, look up the corresponding attribute name using `htmlPropertyToAttribute(key)` and invoke `renderer.removeAttribute(elm, attrName)`.

Fixes #5336

## Testing
- Added regression tests in `packages/@lwc/integration-wtr/test/spread/index.spec.js` verifying that `className`, `title`, and `lang` bound through `lwc:spread` are properly removed from the DOM when set to `null` or `undefined`.