### PR TITLE
fix(hydration): only hydrate components (W-23722850) [winter27 backport]

### DIFF
--- a/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
+++ b/packages/@lwc/engine-dom/src/apis/hydrate-component.ts
@@ -14,6 +14,7 @@ import {
 } from '@lwc/engine-core';
 import { StringToLowerCase, isFunction, isNull, isObject } from '@lwc/shared';
 import { renderer } from '../renderer';
+import { ElementDescriptors } from '../language';
 import type { LightningElement } from '@lwc/engine-core';
 
 function resetShadowRootAndLightDom(element: Element, Ctor: typeof LightningElement) {
@@ -67,6 +68,16 @@ export function hydrateComponent(
     if (!(element instanceof Element)) {
         throw new TypeError(
             `"hydrateComponent" expects a valid DOM element as the first parameter but instead received ${element}.`
+        );
+    }
+
+    if (
+        // All custom elements must have a `-` in their tag name
+        !ElementDescriptors.tagName.get!.call(element).includes('-') &&
+        !lwcRuntimeFlags.DISABLE_HYDRATION_CUSTOM_ELEMENT_CHECK
+    ) {
+        throw new TypeError(
+            `"hydrateComponent" expects a custom element as the first parameter but instead received ${element.tagName}.`
         );
     }
 

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -21,6 +21,8 @@ const features: FeatureFlagMap = {
     DISABLE_HOST_ATTACH_SHADOW_GUARD: null,
     DISABLE_STRICT_VALIDATION: null,
     DISABLE_DETACHED_REHYDRATION: null,
+    // Remove in 270
+    DISABLE_HYDRATION_CUSTOM_ELEMENT_CHECK: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -82,6 +82,12 @@ export interface FeatureFlagMap {
      * synthetic shadow. When false or unset, the guard is active (default).
      */
     DISABLE_HOST_ATTACH_SHADOW_GUARD: FeatureFlagValue;
+
+    /**
+     * If true, disables the check in `hydrateComponent(element)` that `element` is a custom element.
+     */
+    // Remove in 270
+    DISABLE_HYDRATION_CUSTOM_ELEMENT_CHECK: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-wtr/test/hydration/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/hydration/index.spec.js
@@ -1,4 +1,4 @@
-import { hydrateComponent } from 'lwc';
+import { hydrateComponent, setFeatureFlagForTest } from 'lwc';
 import Simple from 'x/simple';
 
 it('throws error when hydrating non DOM element', () => {
@@ -7,6 +7,23 @@ it('throws error when hydrating non DOM element', () => {
     }).toThrowError(
         '"hydrateComponent" expects a valid DOM element as the first parameter but instead received [object Object].'
     );
+});
+
+it('throws error when hydrating non custom element (W-23722850)', () => {
+    expect(() => {
+        hydrateComponent(document.createElement('p'), Simple, {});
+    }).toThrowError(
+        '"hydrateComponent" expects a custom element as the first parameter but instead received P.'
+    );
+});
+
+it('preserves legacy hydration behavior (W-23722850)', () => {
+    try {
+        setFeatureFlagForTest('DISABLE_HYDRATION_CUSTOM_ELEMENT_CHECK', true);
+        expect(() => hydrateComponent(document.createElement('p'), Simple, {})).not.toThrow();
+    } finally {
+        setFeatureFlagForTest('DISABLE_HYDRATION_CUSTOM_ELEMENT_CHECK', false);
+    }
 });
 
 it.runIf(process.env.NATIVE_SHADOW)(


### PR DESCRIPTION
Backport of #5867 to **winter27**.

Cherry-pick of `fa15f591d902cb94dd5c2f9cce424e2bc61b1b8d` (merged to `master` via #5867, GUS **W-23722850**).

## Details

`hydrateComponent(element, Ctor, props)` did not verify that `element` is actually a custom element before hydrating it. This change adds a guard: if the element's tag name has no `-` (all custom elements must have a `-` in their tag name), `hydrateComponent` throws a `TypeError` instead of attempting to hydrate a built-in element.

The guard is gated behind a new runtime feature flag, `DISABLE_HYDRATION_CUSTOM_ELEMENT_CHECK`, which acts as a kill switch. It defaults to off (check active); setting it to `true` restores the prior behavior of hydrating any element. The flag is annotated `// Remove in 270`.

## Backport notes

- Clean cherry-pick of the functional fix (`engine-dom/src/apis/hydrate-component.ts`) and the WTR hydration spec (`integration-wtr/test/hydration/index.spec.js`).
- The two `@lwc/features` files (`index.ts`, `types.ts`) had conflicts because `master` carries several later flags that do not exist on `winter27`. Resolved by taking **only** the `DISABLE_HYDRATION_CUSTOM_ELEMENT_CHECK` flag addition; the unrelated master-only flags (`ENABLE_LEGACY_ITEM_POLYFILL`, `ENABLE_SHADOW_ROOT_UNDEFINED_GET_ELEMENT_BY_ID`, `ENABLE_BROKEN_HTML_COLLECTION_NAMED_ITEM`) were **not** brought over.

## Testing

- `@lwc/features` typechecks clean after the resolution.
- Functional change (`hydrate-component.ts`) and the hydration regression spec are byte-for-byte the original commit.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🔬 Yes. Calling `hydrateComponent` with a non-custom element (a tag name without a `-`) now throws a `TypeError` instead of attempting to hydrate it. Gated behind the `DISABLE_HYDRATION_CUSTOM_ELEMENT_CHECK` feature flag.

## GUS work item

W-23722850

🤖 Generated with [Claude Code](https://claude.com/claude-code)
