### PR TITLE
fix(synthetic-shadow): sanitize native ShadowRoot HTML sinks [W-23994661]

### DIFF
--- a/packages/@lwc/features/src/index.ts
+++ b/packages/@lwc/features/src/index.ts
@@ -36,6 +36,7 @@ const features: FeatureFlagMap = {
     ENABLE_INTRINSIC_TEMPLATE_INVOCATION: null,
     ENABLE_PARSE_FRAGMENT_SANITIZATION: null,
     ENABLE_RENDERER_FACTORY_GUARD: null,
+    DISABLE_NATIVE_SHADOWROOT_SINK_SANITIZATION: null,
 };
 
 if (!(globalThis as any).lwcRuntimeFlags) {

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -171,11 +171,9 @@ export interface FeatureFlagMap {
     ENABLE_RENDERER_FACTORY_GUARD: FeatureFlagValue;
 
     /**
-     * Kill-switch for the W-23994661 hardening. If true, native `ShadowRoot` `innerHTML`/`setHTMLUnsafe`
-     * writes bypass the `sanitizeHtmlContent` hook and pass through unchanged, as they did before this
-     * fix. If false or unset (default), those sinks are routed through the hook so a native root (which
-     * synthetic shadow otherwise leaves undistorted) can't be used to write unsanitized HTML. Only enable
-     * this to unblock a regression; the default is the more secure behavior.
+     * Kill-switch: when true, native `ShadowRoot` `innerHTML`/`setHTMLUnsafe` bypass the
+     * `sanitizeHtmlContent` hook. Default routes them through it so a native root can't write
+     * unsanitized HTML. Enable only to unblock a regression.
      */
     DISABLE_NATIVE_SHADOWROOT_SINK_SANITIZATION: FeatureFlagValue;
 }

--- a/packages/@lwc/features/src/types.ts
+++ b/packages/@lwc/features/src/types.ts
@@ -169,6 +169,15 @@ export interface FeatureFlagMap {
      * `rendererFactory` stays freely re-invocable, as it was before this flag. (W-23814927)
      */
     ENABLE_RENDERER_FACTORY_GUARD: FeatureFlagValue;
+
+    /**
+     * Kill-switch for the W-23994661 hardening. If true, native `ShadowRoot` `innerHTML`/`setHTMLUnsafe`
+     * writes bypass the `sanitizeHtmlContent` hook and pass through unchanged, as they did before this
+     * fix. If false or unset (default), those sinks are routed through the hook so a native root (which
+     * synthetic shadow otherwise leaves undistorted) can't be used to write unsanitized HTML. Only enable
+     * this to unblock a regression; the default is the more secure behavior.
+     */
+    DISABLE_NATIVE_SHADOWROOT_SINK_SANITIZATION: FeatureFlagValue;
 }
 
 export type FeatureFlagName = keyof FeatureFlagMap;

--- a/packages/@lwc/integration-wtr/test/synthetic-shadow/native-shadowroot-sanitize/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/synthetic-shadow/native-shadowroot-sanitize/index.spec.js
@@ -1,0 +1,89 @@
+import { fn as mockFn } from '@vitest/spy';
+import { getHooks, setHooks } from '../../../helpers/hooks.js';
+
+// Skipped in native mode: synthetic-shadow isn't loaded there, so there is no native-sink patch to test.
+describe.skipIf(process.env.NATIVE_SHADOW)(
+    'native ShadowRoot HTML sinks route through sanitizeHtmlContent',
+    () => {
+        const PAYLOAD = '<iframe srcdoc="<script>window.__pwned = true</script>"></iframe>';
+
+        // Outside an LWC host, attachShadow yields a native root under synthetic shadow.
+        function createNativeRoot() {
+            return document.createElement('div').attachShadow({ mode: 'open' });
+        }
+
+        function stripDangerous(content) {
+            return String(content)
+                .replace(/<script[\s\S]*?<\/script>/gi, '')
+                .replace(/<iframe[\s\S]*?<\/iframe>/gi, '')
+                .replace(/<iframe\b[^>]*>/gi, '');
+        }
+
+        let original;
+        beforeAll(() => {
+            original = getHooks().sanitizeHtmlContent;
+        });
+        afterEach(() => setHooks({ sanitizeHtmlContent: original }));
+
+        it('routes native innerHTML writes through the hook with the raw value', () => {
+            const spy = mockFn((content) => stripDangerous(content));
+            setHooks({ sanitizeHtmlContent: spy });
+
+            const root = createNativeRoot();
+            root.innerHTML = PAYLOAD;
+
+            // A synthetic root's innerHTML setter never calls the hook, so being called at all proves
+            // the write went through the patched *native* prototype.
+            expect(spy).toHaveBeenCalledWith(PAYLOAD);
+        });
+
+        it('neutralizes the srcdoc PoC written to a native root innerHTML', () => {
+            setHooks({ sanitizeHtmlContent: stripDangerous });
+
+            const root = createNativeRoot();
+            root.innerHTML = PAYLOAD;
+
+            expect(root.querySelector('iframe')).toBeNull();
+            expect(root.querySelector('script')).toBeNull();
+        });
+
+        it('passes benign markup through unchanged', () => {
+            const spy = mockFn((content) => content);
+            setHooks({ sanitizeHtmlContent: spy });
+
+            const root = createNativeRoot();
+            root.innerHTML = '<span>ok</span>';
+
+            expect(spy).toHaveBeenCalledWith('<span>ok</span>');
+            expect(root.querySelector('span')).not.toBeNull();
+            expect(root.querySelector('span').textContent).toBe('ok');
+        });
+
+        it('writes the hook return value, not the raw input, to the native root', () => {
+            setHooks({ sanitizeHtmlContent: () => '<b>safe</b>' });
+
+            const root = createNativeRoot();
+            root.innerHTML = PAYLOAD;
+
+            expect(root.querySelector('b')).not.toBeNull();
+            expect(root.querySelector('iframe')).toBeNull();
+        });
+
+        it('routes native setHTMLUnsafe through the hook when supported', function () {
+            const root = createNativeRoot();
+            if (typeof root.setHTMLUnsafe !== 'function') {
+                this.skip();
+                return;
+            }
+
+            const spy = mockFn((content) => stripDangerous(content));
+            setHooks({ sanitizeHtmlContent: spy });
+
+            root.setHTMLUnsafe(PAYLOAD);
+
+            expect(spy).toHaveBeenCalledWith(PAYLOAD);
+            expect(root.querySelector('iframe')).toBeNull();
+            expect(root.querySelector('script')).toBeNull();
+        });
+    }
+);

--- a/packages/@lwc/integration-wtr/test/synthetic-shadow/native-shadowroot-sanitize/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/synthetic-shadow/native-shadowroot-sanitize/index.spec.js
@@ -107,6 +107,22 @@ describe.skipIf(process.env.NATIVE_SHADOW)(
             expect(root.querySelector('script')).toBeNull();
         });
 
+        it('kill-switch bypasses the hook so native sinks are not sanitized', () => {
+            const spy = mockFn((content) => stripDangerous(content));
+            setHooks({ sanitizeHtmlContent: spy });
+            lwcRuntimeFlags.DISABLE_NATIVE_SHADOWROOT_SINK_SANITIZATION = true;
+
+            try {
+                const root = createNativeRoot();
+                root.innerHTML = '<span>ok</span>';
+
+                expect(spy).not.toHaveBeenCalled();
+                expect(root.querySelector('span')).not.toBeNull();
+            } finally {
+                lwcRuntimeFlags.DISABLE_NATIVE_SHADOWROOT_SINK_SANITIZATION = false;
+            }
+        });
+
         it('native innerHTML sink cannot be restored by page code', () => {
             setHooks({ sanitizeHtmlContent: stripDangerous });
 

--- a/packages/@lwc/integration-wtr/test/synthetic-shadow/native-shadowroot-sanitize/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/synthetic-shadow/native-shadowroot-sanitize/index.spec.js
@@ -85,5 +85,44 @@ describe.skipIf(process.env.NATIVE_SHADOW)(
             expect(root.querySelector('iframe')).toBeNull();
             expect(root.querySelector('script')).toBeNull();
         });
+
+        it('sanitizer bridge cannot be replaced by page code', () => {
+            setHooks({ sanitizeHtmlContent: stripDangerous });
+
+            // The bridge is frozen (non-writable, non-configurable), so neither assignment nor
+            // redefinition can swap in a passthrough that would bypass sanitization.
+            expect(() => {
+                globalThis.$sanitizeHtmlContent$ = (value) => value;
+            }).toThrow();
+            expect(() =>
+                Object.defineProperty(globalThis, '$sanitizeHtmlContent$', {
+                    configurable: true,
+                    value: (value) => value,
+                })
+            ).toThrow();
+
+            const root = createNativeRoot();
+            root.innerHTML = PAYLOAD;
+            expect(root.querySelector('iframe')).toBeNull();
+            expect(root.querySelector('script')).toBeNull();
+        });
+
+        it('native innerHTML sink cannot be restored by page code', () => {
+            setHooks({ sanitizeHtmlContent: stripDangerous });
+
+            const root = createNativeRoot();
+            // The patched setter is non-configurable, so page code cannot redefine it back to the
+            // raw native setter to regain an unsanitized sink.
+            expect(() =>
+                Object.defineProperty(Object.getPrototypeOf(root), 'innerHTML', {
+                    configurable: true,
+                    set() {},
+                })
+            ).toThrow();
+
+            root.innerHTML = PAYLOAD;
+            expect(root.querySelector('iframe')).toBeNull();
+            expect(root.querySelector('script')).toBeNull();
+        });
     }
 );

--- a/packages/@lwc/integration-wtr/test/synthetic-shadow/native-shadowroot-sanitize/index.spec.js
+++ b/packages/@lwc/integration-wtr/test/synthetic-shadow/native-shadowroot-sanitize/index.spec.js
@@ -1,22 +1,21 @@
 import { fn as mockFn } from '@vitest/spy';
 import { getHooks, setHooks } from '../../../helpers/hooks.js';
 
-// Skipped in native mode: synthetic-shadow isn't loaded there, so there is no native-sink patch to test.
+// No native-sink patch exists in native mode — synthetic-shadow isn't loaded.
 describe.skipIf(process.env.NATIVE_SHADOW)(
     'native ShadowRoot HTML sinks route through sanitizeHtmlContent',
     () => {
-        const PAYLOAD = '<iframe srcdoc="<script>window.__pwned = true</script>"></iframe>';
+        // Sink routing is element-agnostic; inert <template> stands in for untrusted markup.
+        const PAYLOAD =
+            '<p>keep</p><a href="#">link</a><ul><li>x</li></ul><template>drop</template>';
 
-        // Outside an LWC host, attachShadow yields a native root under synthetic shadow.
+        // Under synthetic shadow, attachShadow outside an LWC host returns a native root.
         function createNativeRoot() {
             return document.createElement('div').attachShadow({ mode: 'open' });
         }
 
-        function stripDangerous(content) {
-            return String(content)
-                .replace(/<script[\s\S]*?<\/script>/gi, '')
-                .replace(/<iframe[\s\S]*?<\/iframe>/gi, '')
-                .replace(/<iframe\b[^>]*>/gi, '');
+        function sanitize(content) {
+            return String(content).replace(/<template[\s\S]*?<\/template>/gi, '');
         }
 
         let original;
@@ -26,25 +25,26 @@ describe.skipIf(process.env.NATIVE_SHADOW)(
         afterEach(() => setHooks({ sanitizeHtmlContent: original }));
 
         it('routes native innerHTML writes through the hook with the raw value', () => {
-            const spy = mockFn((content) => stripDangerous(content));
+            const spy = mockFn((content) => sanitize(content));
             setHooks({ sanitizeHtmlContent: spy });
 
             const root = createNativeRoot();
             root.innerHTML = PAYLOAD;
 
-            // A synthetic root's innerHTML setter never calls the hook, so being called at all proves
-            // the write went through the patched *native* prototype.
+            // Synthetic roots never call the hook; a call proves the native prototype was patched.
             expect(spy).toHaveBeenCalledWith(PAYLOAD);
         });
 
-        it('neutralizes the srcdoc PoC written to a native root innerHTML', () => {
-            setHooks({ sanitizeHtmlContent: stripDangerous });
+        it('strips untrusted markup written to a native root, keeping benign nodes', () => {
+            setHooks({ sanitizeHtmlContent: sanitize });
 
             const root = createNativeRoot();
             root.innerHTML = PAYLOAD;
 
-            expect(root.querySelector('iframe')).toBeNull();
-            expect(root.querySelector('script')).toBeNull();
+            expect(root.querySelector('template')).toBeNull();
+            expect(root.querySelector('p')).not.toBeNull();
+            expect(root.querySelector('a')).not.toBeNull();
+            expect(root.querySelector('li').textContent).toBe('x');
         });
 
         it('passes benign markup through unchanged', () => {
@@ -66,7 +66,7 @@ describe.skipIf(process.env.NATIVE_SHADOW)(
             root.innerHTML = PAYLOAD;
 
             expect(root.querySelector('b')).not.toBeNull();
-            expect(root.querySelector('iframe')).toBeNull();
+            expect(root.querySelector('template')).toBeNull();
         });
 
         it('routes native setHTMLUnsafe through the hook when supported', function () {
@@ -76,21 +76,20 @@ describe.skipIf(process.env.NATIVE_SHADOW)(
                 return;
             }
 
-            const spy = mockFn((content) => stripDangerous(content));
+            const spy = mockFn((content) => sanitize(content));
             setHooks({ sanitizeHtmlContent: spy });
 
             root.setHTMLUnsafe(PAYLOAD);
 
             expect(spy).toHaveBeenCalledWith(PAYLOAD);
-            expect(root.querySelector('iframe')).toBeNull();
-            expect(root.querySelector('script')).toBeNull();
+            expect(root.querySelector('template')).toBeNull();
+            expect(root.querySelector('p')).not.toBeNull();
         });
 
         it('sanitizer bridge cannot be replaced by page code', () => {
-            setHooks({ sanitizeHtmlContent: stripDangerous });
+            setHooks({ sanitizeHtmlContent: sanitize });
 
-            // The bridge is frozen (non-writable, non-configurable), so neither assignment nor
-            // redefinition can swap in a passthrough that would bypass sanitization.
+            // Frozen bridge: neither assignment nor redefine can swap in a passthrough.
             expect(() => {
                 globalThis.$sanitizeHtmlContent$ = (value) => value;
             }).toThrow();
@@ -103,12 +102,11 @@ describe.skipIf(process.env.NATIVE_SHADOW)(
 
             const root = createNativeRoot();
             root.innerHTML = PAYLOAD;
-            expect(root.querySelector('iframe')).toBeNull();
-            expect(root.querySelector('script')).toBeNull();
+            expect(root.querySelector('template')).toBeNull();
         });
 
         it('kill-switch bypasses the hook so native sinks are not sanitized', () => {
-            const spy = mockFn((content) => stripDangerous(content));
+            const spy = mockFn((content) => sanitize(content));
             setHooks({ sanitizeHtmlContent: spy });
             lwcRuntimeFlags.DISABLE_NATIVE_SHADOWROOT_SINK_SANITIZATION = true;
 
@@ -124,11 +122,10 @@ describe.skipIf(process.env.NATIVE_SHADOW)(
         });
 
         it('native innerHTML sink cannot be restored by page code', () => {
-            setHooks({ sanitizeHtmlContent: stripDangerous });
+            setHooks({ sanitizeHtmlContent: sanitize });
 
             const root = createNativeRoot();
-            // The patched setter is non-configurable, so page code cannot redefine it back to the
-            // raw native setter to regain an unsanitized sink.
+            // Non-configurable setter: page code can't restore the raw native sink.
             expect(() =>
                 Object.defineProperty(Object.getPrototypeOf(root), 'innerHTML', {
                     configurable: true,
@@ -137,8 +134,7 @@ describe.skipIf(process.env.NATIVE_SHADOW)(
             ).toThrow();
 
             root.innerHTML = PAYLOAD;
-            expect(root.querySelector('iframe')).toBeNull();
-            expect(root.querySelector('script')).toBeNull();
+            expect(root.querySelector('template')).toBeNull();
         });
     }
 );

--- a/packages/@lwc/shared/src/keys.ts
+++ b/packages/@lwc/shared/src/keys.ts
@@ -16,3 +16,5 @@ export const KEY__SCOPED_CSS = '$scoped$';
 export const KEY__NATIVE_ONLY_CSS = '$nativeOnly$';
 export const KEY__NATIVE_GET_ELEMENT_BY_ID = '$nativeGetElementById$';
 export const KEY__NATIVE_QUERY_SELECTOR_ALL = '$nativeQuerySelectorAll$';
+export const KEY__SANITIZE_HTML_CONTENT = '$sanitizeHtmlContent$';
+export const KEY__NATIVE_SHADOWROOT_SINKS_PATCHED = '$nativeShadowRootSinksPatched$';

--- a/packages/@lwc/shared/src/keys.ts
+++ b/packages/@lwc/shared/src/keys.ts
@@ -17,4 +17,3 @@ export const KEY__NATIVE_ONLY_CSS = '$nativeOnly$';
 export const KEY__NATIVE_GET_ELEMENT_BY_ID = '$nativeGetElementById$';
 export const KEY__NATIVE_QUERY_SELECTOR_ALL = '$nativeQuerySelectorAll$';
 export const KEY__SANITIZE_HTML_CONTENT = '$sanitizeHtmlContent$';
-export const KEY__NATIVE_SHADOWROOT_SINKS_PATCHED = '$nativeShadowRootSinksPatched$';

--- a/packages/@lwc/shared/src/overridable-hooks.ts
+++ b/packages/@lwc/shared/src/overridable-hooks.ts
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import * as assert from './assert';
+import { defineProperty, isUndefined } from './language';
+import { KEY__SANITIZE_HTML_CONTENT } from './keys';
 
 export interface SanitizeHtmlContentHook {
     (content: unknown): string;
@@ -35,4 +37,12 @@ export function setHooks(hooks: OverridableHooks) {
     assert.isFalse(hooksAreSet, 'Hooks are already overridden, only one definition is allowed.');
     hooksAreSet = true;
     sanitizeHtmlContentImpl = hooks.sanitizeHtmlContent;
+
+    // Bridge for `@lwc/synthetic-shadow`, which can't import this directly (separate, tree-shaken bundle).
+    if (isUndefined((globalThis as any)[KEY__SANITIZE_HTML_CONTENT])) {
+        defineProperty(globalThis, KEY__SANITIZE_HTML_CONTENT, {
+            value: sanitizeHtmlContent,
+            configurable: true,
+        });
+    }
 }

--- a/packages/@lwc/shared/src/overridable-hooks.ts
+++ b/packages/@lwc/shared/src/overridable-hooks.ts
@@ -38,9 +38,8 @@ export function setHooks(hooks: OverridableHooks) {
     hooksAreSet = true;
     sanitizeHtmlContentImpl = hooks.sanitizeHtmlContent;
 
-    // Bridge for `@lwc/synthetic-shadow`, which can't import this directly (separate, tree-shaken bundle).
-    // Frozen (non-writable, non-configurable) so sandboxed code can't swap in a passthrough sanitizer;
-    // safe because setHooks runs at boot, before any untrusted code, so the framework always wins the slot.
+    // Global bridge for `@lwc/synthetic-shadow` (separate bundle, can't import this). Frozen so
+    // sandboxed code can't swap in a passthrough — setHooks runs at boot, before any untrusted code.
     if (isUndefined((globalThis as any)[KEY__SANITIZE_HTML_CONTENT])) {
         defineProperty(globalThis, KEY__SANITIZE_HTML_CONTENT, {
             value: sanitizeHtmlContent,

--- a/packages/@lwc/shared/src/overridable-hooks.ts
+++ b/packages/@lwc/shared/src/overridable-hooks.ts
@@ -39,10 +39,13 @@ export function setHooks(hooks: OverridableHooks) {
     sanitizeHtmlContentImpl = hooks.sanitizeHtmlContent;
 
     // Bridge for `@lwc/synthetic-shadow`, which can't import this directly (separate, tree-shaken bundle).
+    // Frozen (non-writable, non-configurable) so sandboxed code can't swap in a passthrough sanitizer;
+    // safe because setHooks runs at boot, before any untrusted code, so the framework always wins the slot.
     if (isUndefined((globalThis as any)[KEY__SANITIZE_HTML_CONTENT])) {
         defineProperty(globalThis, KEY__SANITIZE_HTML_CONTENT, {
             value: sanitizeHtmlContent,
-            configurable: true,
+            writable: false,
+            configurable: false,
         });
     }
 }

--- a/packages/@lwc/synthetic-shadow/src/env/shadow-root.ts
+++ b/packages/@lwc/synthetic-shadow/src/env/shadow-root.ts
@@ -4,8 +4,17 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import { getOwnPropertyDescriptor } from '@lwc/shared';
 
 // Capture the global `ShadowRoot` since synthetic shadow will override it later
-const NativeShadowRoot = ShadowRoot;
+export const NativeShadowRoot = ShadowRoot;
 
 export const isInstanceOfNativeShadowRoot = (node: any) => node instanceof NativeShadowRoot;
+
+// Captured before synthetic shadow patches the prototype, so the wrappers see the real native sinks.
+export const nativeShadowRootInnerHTMLDescriptor = getOwnPropertyDescriptor(
+    NativeShadowRoot.prototype,
+    'innerHTML'
+);
+export const nativeShadowRootSetHTMLUnsafe = (NativeShadowRoot.prototype as any).setHTMLUnsafe as
+    ((html: any, ...rest: unknown[]) => void) | undefined;

--- a/packages/@lwc/synthetic-shadow/src/polyfills/shadow-root/main.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/shadow-root/main.ts
@@ -6,3 +6,4 @@
  */
 
 import './polyfill';
+import './sanitize-native-sink';

--- a/packages/@lwc/synthetic-shadow/src/polyfills/shadow-root/sanitize-native-sink.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/shadow-root/sanitize-native-sink.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import {
+    defineProperty,
+    isFunction,
+    isUndefined,
+    KEY__NATIVE_SHADOWROOT_SINKS_PATCHED,
+    KEY__SANITIZE_HTML_CONTENT,
+} from '@lwc/shared';
+import {
+    NativeShadowRoot,
+    nativeShadowRootInnerHTMLDescriptor,
+    nativeShadowRootSetHTMLUnsafe,
+} from '../../env/shadow-root';
+
+// Read from the global instead of importing `sanitizeHtmlContent`: this bundle's own `@lwc/shared`
+// copy never runs `setHooks`, so a bundler constant-folds the imported hook to a no-op.
+function maybeSanitize(value: unknown): unknown {
+    const sanitize = (globalThis as any)[KEY__SANITIZE_HTML_CONTENT];
+    return isFunction(sanitize) ? sanitize(value) : value;
+}
+
+// Apply once: a second synthetic-shadow copy would capture this wrapper as "native" and sanitize twice.
+if (isUndefined((globalThis as any)[KEY__NATIVE_SHADOWROOT_SINKS_PATCHED])) {
+    defineProperty(globalThis, KEY__NATIVE_SHADOWROOT_SINKS_PATCHED, {
+        value: true,
+        configurable: true,
+    });
+
+    if (
+        !isUndefined(nativeShadowRootInnerHTMLDescriptor) &&
+        isFunction(nativeShadowRootInnerHTMLDescriptor.set)
+    ) {
+        const nativeInnerHTMLSetter = nativeShadowRootInnerHTMLDescriptor.set;
+        defineProperty(NativeShadowRoot.prototype, 'innerHTML', {
+            ...nativeShadowRootInnerHTMLDescriptor,
+            set(this: ShadowRoot, value: unknown) {
+                nativeInnerHTMLSetter.call(this, maybeSanitize(value));
+            },
+        });
+    }
+
+    if (isFunction(nativeShadowRootSetHTMLUnsafe)) {
+        const nativeSetHTMLUnsafe = nativeShadowRootSetHTMLUnsafe;
+        defineProperty(NativeShadowRoot.prototype, 'setHTMLUnsafe', {
+            writable: true,
+            enumerable: false,
+            configurable: true,
+            value(this: ShadowRoot, html: unknown) {
+                return nativeSetHTMLUnsafe.call(this, maybeSanitize(html));
+            },
+        });
+    }
+}

--- a/packages/@lwc/synthetic-shadow/src/polyfills/shadow-root/sanitize-native-sink.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/shadow-root/sanitize-native-sink.ts
@@ -6,9 +6,9 @@
  */
 import {
     defineProperty,
+    getOwnPropertyDescriptor,
     isFunction,
     isUndefined,
-    KEY__NATIVE_SHADOWROOT_SINKS_PATCHED,
     KEY__SANITIZE_HTML_CONTENT,
 } from '@lwc/shared';
 import {
@@ -24,35 +24,42 @@ function maybeSanitize(value: unknown): unknown {
     return isFunction(sanitize) ? sanitize(value) : value;
 }
 
-// Apply once: a second synthetic-shadow copy would capture this wrapper as "native" and sanitize twice.
-if (isUndefined((globalThis as any)[KEY__NATIVE_SHADOWROOT_SINKS_PATCHED])) {
-    defineProperty(globalThis, KEY__NATIVE_SHADOWROOT_SINKS_PATCHED, {
-        value: true,
-        configurable: true,
+// Idempotency without a forgeable global flag: the wrappers are installed non-configurable, so a
+// prototype whose sink descriptor is already non-configurable has been patched (by us, or a prior
+// synthetic-shadow copy) — re-defining would throw, so skip. This reads the real descriptor rather
+// than a global marker, so sandboxed code can't fake "already patched" to skip protection; the only
+// way to make the descriptor non-configurable is to actually lock it, which is what we want anyway.
+function isLocked(proto: object, name: string): boolean {
+    const descriptor = getOwnPropertyDescriptor(proto, name);
+    return !isUndefined(descriptor) && descriptor.configurable === false;
+}
+
+if (
+    !isUndefined(nativeShadowRootInnerHTMLDescriptor) &&
+    isFunction(nativeShadowRootInnerHTMLDescriptor.set) &&
+    !isLocked(NativeShadowRoot.prototype, 'innerHTML')
+) {
+    const nativeInnerHTMLSetter = nativeShadowRootInnerHTMLDescriptor.set;
+    defineProperty(NativeShadowRoot.prototype, 'innerHTML', {
+        ...nativeShadowRootInnerHTMLDescriptor,
+        configurable: false,
+        set(this: ShadowRoot, value: unknown) {
+            nativeInnerHTMLSetter.call(this, maybeSanitize(value));
+        },
     });
+}
 
-    if (
-        !isUndefined(nativeShadowRootInnerHTMLDescriptor) &&
-        isFunction(nativeShadowRootInnerHTMLDescriptor.set)
-    ) {
-        const nativeInnerHTMLSetter = nativeShadowRootInnerHTMLDescriptor.set;
-        defineProperty(NativeShadowRoot.prototype, 'innerHTML', {
-            ...nativeShadowRootInnerHTMLDescriptor,
-            set(this: ShadowRoot, value: unknown) {
-                nativeInnerHTMLSetter.call(this, maybeSanitize(value));
-            },
-        });
-    }
-
-    if (isFunction(nativeShadowRootSetHTMLUnsafe)) {
-        const nativeSetHTMLUnsafe = nativeShadowRootSetHTMLUnsafe;
-        defineProperty(NativeShadowRoot.prototype, 'setHTMLUnsafe', {
-            writable: true,
-            enumerable: false,
-            configurable: true,
-            value(this: ShadowRoot, html: unknown) {
-                return nativeSetHTMLUnsafe.call(this, maybeSanitize(html));
-            },
-        });
-    }
+if (
+    isFunction(nativeShadowRootSetHTMLUnsafe) &&
+    !isLocked(NativeShadowRoot.prototype, 'setHTMLUnsafe')
+) {
+    const nativeSetHTMLUnsafe = nativeShadowRootSetHTMLUnsafe;
+    defineProperty(NativeShadowRoot.prototype, 'setHTMLUnsafe', {
+        writable: false,
+        enumerable: false,
+        configurable: false,
+        value(this: ShadowRoot, html: unknown) {
+            return nativeSetHTMLUnsafe.call(this, maybeSanitize(html));
+        },
+    });
 }

--- a/packages/@lwc/synthetic-shadow/src/polyfills/shadow-root/sanitize-native-sink.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/shadow-root/sanitize-native-sink.ts
@@ -17,10 +17,8 @@ import {
     nativeShadowRootSetHTMLUnsafe,
 } from '../../env/shadow-root';
 
-// Read from the global instead of importing `sanitizeHtmlContent`: this bundle's own `@lwc/shared`
-// copy never runs `setHooks`, so a bundler constant-folds the imported hook to a no-op.
-// Checked at call time (not module load) so the kill-switch takes effect even if the flag is set
-// after synthetic shadow loads.
+// Read the hook off the global, not via import: this bundle's `@lwc/shared` never runs setHooks, so
+// the import constant-folds to a no-op. Resolved at call time so the kill-switch flag can flip late.
 function maybeSanitize(value: unknown): unknown {
     if (lwcRuntimeFlags.DISABLE_NATIVE_SHADOWROOT_SINK_SANITIZATION) {
         return value;
@@ -29,11 +27,9 @@ function maybeSanitize(value: unknown): unknown {
     return isFunction(sanitize) ? sanitize(value) : value;
 }
 
-// Idempotency without a forgeable global flag: the wrappers are installed non-configurable, so a
-// prototype whose sink descriptor is already non-configurable has been patched (by us, or a prior
-// synthetic-shadow copy) — re-defining would throw, so skip. This reads the real descriptor rather
-// than a global marker, so sandboxed code can't fake "already patched" to skip protection; the only
-// way to make the descriptor non-configurable is to actually lock it, which is what we want anyway.
+// Idempotency without a forgeable marker: our wrappers install non-configurable, so a
+// non-configurable sink descriptor means it's already patched. Faking this requires actually locking
+// the sink — which is the protection anyway.
 function isLocked(proto: object, name: string): boolean {
     const descriptor = getOwnPropertyDescriptor(proto, name);
     return !isUndefined(descriptor) && descriptor.configurable === false;

--- a/packages/@lwc/synthetic-shadow/src/polyfills/shadow-root/sanitize-native-sink.ts
+++ b/packages/@lwc/synthetic-shadow/src/polyfills/shadow-root/sanitize-native-sink.ts
@@ -19,7 +19,12 @@ import {
 
 // Read from the global instead of importing `sanitizeHtmlContent`: this bundle's own `@lwc/shared`
 // copy never runs `setHooks`, so a bundler constant-folds the imported hook to a no-op.
+// Checked at call time (not module load) so the kill-switch takes effect even if the flag is set
+// after synthetic shadow loads.
 function maybeSanitize(value: unknown): unknown {
+    if (lwcRuntimeFlags.DISABLE_NATIVE_SHADOWROOT_SINK_SANITIZATION) {
+        return value;
+    }
     const sanitize = (globalThis as any)[KEY__SANITIZE_HTML_CONTENT];
     return isFunction(sanitize) ? sanitize(value) : value;
 }


### PR DESCRIPTION
## Details
Route the native `ShadowRoot.prototype` `innerHTML` setter and `setHTMLUnsafe` through the installed `sanitizeHtmlContent` hook. The sanitization bound to the synthetic `ShadowRoot` prototype does not cover the native prototype; `attachShadow` is unchanged, so native shadow roots keep working — only these two HTML sinks are wrapped.

The hook is reached via the same cross-bundle `globalThis` bridge already used by `KEY__NATIVE_GET_ELEMENT_BY_ID` / `KEY__NATIVE_QUERY_SELECTOR_ALL`, because `@lwc/synthetic-shadow` ships as a separate bundle and cannot import the runtime hook directly.

Internal context: W-23994661.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

With no hook installed (OSS, plain native web components, no security runtime), the wrapped setters pass values through unchanged — identical to native behavior.

## Tests
New `integration-wtr` spec plus full `synthetic-shadow` / `mixed-shadow-mode` / `sanitizeHtmlContent` consumer regression, 3 browsers, synthetic + native modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
