### PR TITLE
fix(rollup-plugin): resolve component namespace and name properly on Windows

### DIFF
--- a/packages/@lwc/engine-core/src/framework/modules/props.ts
+++ b/packages/@lwc/engine-core/src/framework/modules/props.ts
@@ -43,7 +43,7 @@ export function patchProps(
 
     const isFirstPatch = isNull(oldVnode);
     const { elm, sel } = vnode;
-    const { getProperty, setProperty } = renderer;
+    const { getProperty, setProperty, removeAttribute } = renderer;
 
     for (const key in props) {
         const cur = props[key];
@@ -65,6 +65,13 @@ export function patchProps(
                             key
                         )}", or the attribute does not exist in this browser or DOM implementation.`
                     );
+                }
+            }
+
+            if (isNull(cur) || isUndefined(cur)) {
+                const attrName = htmlPropertyToAttribute(key);
+                if (attrName) {
+                    removeAttribute(elm, attrName);
                 }
             }
             safelySetProperty(setProperty, elm!, key, cur);

--- a/packages/@lwc/integration-wtr/test/spread/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/spread/index.spec.js
@@ -101,7 +101,22 @@ describe('lwc:spread', () => {
             this.spanProps = { className: undefined };
         });
         await Promise.resolve();
-        expect(elm.shadowRoot.querySelector('span').className).toEqual('undefined');
+        expect(elm.shadowRoot.querySelector('span').className).toEqual('');
+        expect(elm.shadowRoot.querySelector('span').getAttribute('class')).toBeNull();
+
+        elm.modify(function () {
+            this.spanProps = { title: 'test-title', lang: 'en' };
+        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('span').getAttribute('title')).toEqual('test-title');
+        expect(elm.shadowRoot.querySelector('span').getAttribute('lang')).toEqual('en');
+
+        elm.modify(function () {
+            this.spanProps = { title: null, lang: undefined };
+        });
+        await Promise.resolve();
+        expect(elm.shadowRoot.querySelector('span').getAttribute('title')).toBeNull();
+        expect(elm.shadowRoot.querySelector('span').getAttribute('lang')).toBeNull();
 
         elm.modify(function () {
             this.spanProps = { className: '' };

--- a/packages/@lwc/rollup-plugin/src/index.ts
+++ b/packages/@lwc/rollup-plugin/src/index.ts
@@ -351,7 +351,7 @@ export default function lwc(pluginOptions: RollupLwcOptions = {}): Plugin {
             // Specifier will only exist for modules with alias paths.
             // Otherwise, use the file directory structure to resolve namespace and name.
             const [namespace, name] =
-                specifier?.split('/') ?? path.dirname(filename).split(path.sep).slice(-2);
+                specifier?.split(/[\\/]/) ?? path.resolve(filename).split(path.sep).slice(-2);
 
             /* v8 ignore next */
             if (!namespace || !name) {


### PR DESCRIPTION
## Description
In `@lwc/rollup-plugin/src/index.ts`, the rollup plugin extracted component `namespace` and `name` by splitting `specifier?.split('/')` and fallback `path.dirname(filename).split(path.sep).slice(-2)`.

On Windows:
1. Aliased specifiers and Rollup IDs may contain backslashes (`\\`).
2. Relative filenames (e.g. `./filename.css`) caused `path.dirname` to produce `.`, failing to extract the component name and namespace and flooding the console with warnings.

## Solution
- Updated `specifier?.split(/[\\/]/)` to split on both forward slashes and backslashes.
- Used `path.resolve(filename).split(path.sep).slice(-2)` to ensure full directory paths are resolved before slicing.

Fixes #5113