### PR TITLE
fix(engine-dom): guard repeat rendererFactory invocations behind a flag (W-23814927) [winter27 backport]

### DIFF
--- a/packages/@lwc/engine-dom/src/renderer-factory.ts
+++ b/packages/@lwc/engine-dom/src/renderer-factory.ts
@@ -18,6 +18,15 @@
 
 import type { RendererAPI } from '@lwc/engine-core';
 
+declare global {
+    // Records whether this function has already produced a renderer in the current realm. It is kept on
+    // the global rather than in module scope so that this function stays self-contained: its source text
+    // (read via `Function.prototype.toString`) must reference no variables from the surrounding module in
+    // order to be recreated in another realm. `globalThis` exists in every realm, so a reference to it
+    // survives that recreation.
+    var __lwcRendererFactoryInvoked: boolean | undefined;
+}
+
 // Properties that are either not required to be sandboxed or rely on a globally shared information
 // are omitted here
 export type SandboxableRendererAPI = Omit<
@@ -43,6 +52,26 @@ export type RendererAPIType<Type> = Type extends RendererAPI ? RendererAPI : San
  * const customRenderer = rendererFactory(renderer);
  */
 export function rendererFactory<T extends RendererAPI | null>(baseRenderer: T): RendererAPIType<T> {
+    // Invariant (W-23814927): this factory is expected to build a renderer exactly once per realm — the
+    // engine's own bootstrap of the base `renderer`. `globalThis.__lwcRendererFactoryInvoked` records
+    // that a renderer has already been produced; when `ENABLE_RENDERER_FACTORY_GUARD` is set, any later
+    // invocation is rejected. The flag and the marker are reached through globals (the ambient
+    // `lwcRuntimeFlags` and `globalThis`) rather than through module-scoped variables, so this function
+    // stays self-contained: its source text can be read via `Function.prototype.toString` and recreated
+    // in another realm without referencing anything from this module. `typeof` keeps the check inert in a
+    // realm where the flag global is absent, so recreation elsewhere is unaffected and, by default (flag
+    // unset), the factory stays freely re-invocable exactly as before.
+    const alreadyCreated = globalThis.__lwcRendererFactoryInvoked === true;
+    globalThis.__lwcRendererFactoryInvoked = true;
+    if (
+        alreadyCreated &&
+        typeof lwcRuntimeFlags !== 'undefined' &&
+        lwcRuntimeFlags.ENABLE_RENDERER_FACTORY_GUARD
+    ) {
+        throw new Error(
+            'Invalid invocation of rendererFactory. The renderer has already been created and cannot be recreated.'
+        );
+    }
     // Type assertion because this is replaced by rollup with an object, not a string.
     // See `injectInlineRenderer` in /scripts/rollup/rollup.config.js
     const renderer = process.env.RENDERER as unknown as RendererAPIType<T>;

--- a/packages/@lwc/engine-dom/src/renderer.ts
+++ b/packages/@lwc/engine-dom/src/renderer.ts
@@ -24,7 +24,9 @@ const stopTrackingMutations = noop;
  */
 export const renderer: RendererAPI = assign(
     // The base renderer will invoke the factory with null and assign additional properties that are
-    // shared across renderers
+    // shared across renderers. This is the factory's single expected invocation per realm; it marks
+    // the renderer as created so that, when ENABLE_RENDERER_FACTORY_GUARD is set, later invocations are
+    // rejected (see renderer-factory.ts).
     rendererFactory(null),
     // Properties that are either not required to be sandboxed or rely on a globally shared information
     {

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -21,6 +21,7 @@ const features: FeatureFlagMap = {
     DISABLE_HOST_ATTACH_SHADOW_GUARD: null,
     DISABLE_STRICT_VALIDATION: null,
     DISABLE_DETACHED_REHYDRATION: null,
+    ENABLE_RENDERER_FACTORY_GUARD: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -82,6 +82,13 @@ export interface FeatureFlagMap {
      * synthetic shadow. When false or unset, the guard is active (default).
      */
     DISABLE_HOST_ATTACH_SHADOW_GUARD: FeatureFlagValue;
+
+    /**
+     * If true, `rendererFactory` may only be invoked once per realm — during the engine's own bootstrap
+     * of the base `renderer`; any later invocation throws. When false or unset (default),
+     * `rendererFactory` stays freely re-invocable, as it was before this flag. (W-23814927)
+     */
+    ENABLE_RENDERER_FACTORY_GUARD: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-wtr/test/regression/renderer-factory-invariant/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/regression/renderer-factory-invariant/index.spec.js
@@ -1,0 +1,101 @@
+import { createElement, rendererFactory, renderer, setFeatureFlagForTest } from 'lwc';
+import Probe from 'x/probe';
+
+// W-23814927: `rendererFactory` is a self-contained function that external libraries may recreate by
+// reading its source (via `Function.prototype.toString`) and re-evaluating it in another realm. It is
+// also expected to build a renderer exactly once per realm — the engine's own bootstrap of the base
+// `renderer`. When ENABLE_RENDERER_FACTORY_GUARD is set, any later invocation throws. The flag defaults
+// off, so by default the factory stays freely re-invocable.
+//
+// The bootstrap invocation has already run by the time these tests execute, so any call here is a
+// later invocation. `setFeatureFlagForTest` is a no-op in production, so the flag-on assertions are
+// skipped there.
+
+// The source reader external libraries use: `Reflect.apply(Function.prototype.toString, fn, [])` reads
+// the function's real source text and is not affected by any own `toString` property on `fn`.
+function sourceOf(fn) {
+    return Reflect.apply(Function.prototype.toString, fn, []);
+}
+
+// Recreate the function from its source the way an external library does, then return the new function.
+// Indirect eval evaluates in global scope, so any variable the source closed over would be unresolved
+// here and throw when the function runs — which is exactly what proves the source is self-contained.
+function recreate(source) {
+    // eslint-disable-next-line no-eval
+    return (0, eval)('(' + source + ')');
+}
+
+describe('rendererFactory single-invocation invariant (W-23814927)', () => {
+    afterEach(() => {
+        setFeatureFlagForTest('ENABLE_RENDERER_FACTORY_GUARD', false);
+    });
+
+    it('renders a component after the engine bootstrap invocation', () => {
+        // Sanity check: the fixture mounts and the engine bootstrap (which invokes the factory once)
+        // completed without being rejected.
+        const elm = createElement('x-probe', { is: Probe });
+        document.body.appendChild(elm);
+        expect(elm.shadowRoot.querySelector('p').textContent).toBe('rendererFactory invariant');
+        document.body.removeChild(elm);
+    });
+
+    it('keeps rendererFactory re-invocable when the flag is off (default, legacy behavior)', () => {
+        // With the flag unset (the default), the exported factory stays freely callable exactly as it
+        // did before: no behavior change for the overwhelming majority of consumers.
+        expect(() => rendererFactory({})).not.toThrow();
+        const rebuilt = rendererFactory({});
+        expect(typeof rebuilt.getProperty).toBe('function');
+        const div = document.createElement('div');
+        div.id = 'probe';
+        expect(rebuilt.getProperty(div, 'id')).toBe('probe');
+    });
+
+    it('exposes free-variable-free source under Function.prototype.toString and recreates cleanly', () => {
+        // The source read via the reader external libraries use must be self-contained: recreating it
+        // and invoking it must not throw a ReferenceError for any variable captured from the module.
+        const source = sourceOf(rendererFactory);
+        // The source reads its state through globals, never through a `globalThis.`-qualified reference,
+        // so that expression form must not appear.
+        expect(source).not.toContain('globalThis.lwcRuntimeFlags');
+        // Recreate and invoke twice. Any variable captured from the module would be unresolved in this
+        // global eval scope and throw; the only global the source relies on is the flag, guarded by
+        // `typeof`. The flag defaults off, so the invariant check is inert and both calls must succeed
+        // with a working renderer.
+        const recreated = recreate(source);
+        for (let i = 0; i < 2; i++) {
+            const rebuilt = recreated(null);
+            expect(typeof rebuilt.getProperty).toBe('function');
+            const div = document.createElement('div');
+            div.id = 'probe';
+            expect(rebuilt.getProperty(div, 'id')).toBe('probe');
+        }
+    });
+
+    describe.skipIf(process.env.NODE_ENV === 'production')('flag enabled', () => {
+        it('rejects a later invocation of the exported rendererFactory', () => {
+            setFeatureFlagForTest('ENABLE_RENDERER_FACTORY_GUARD', true);
+            // The engine's bootstrap already consumed the one expected invocation, so any call now is a
+            // later invocation and must throw.
+            expect(() => rendererFactory({})).toThrowError(/already been created/);
+        });
+
+        it('rejects a later invocation reached through component code', () => {
+            setFeatureFlagForTest('ENABLE_RENDERER_FACTORY_GUARD', true);
+            const elm = createElement('x-probe', { is: Probe });
+            document.body.appendChild(elm);
+            expect(() => elm.rebuildRenderer()).toThrowError(/already been created/);
+            document.body.removeChild(elm);
+        });
+
+        it('leaves the already-bootstrapped base renderer intact', () => {
+            setFeatureFlagForTest('ENABLE_RENDERER_FACTORY_GUARD', true);
+            // Enabling the flag must not disturb the base renderer the engine built at bootstrap;
+            // rendering must keep working.
+            expect(typeof renderer.getProperty).toBe('function');
+            const elm = createElement('x-probe', { is: Probe });
+            document.body.appendChild(elm);
+            expect(elm.shadowRoot.querySelector('p').textContent).toBe('rendererFactory invariant');
+            document.body.removeChild(elm);
+        });
+    });
+});

--- a/packages/@lwc/integration-wtr/test/regression/renderer-factory-invariant/x/probe/probe.html
+++ b/packages/@lwc/integration-wtr/test/regression/renderer-factory-invariant/x/probe/probe.html
@@ -1,0 +1,3 @@
+<template>
+    <p>rendererFactory invariant</p>
+</template>

--- a/packages/@lwc/integration-wtr/test/regression/renderer-factory-invariant/x/probe/probe.js
+++ b/packages/@lwc/integration-wtr/test/regression/renderer-factory-invariant/x/probe/probe.js
@@ -1,0 +1,11 @@
+import { LightningElement, api, rendererFactory } from 'lwc';
+
+// Exercises component code reaching the exported `rendererFactory` to build a renderer after the
+// engine has already bootstrapped its base renderer (W-23814927). Whether that later invocation is
+// allowed depends on the ENABLE_RENDERER_FACTORY_GUARD flag.
+export default class Probe extends LightningElement {
+    @api
+    rebuildRenderer() {
+        return rendererFactory({});
+    }
+}


### PR DESCRIPTION
Backport of #5883 to **winter27**.

Cherry-pick of `f99795da833c1bd98a38594a2a91ef75781be4d4` (merged to `master` via #5883, GUS **W-23814927**).

## Details

`rendererFactory` (exported from `lwc`) builds a renderer and is expected to run once per realm — the engine's own bootstrap of the base `renderer`. This adds an opt-in invariant: when the new `ENABLE_RENDERER_FACTORY_GUARD` feature flag is set, the factory records its first invocation and rejects any later one. The flag **defaults to off**, so with the default value `rendererFactory` behaves exactly as before — freely re-invocable.

The guard lives inside the factory itself and reads its state through globals (the ambient `lwcRuntimeFlags` and a `globalThis` marker) rather than module-scoped variables, so `rendererFactory` stays self-contained: its source text can be read via `Function.prototype.toString` and recreated in another realm without referencing anything from this module. A `typeof` check keeps the invariant inert where the flag global is absent, so a legitimate recreate-and-invoke elsewhere is unaffected.

## Backport notes

- Clean cherry-pick of the functional change (`@lwc/engine-dom`) and its regression suite.
- The two `@lwc/features` files (`index.ts`, `types.ts`) had conflicts because `master` carries several later flags that do not exist on `winter27`. Resolved by taking **only** the `ENABLE_RENDERER_FACTORY_GUARD` flag addition; unrelated master-only flags were **not** brought over.

## Testing

- `@lwc/features` typechecks clean after the resolution.
- Functional change and regression suite are the original commit, applied cleanly.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change. The guard is default-off and inert until the flag is enabled.

## GUS work item

W-23814927

🤖 Generated with [Claude Code](https://claude.com/claude-code)
