### PR TITLE
feat(engine): opt-in hook for parseFragment static content (W-23814957) [winter27 backport]

### DIFF
--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -15,6 +15,7 @@ import {
     isUndefined,
     KEY__SCOPED_CSS,
     keys,
+    sanitizeHtmlContent,
     StringCharAt,
     STATIC_PART_TOKEN_ID,
     toString,
@@ -325,15 +326,31 @@ function buildParseFragmentFn(
     };
 }
 
+// W-23814957: static-content markup is assembled here and assigned to `innerHTML` by
+// `createFragment` (see @lwc/engine-dom). The `lwc:inner-html` directive routes its markup through
+// the overridable `sanitizeHtmlContent` hook before it becomes DOM; the static-content path does
+// not. When the opt-in flag is enabled, route the exact string that will be assigned to `innerHTML`
+// through the same hook, so both paths are consistent. This is applied per fragment variant (rather
+// than once on the pre-assembled markup) so the SVG variant is processed with its `<svg>` wrapper in
+// place — i.e. in the same parsing context (namespace) `createFragment` will use. Off by default to
+// preserve existing behavior (and because enabling it requires a hook that preserves the
+// engine-generated scope tokens embedded in the markup).
+function sanitizeFragmentIfEnabled(html: string): string {
+    if (lwcRuntimeFlags.ENABLE_PARSE_FRAGMENT_SANITIZATION) {
+        return sanitizeHtmlContent(html);
+    }
+    return html;
+}
+
 // Note: at the moment this code executes, we don't have a renderer yet.
 export const parseFragment = buildParseFragmentFn((html, renderer) => {
     const { createFragment } = renderer;
-    return createFragment(html);
+    return createFragment(sanitizeFragmentIfEnabled(html));
 });
 
 export const parseSVGFragment = buildParseFragmentFn((html, renderer) => {
     const { createFragment, getFirstChild } = renderer;
-    const fragment = createFragment('<svg>' + html + '</svg>');
+    const fragment = createFragment(sanitizeFragmentIfEnabled('<svg>' + html + '</svg>'));
     return getFirstChild(fragment);
 });
 

--- a/packages/@lwc/engine-server/src/__tests__/parse-fragment-sanitization.spec.ts
+++ b/packages/@lwc/engine-server/src/__tests__/parse-fragment-sanitization.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+    LightningElement,
+    parseFragment,
+    registerComponent,
+    registerTemplate,
+    renderComponent,
+    setFeatureFlagForTest,
+    setHooks,
+} from '../index';
+import type { FeatureFlagName } from '@lwc/features/dist/types';
+
+// W-23814957: the static-content optimization (`parseFragment`) assembles the component-authored
+// markup for a static element and hands it to the renderer, which turns it into DOM. The
+// `lwc:inner-html` directive routes its markup through the `sanitizeHtmlContent` hook before it
+// becomes DOM; the static-content path does not. The opt-in flag routes the assembled markup
+// through that same hook so both paths are consistent. This suite drives the engine-core
+// `buildParseFragmentFn` code path via the server renderer (synchronous, no browser) and asserts
+// the flag genuinely toggles that routing.
+//
+// NOTE: engine-server's vitest resolves `@lwc/engine-core` from its built `dist`, so this suite
+// only reflects source changes to `template.ts` after a rebuild. CI builds all packages via the
+// root `prepare` script during `yarn install`, so the change is present there.
+const FLAG: FeatureFlagName = 'ENABLE_PARSE_FRAGMENT_SANITIZATION';
+
+// A plain marker attribute standing in for "an attribute the hook would act on".
+const MARKER = 'data-marker';
+
+// The hook implementation, delegated to per test. `setHooks` may only be called once per module
+// registry, so a single delegating hook is installed and its target swapped (same indirection as
+// integration-wtr/helpers/hooks.js).
+let sanitizeImpl: (content: unknown) => string = (content) => String(content);
+beforeAll(() => {
+    try {
+        setHooks({ sanitizeHtmlContent: (content) => sanitizeImpl(content) });
+    } catch {
+        // Already overridden in this registry — the delegating hook is in place.
+    }
+});
+
+// `setFeatureFlagForTest` is intentionally a no-op in production. Temporarily drop out of production
+// mode so the flag can be toggled (matching this package's `fixtures.spec.ts` helper), so the
+// "flag enabled" assertions run in production mode too — where the fix actually ships.
+function setFlagAllModes(value: boolean): void {
+    const original = process.env.NODE_ENV;
+    if (original === 'production') {
+        process.env.NODE_ENV = 'development';
+    }
+    setFeatureFlagForTest(FLAG, value);
+    if (original === 'production') {
+        process.env.NODE_ENV = original;
+    }
+}
+
+// Hand-authored equivalent of what the template compiler emits for a static element (see any
+// fixture `dist/compiled-default.js`): a `parseFragment` tagged template consumed by `$api.st`.
+// A fresh component ctor per invocation keeps each render independent.
+function makeComponent(tag: string) {
+    // Call form (rather than the tagged-template form the compiler emits) so a single mutable
+    // `string[]` with no interpolated keys typechecks; `buildParseFragmentFn` simply concatenates
+    // `strings`, so this is equivalent to `parseFragment`...`` for a static fragment.
+    const fragment = parseFragment(['<div data-region><span data-marker></span></div>']);
+    function tmpl($api: any) {
+        const { st: api_static_fragment } = $api;
+        return [api_static_fragment(fragment, 1)];
+    }
+    const _tmpl = registerTemplate(tmpl);
+    (tmpl as any).stylesheets = [];
+    class StaticFragmentCmp extends LightningElement {}
+    return registerComponent(StaticFragmentCmp, { tmpl: _tmpl, sel: tag } as any) as any;
+}
+
+describe('parseFragment sanitization (W-23814957)', () => {
+    afterEach(() => {
+        setFlagAllModes(false);
+        sanitizeImpl = (content) => String(content);
+    });
+
+    it('does NOT route static-content markup through the hook when the flag is unset (default)', () => {
+        const spy = vi.fn((content: unknown) => String(content));
+        sanitizeImpl = spy;
+
+        const html = renderComponent('x-parse-fragment-off', makeComponent('x-parse-fragment-off'));
+
+        // Default behavior is preserved: the hook is never consulted for static content...
+        expect(spy).not.toHaveBeenCalled();
+        // ...and the authored markup reaches the fragment unchanged.
+        expect(html).toContain(MARKER);
+    });
+
+    it('routes static-content markup through the hook when the flag is enabled', () => {
+        // A hook that strips the marker attribute from whatever markup it is given.
+        const spy = vi.fn((content: unknown) => String(content).replaceAll(' ' + MARKER, ''));
+        sanitizeImpl = spy;
+        setFlagAllModes(true);
+
+        const html = renderComponent('x-parse-fragment-on', makeComponent('x-parse-fragment-on'));
+
+        // The hook saw the fully assembled fragment markup...
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mock.calls[0][0]).toContain(MARKER);
+        // ...and its return value is what became the fragment: the marker no longer reaches output.
+        expect(html).not.toContain(MARKER);
+    });
+});

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -21,6 +21,7 @@ const features: FeatureFlagMap = {
     DISABLE_HOST_ATTACH_SHADOW_GUARD: null,
     DISABLE_STRICT_VALIDATION: null,
     DISABLE_DETACHED_REHYDRATION: null,
+    ENABLE_PARSE_FRAGMENT_SANITIZATION: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -82,6 +82,22 @@ export interface FeatureFlagMap {
      * synthetic shadow. When false or unset, the guard is active (default).
      */
     DISABLE_HOST_ATTACH_SHADOW_GUARD: FeatureFlagValue;
+
+    /**
+     * Opt-in flag for W-23814957. When true, the static-content optimization
+     * (`parseFragment` / `parseSVGFragment`) routes the exact markup it will assign to the
+     * underlying `<template>.innerHTML` through the `sanitizeHtmlContent` hook — the same hook that
+     * backs `lwc:inner-html` — before that markup becomes DOM, so both paths consult the hook
+     * consistently. If false or unset (default), the markup is not routed through the hook and the
+     * existing behavior is preserved.
+     *
+     * Only enable this in environments that install a `sanitizeHtmlContent` hook: when the flag is
+     * on and no hook is installed, the default hook throws, which fails rendering of every static
+     * fragment. The installed hook must also preserve the engine-generated scope tokens embedded in
+     * the markup (or scoped styles break), and — because the SVG variant is processed with its
+     * `<svg>` wrapper in place — must handle both HTML- and SVG-namespace fragments.
+     */
+    ENABLE_PARSE_FRAGMENT_SANITIZATION: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-wtr/test/regression/parse-fragment-sanitization/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/regression/parse-fragment-sanitization/index.spec.js
@@ -1,0 +1,127 @@
+import { createElement, setFeatureFlagForTest } from 'lwc';
+import StaticFragment from 'x/staticFragment';
+import StaticSvgFragment from 'x/staticSvgFragment';
+import { getHooks, setHooks } from '../../../helpers/hooks.js';
+import { resetDOM, resetFragmentCache } from '../../../helpers/reset.js';
+import { LOWERCASE_SCOPE_TOKENS } from '../../../helpers/constants.js';
+
+// W-23814957: the static-content optimization builds its fragment by assigning the
+// component-authored markup to a `<template>.innerHTML` (see `createFragment` in @lwc/engine-dom).
+// The `lwc:inner-html` directive routes its markup through the `sanitizeHtmlContent` hook before it
+// becomes DOM; the static-content path does not. The opt-in `ENABLE_PARSE_FRAGMENT_SANITIZATION`
+// flag routes the assembled markup through that same hook so both paths are consistent.
+//
+// This real-browser test exercises the actual `innerHTML` path (which the node/server unit test in
+// engine-server cannot) and asserts the flag toggles whether the hook is consulted for
+// static-content markup.
+
+const FLAG = 'ENABLE_PARSE_FRAGMENT_SANITIZATION';
+const MARKER = 'data-marker';
+
+// The hook only runs when the component actually compiles to a `parseFragment` / `parseSVGFragment`
+// call. That optimization is off when `DISABLE_STATIC_CONTENT_OPTIMIZATION=1` (both fragment
+// variants fall back to the vdom path), and SVG specifically is excluded from the optimization
+// before API version 59 (see `isStaticNode` in @lwc/template-compiler). In those configs there is
+// no static fragment for the hook to process, so the "flag enabled" assertions do not apply.
+const STATIC_CONTENT_OPTIMIZATION_ENABLED = !process.env.DISABLE_STATIC_CONTENT_OPTIMIZATION;
+const SVG_STATIC_CONTENT_OPTIMIZATION_ENABLED =
+    STATIC_CONTENT_OPTIMIZATION_ENABLED && LOWERCASE_SCOPE_TOKENS;
+
+let originalSanitizeHtmlContent;
+
+beforeAll(() => {
+    originalSanitizeHtmlContent = getHooks().sanitizeHtmlContent;
+});
+
+afterEach(() => {
+    setHooks({ sanitizeHtmlContent: originalSanitizeHtmlContent });
+    setFeatureFlagForTest(FLAG, false);
+    // Static fragments are cached by the (module-level) template literal, so a fragment parsed
+    // under one flag state would otherwise leak into the next test.
+    resetFragmentCache();
+    resetDOM();
+});
+
+function render() {
+    const elm = createElement('x-static-fragment', { is: StaticFragment });
+    document.body.appendChild(elm);
+    return elm;
+}
+
+function renderSvg() {
+    const elm = createElement('x-static-svg-fragment', { is: StaticSvgFragment });
+    document.body.appendChild(elm);
+    return elm;
+}
+
+it('does not route static-content markup through the hook when the flag is unset (default)', () => {
+    // A hook that renames the marker — it must never be consulted for static content by default,
+    // and its rename must therefore have no effect.
+    let called = false;
+    setHooks({
+        sanitizeHtmlContent: (content) => {
+            called = true;
+            return String(content).replaceAll(MARKER, 'data-sanitized');
+        },
+    });
+
+    const elm = render();
+    const span = elm.shadowRoot.querySelector('[data-id="region"] span');
+
+    expect(called).toBe(false);
+    // The authored marker reaches the live DOM unchanged.
+    expect(span.hasAttribute(MARKER)).toBe(true);
+});
+
+it.skipIf(!STATIC_CONTENT_OPTIMIZATION_ENABLED)(
+    'routes static-content markup through the hook when the flag is enabled',
+    () => {
+        setFeatureFlagForTest(FLAG, true);
+        // A hook that renames the marker attribute on whatever markup it is handed.
+        let seenMarkup;
+        setHooks({
+            sanitizeHtmlContent: (content) => {
+                seenMarkup = String(content);
+                return seenMarkup.replaceAll(MARKER, 'data-sanitized');
+            },
+        });
+
+        const elm = render();
+        const span = elm.shadowRoot.querySelector('[data-id="region"] span');
+
+        // The hook saw the assembled static-fragment markup before it became DOM...
+        expect(seenMarkup).toContain(MARKER);
+        // ...and its sanitized result is what reached the live DOM: the marker is gone.
+        expect(span.hasAttribute(MARKER)).toBe(false);
+        expect(span.hasAttribute('data-sanitized')).toBe(true);
+    }
+);
+
+it.skipIf(!SVG_STATIC_CONTENT_OPTIMIZATION_ENABLED)(
+    'sanitizes the SVG-variant markup with its <svg> wrapper in place when the flag is enabled',
+    () => {
+        setFeatureFlagForTest(FLAG, true);
+        // Same hook, but record every markup string the hook is handed so we can assert the SVG
+        // variant is processed in the same parsing context (namespace) `createFragment` will use.
+        const seen = [];
+        setHooks({
+            sanitizeHtmlContent: (content) => {
+                const markup = String(content);
+                seen.push(markup);
+                return markup.replaceAll(MARKER, 'data-sanitized');
+            },
+        });
+
+        const elm = renderSvg();
+        const rect = elm.shadowRoot.querySelector('[data-id="region"] rect');
+
+        // The SVG child's markup was handed to the hook already wrapped in <svg>...</svg> — i.e. in
+        // the namespace `createFragment` will parse it in, not the raw pre-wrap markup.
+        const svgMarkup = seen.find((m) => m.includes(MARKER));
+        expect(svgMarkup).toBeDefined();
+        expect(svgMarkup).toContain('<svg>');
+        // ...and the sanitized result is what reached the live DOM.
+        expect(rect.hasAttribute(MARKER)).toBe(false);
+        expect(rect.hasAttribute('data-sanitized')).toBe(true);
+    }
+);

--- a/packages/@lwc/integration-wtr/test/regression/parse-fragment-sanitization/x/staticFragment/staticFragment.html
+++ b/packages/@lwc/integration-wtr/test/regression/parse-fragment-sanitization/x/staticFragment/staticFragment.html
@@ -1,0 +1,5 @@
+<template>
+    <div data-id="region">
+        <span data-marker="marker">static</span>
+    </div>
+</template>

--- a/packages/@lwc/integration-wtr/test/regression/parse-fragment-sanitization/x/staticFragment/staticFragment.js
+++ b/packages/@lwc/integration-wtr/test/regression/parse-fragment-sanitization/x/staticFragment/staticFragment.js
@@ -1,0 +1,5 @@
+import { LightningElement } from 'lwc';
+
+// A purely static template (no dynamic bindings) compiles to a `parseFragment` / `$api.st`
+// call, which drives the static-content optimization under test (W-23814957).
+export default class StaticFragment extends LightningElement {}

--- a/packages/@lwc/integration-wtr/test/regression/parse-fragment-sanitization/x/staticSvgFragment/staticSvgFragment.html
+++ b/packages/@lwc/integration-wtr/test/regression/parse-fragment-sanitization/x/staticSvgFragment/staticSvgFragment.html
@@ -1,0 +1,13 @@
+<template>
+    <svg data-id="region">
+        <!--
+          A static SVG *child* under a non-static parent (the for:each) is what the compiler emits
+          as `parseSVGFragment` — a fully-static `<svg>` root compiles to plain `parseFragment`. The
+          `parseSVGFragment` path wraps this markup in `<svg>...</svg>` before it reaches
+          `createFragment`, exercising the SVG-namespace branch of the flag (W-23814957).
+        -->
+        <template for:each={items} for:item="item">
+            <rect key={item.key} data-marker="marker" width="10" height="10"></rect>
+        </template>
+    </svg>
+</template>

--- a/packages/@lwc/integration-wtr/test/regression/parse-fragment-sanitization/x/staticSvgFragment/staticSvgFragment.js
+++ b/packages/@lwc/integration-wtr/test/regression/parse-fragment-sanitization/x/staticSvgFragment/staticSvgFragment.js
@@ -1,0 +1,9 @@
+import { LightningElement } from 'lwc';
+
+// A static SVG child under a non-static parent (the for:each) compiles to a `parseSVGFragment` /
+// `$api.st` call. Unlike the plain `parseFragment` path, `parseSVGFragment` wraps the authored
+// markup in `<svg>...</svg>` before it reaches the host-realm `<template>.innerHTML` sink, so it
+// exercises the SVG-namespace branch of the sanitization gate under test (W-23814957).
+export default class StaticSvgFragment extends LightningElement {
+    items = [{ key: 'a' }];
+}


### PR DESCRIPTION
Backport of #5874 to **winter27**.

Cherry-pick of `0a31ddac1e15297f14d7c2f65edb3d6c22afc61b` (merged to `master` via #5874, GUS **W-23814957**).

## Details

The static-content optimization (`parseFragment` / `parseSVGFragment`) assembles component-authored markup and assigns it to `<template>.innerHTML` via `createFragment`. The `lwc:inner-html` directive routes its markup through the overridable `sanitizeHtmlContent` hook before it becomes DOM; the static-content path does not.

This change adds a new, **default-off** feature flag `ENABLE_PARSE_FRAGMENT_SANITIZATION`. When enabled, each fragment variant routes the exact markup it will assign to `innerHTML` through the same `sanitizeHtmlContent` hook, at the single assembly choke point that covers both `parseFragment` and `parseSVGFragment`, browser and server. The SVG variant is processed with its `<svg>` wrapper in place, so the hook inspects the markup in the same parsing context (namespace) `createFragment` will use. When the flag is unset (default), behavior is completely unchanged.

Enabling the flag requires an installed `sanitizeHtmlContent` hook that preserves the engine-generated scope tokens embedded in the markup and handles both HTML- and SVG-namespace fragments (the default hook throws). This is documented on the flag's JSDoc.

## Backport notes

- Clean cherry-pick of the functional change (`engine-core/src/framework/template.ts`), the engine-server unit spec, and the integration-wtr regression suite + fixtures.
- The two `@lwc/features` files (`index.ts`, `types.ts`) had conflicts because `master` carries several later flags that do not exist on `winter27`. Resolved by taking **only** the `ENABLE_PARSE_FRAGMENT_SANITIZATION` flag addition; unrelated master-only flags were **not** brought over.

## Testing

- `@lwc/features` typechecks clean after the resolution.
- Functional change and test suites are the original commit, applied cleanly.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change.

## Does this pull request introduce an observable change?

- 🔬 Yes. When the flag is enabled, static-fragment markup is routed through the `sanitizeHtmlContent` hook. Default-off, so default behavior is unchanged. Gated behind the `ENABLE_PARSE_FRAGMENT_SANITIZATION` feature flag.

## GUS work item

W-23814957

🤖 Generated with [Claude Code](https://claude.com/claude-code)
