### PR TITLE
feat(engine-core): invoke compiled template via intrinsic apply behind a flag (W-23790290) [winter27 backport]

### DIFF
--- a/packages/@lwc/engine-core/src/framework/template.ts
+++ b/packages/@lwc/engine-core/src/framework/template.ts
@@ -417,10 +417,18 @@ export function evaluateTemplate(vm: VM, html: Template): VNodes {
                 // Set the global flag that template is being updated
                 isUpdatingTemplate = true;
 
-                vnodes = html.call(undefined, api, component, cmpSlots, context.tplCache);
+                // `html.call(...)` reads a `call` property off the compiled template function. A
+                // component can shadow that property with an own value, causing the engine to invoke
+                // the component-supplied function (with the privileged template `api`) instead of
+                // `Function.prototype.call`. Invoking through the intrinsic `Reflect.apply` uses the
+                // function's internal call behavior and ignores any own `call` property. Gated behind
+                // a flag so the hardened path can be rolled out separately from the default behavior.
+                vnodes = lwcRuntimeFlags.ENABLE_INTRINSIC_TEMPLATE_INVOCATION
+                    ? Reflect.apply(html, undefined, [api, component, cmpSlots, context.tplCache])
+                    : html.call(undefined, api, component, cmpSlots, context.tplCache);
                 const { styleVNodes } = context;
                 if (!isNull(styleVNodes)) {
-                    // It's important here not to mutate the underlying `vnodes` returned from `html.call()`.
+                    // It's important here not to mutate the underlying `vnodes` returned from the template invocation.
                     // The reason for this is because, due to the static content optimization, the vnodes array
                     // may be a static array shared across multiple component instances. E.g. this occurs in the
                     // case of an empty `<template></template>` in a `component.html` file, due to the underlying

--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -21,6 +21,7 @@ const features: FeatureFlagMap = {
     DISABLE_HOST_ATTACH_SHADOW_GUARD: null,
     DISABLE_STRICT_VALIDATION: null,
     DISABLE_DETACHED_REHYDRATION: null,
+    ENABLE_INTRINSIC_TEMPLATE_INVOCATION: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -82,6 +82,16 @@ export interface FeatureFlagMap {
      * synthetic shadow. When false or unset, the guard is active (default).
      */
     DISABLE_HOST_ATTACH_SHADOW_GUARD: FeatureFlagValue;
+
+    /**
+     * If true, the engine invokes a component's compiled template function through the intrinsic
+     * `Reflect.apply` instead of `template.call(...)`. The `template.call(...)` form performs a
+     * property lookup for `call` on the template function, which a component can shadow with an own
+     * property; invoking via `Reflect.apply` uses the function's internal call behavior and ignores
+     * any such own property. When false or unset (default), the prior `template.call(...)` invocation
+     * is used.
+     */
+    ENABLE_INTRINSIC_TEMPLATE_INVOCATION: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-wtr/test/template/template-call-invocation/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/template/template-call-invocation/index.spec.js
@@ -1,0 +1,44 @@
+import { createElement, setFeatureFlagForTest } from 'lwc';
+import Component from 'x/component';
+import { resetDOM } from '../../../helpers/reset.js';
+
+// W-23790290: the engine invokes a component's compiled template function to produce its vnodes.
+// The default path uses `template.call(...)`, which resolves `call` as a property lookup on the
+// template function. Because a compiled template is a plain (non-frozen) function, a component can
+// define an own `call` property on it, shadowing `Function.prototype.call`; the engine then invokes
+// the component-supplied function and hands it the engine-internal render `api`. The
+// `ENABLE_INTRINSIC_TEMPLATE_INVOCATION` flag switches invocation to the intrinsic `Reflect.apply`,
+// which uses the function's internal call behavior and ignores any own `call` property.
+//
+// The fixture component (`x/component`) defines a benign own `call` on its template that renders a
+// distinguishable "shadowed" marker and records that it received the render `api`, so both code
+// paths are observable in the DOM and via component state.
+
+describe('template invocation (W-23790290)', () => {
+    afterEach(() => {
+        setFeatureFlagForTest('ENABLE_INTRINSIC_TEMPLATE_INVOCATION', false);
+        resetDOM();
+    });
+
+    it('legacy path (flag off): an own `call` on the template shadows the invocation', () => {
+        const elm = createElement('x-component', { is: Component });
+        document.body.appendChild(elm);
+
+        // The own `call` ran instead of the real template, and it received the render api.
+        expect(elm.ownCallInvoked).toBe(true);
+        expect(elm.receivedRenderApi).toBe(true);
+        expect(elm.shadowRoot.textContent).toBe('shadowed');
+    });
+
+    it('intrinsic path (flag on): an own `call` on the template is ignored', () => {
+        setFeatureFlagForTest('ENABLE_INTRINSIC_TEMPLATE_INVOCATION', true);
+
+        const elm = createElement('x-component', { is: Component });
+        document.body.appendChild(elm);
+
+        // Reflect.apply invokes the real template; the own `call` never runs and never sees the api.
+        expect(elm.ownCallInvoked).toBe(false);
+        expect(elm.receivedRenderApi).toBe(false);
+        expect(elm.shadowRoot.textContent).toBe('real');
+    });
+});

--- a/packages/@lwc/integration-wtr/test/template/template-call-invocation/x/component/component.html
+++ b/packages/@lwc/integration-wtr/test/template/template-call-invocation/x/component/component.html
@@ -1,0 +1,3 @@
+<template>
+    <div>real</div>
+</template>

--- a/packages/@lwc/integration-wtr/test/template/template-call-invocation/x/component/component.js
+++ b/packages/@lwc/integration-wtr/test/template/template-call-invocation/x/component/component.js
@@ -1,0 +1,36 @@
+import { LightningElement, api } from 'lwc';
+import tmpl from './component.html';
+
+// Observations recorded by the shadowed `call` below. Reset at the start of every render so each
+// test observes only its own render. The engine passes `undefined` as the invoked function's `this`
+// value, so the function reports through this module-scoped state rather than through `this`.
+let renderState = { ownCallInvoked: false, receivedRenderApi: false };
+
+// A component can define an own `call` property on its compiled template function. The default
+// invocation path (`template.call(...)`) resolves `call` as a property lookup, so this own value
+// shadows `Function.prototype.call` and the engine invokes this function instead — handing it the
+// engine-internal render `api` as its second argument. This benign stand-in records that it was
+// invoked (and that it received the `api`) and renders a marker so the two code paths are
+// distinguishable in the DOM. The intrinsic invocation path (`Reflect.apply`) ignores this own
+// property and runs the real template.
+tmpl.call = function shadowedCall(_thisArg, renderApi) {
+    renderState.ownCallInvoked = true;
+    // The presence of a usable render `api` here is exactly what the intrinsic path prevents.
+    renderState.receivedRenderApi = typeof renderApi?.h === 'function';
+    return [renderApi.h('div', { key: 0 }, [renderApi.t('shadowed')])];
+};
+
+export default class extends LightningElement {
+    render() {
+        renderState = { ownCallInvoked: false, receivedRenderApi: false };
+        return tmpl;
+    }
+
+    @api get ownCallInvoked() {
+        return renderState.ownCallInvoked;
+    }
+
+    @api get receivedRenderApi() {
+        return renderState.receivedRenderApi;
+    }
+}


### PR DESCRIPTION
Backport of #5873 to **winter27**.

Cherry-pick of `321a23fa8a03802acc3e3d091f82742df7cd0034` (merged to `master` via #5873, GUS **W-23790290**).

## Details

When rendering a component, the engine invokes its compiled template function via `html.call(undefined, api, component, cmpSlots, context.tplCache)`. `html.call(...)` resolves `call` as a **property lookup** on the template function. A compiled template is a plain, non-frozen function object (frozen only under `ENABLE_FROZEN_TEMPLATE`), so a component can define an own `call` property on its own template; when it does, `html.call(...)` reads that own property instead of `Function.prototype.call` and the engine invokes the component-supplied function, handing it the engine-internal render `api`.

This change invokes the template through the intrinsic `Reflect.apply` instead, gated behind a **new, default-off** feature flag `ENABLE_INTRINSIC_TEMPLATE_INVOCATION`. `Reflect.apply` uses the function's internal call behavior and does not read a `call` (or any own) property off the function, so an own `call` property has no effect on invocation. When the flag is unset (the default), the prior `html.call(...)` invocation is used and behavior is byte-for-byte unchanged.

## Backport notes

- Clean cherry-pick of the functional change (`@lwc/engine-core`) and the integration test (`integration-wtr/test/template/template-call-invocation`).
- The two `@lwc/features` files (`index.ts`, `types.ts`) had conflicts because `master` carries several later flags that do not exist on `winter27`. Resolved by taking **only** the `ENABLE_INTRINSIC_TEMPLATE_INVOCATION` flag addition; unrelated master-only flags were **not** brought over.

## Testing

- `@lwc/features` typechecks clean after the resolution.
- Functional change and integration test are the original commit, applied cleanly.

## Does this pull request introduce a breaking change?

- 😮‍💨 No, it does not introduce a breaking change. The new behavior is behind a default-off flag; with the flag unset the invocation is byte-for-byte the previous `html.call(...)`.

## Does this pull request introduce an observable change?

- 🤞 No, it does not introduce an observable change. By default the flag is unset and the render path is unchanged.

## GUS work item

W-23790290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
