### PR TITLE
refactor(engine-dom): remove deprecated buildCustomElementConstructor API

### DIFF
--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/allows-importing-supported-apis-from-@lwc-engine-dom/actual.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/allows-importing-supported-apis-from-@lwc-engine-dom/actual.js
@@ -1,1 +1,1 @@
-import { createElement, buildCustomElementConstructor } from "lwc";
+import { createElement, isNodeFromTemplate } from "lwc";

--- a/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/allows-importing-supported-apis-from-@lwc-engine-dom/expected.js
+++ b/packages/@lwc/babel-plugin-component/src/__tests__/fixtures/component/allows-importing-supported-apis-from-@lwc-engine-dom/expected.js
@@ -1,1 +1,1 @@
-import { createElement, buildCustomElementConstructor } from "lwc";
+import { createElement, isNodeFromTemplate } from "lwc";

--- a/packages/@lwc/engine-dom/README.md
+++ b/packages/@lwc/engine-dom/README.md
@@ -32,23 +32,4 @@ This experimental API provides access to the component constructor, given an `HT
 
 This experimental API enables the detection of whether a node was rendered from an LWC template.
 
-## Deprecated APIs
 
-### buildCustomElementConstructor() (deprecated as of v1.3.11)
-
-This function can build a Web Component class that can be registered as a new element via
-`customElements.define()`, given an LWC constructor.
-
-Deprecated in favor of using the `CustomElementConstructor` property of an LWC constructor.
-
-```js
-import { LightningElement } from 'lwc';
-
-class LightningHello extends LightningElement {}
-
-// Don't do this.
-customElements.define('lightning-hello', buildCustomElementConstructor(LightningHello));
-
-// Do this instead.
-customElements.define('lightning-hello', LightningHello.CustomElementConstructor);
-```

--- a/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
+++ b/packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts
@@ -26,32 +26,7 @@ import type { LightningElement, FormRestoreState, FormRestoreReason } from '@lwc
 type ComponentConstructor = typeof LightningElement;
 type HTMLElementConstructor = typeof HTMLElement;
 
-/**
- * This function builds a Web Component class from a LWC constructor so it can be
- * registered as a new element via customElements.define() at any given time.
- * @param Ctor LWC constructor to build
- * @returns A Web Component class
- * @example
- * import { buildCustomElementConstructor } from 'lwc';
- * import Foo from 'ns/foo';
- * const WC = buildCustomElementConstructor(Foo);
- * customElements.define('x-foo', WC);
- * const elm = document.createElement('x-foo');
- * @deprecated since version 1.3.11
- */
-export function deprecatedBuildCustomElementConstructor(
-    Ctor: ComponentConstructor
-): HTMLElementConstructor {
-    if (process.env.NODE_ENV !== 'production') {
-        /* eslint-disable-next-line no-console */
-        console.warn(
-            'Deprecated function called: "buildCustomElementConstructor" function is deprecated and it will be removed.' +
-                `Use "${Ctor.name}.CustomElementConstructor" static property of the component constructor to access the corresponding custom element constructor instead.`
-        );
-    }
 
-    return Ctor.CustomElementConstructor;
-}
 
 function clearNode(node: Node) {
     const childNodes = renderer.getChildNodes(node);
@@ -61,11 +36,10 @@ function clearNode(node: Node) {
 }
 
 /**
- * The real `buildCustomElementConstructor`. Should not be accessible to external users!
+ * The internal `buildCustomElementConstructor`. Should not be accessible to external users!
  * @internal
  * @param Ctor LWC constructor to build
  * @returns A Web Component class
- * @see {@linkcode deprecatedBuildCustomElementConstructor}
  */
 export function buildCustomElementConstructor(Ctor: ComponentConstructor): HTMLElementConstructor {
     const HtmlPrototype = getComponentHtmlPrototype(Ctor);

--- a/packages/@lwc/engine-dom/src/index.ts
+++ b/packages/@lwc/engine-dom/src/index.ts
@@ -58,7 +58,6 @@ export type {
 
 // Engine-dom public APIs --------------------------------------------------------------------------
 export { hydrateComponent } from './apis/hydrate-component';
-export { deprecatedBuildCustomElementConstructor as buildCustomElementConstructor } from './apis/build-custom-element-constructor';
 export { createElement } from './apis/create-element';
 export { isNodeFromTemplate } from './apis/is-node-from-template';
 export { LightningElement } from './apis/lightning-element';

--- a/packages/lwc/__tests__/isomorphic-exports.spec.ts
+++ b/packages/lwc/__tests__/isomorphic-exports.spec.ts
@@ -20,7 +20,6 @@ describe('isomorphic package exports', () => {
             // Exports that intentionally only exist in @lwc/engine-dom
             '__unstable__ProfilerControl',
             '__unstable__ReportingControl',
-            'buildCustomElementConstructor',
             'getComponentConstructor',
             'hydrateComponent',
             'isNodeFromTemplate',


### PR DESCRIPTION
## Summary
Removes the long-deprecated `buildCustomElementConstructor` export from `@lwc/engine-dom` in favor of accessing `Ctor.CustomElementConstructor` directly on the component class constructor.

## Details
- Removed `deprecatedBuildCustomElementConstructor` from `packages/@lwc/engine-dom/src/apis/build-custom-element-constructor.ts`.
- Removed public export `buildCustomElementConstructor` from `packages/@lwc/engine-dom/src/index.ts`.
- Updated README and isomorphic package exports spec to align with current public API surface.
- Updated `@lwc/babel-plugin-component` test fixture to import `isNodeFromTemplate` instead of the deprecated API.

Closes #5030